### PR TITLE
Added $_GET's subscribed, unsubscribed, confirmed

### DIFF
--- a/core/components/sendex/elements/snippets/snippet.sendex.php
+++ b/core/components/sendex/elements/snippets/snippet.sendex.php
@@ -66,6 +66,8 @@ if (!empty($_REQUEST['sx_action'])) {
 					if ($response !== true) {
 						$placeholders['message'] = $modx->lexicon('sendex_subscribe_err_email_send');
 						$placeholders['error'] = 1;
+					} else {
+					    $params['sx_subscribed'] = 1;
 					}
 				}
 			}
@@ -78,12 +80,14 @@ if (!empty($_REQUEST['sx_action'])) {
 		case 'confirm':
 			if (!empty($_REQUEST['hash'])) {
 				$response = $newsletter->confirmEmail($_REQUEST['hash']);
+				$params['sx_confirmed'] = 1;
 				unset($params['hash']);
 			}
 			break;
 		case 'unsubscribe':
 			if (!empty($_REQUEST['code'])) {
 				$response = $newsletter->unSubscribe($_REQUEST['code']);
+				$params['sx_unsubscribed'] = 1;
 			}
 			unset($params['code']);
 			break;


### PR DESCRIPTION
После отправки письма-подтверждения к адресу страницы добавляется параметр **sx_subscribed**, чтобы можно было показать пользователю сообщение, что нужно перейти по ссылке из письма.

То же самое и с событиями перехода по ссылке или отписки от рассылки.

Для закрытия https://github.com/bezumkin/Sendex/issues/11
