### PR TITLE
Change phptype text to string

### DIFF
--- a/core/components/sendex/model/schema/sendex.mysql.schema.xml
+++ b/core/components/sendex/model/schema/sendex.mysql.schema.xml
@@ -3,7 +3,7 @@
 
 	<object class="sxNewsletter" table="sendex_newsletters" extends="xPDOSimpleObject">
 		<field key="name" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
-		<field key="description" dbtype="text" phptype="text" null="true" default="" />
+		<field key="description" dbtype="text" phptype="string" null="true" default="" />
 		<field key="active" dbtype="tinyint" precision="1" phptype="boolean" attributes="unsigned" null="true" default="1" />
 
 		<field key="template" dbtype="integer" precision="10" attributes="unsigned" phptype="integer" null="true" default="0" />

--- a/core/components/sendex/model/sendex/mysql/sxnewsletter.map.inc.php
+++ b/core/components/sendex/model/sendex/mysql/sxnewsletter.map.inc.php
@@ -29,7 +29,7 @@ $xpdo_meta_map['sxNewsletter']= array (
     'description' => 
     array (
       'dbtype' => 'text',
-      'phptype' => 'text',
+      'phptype' => 'string',
       'null' => true,
       'default' => '',
     ),


### PR DESCRIPTION
При сохранении любых символов в описании рассылки сохраняется только 0 
modx 2.7.1 
php 7.2 
mysql 5.6 
utf8_general_ci
[https://modx.pro/help/17730](https://modx.pro/help/17730)