### PR TITLE
Добавил дополнительные сообщения в сниппете

### DIFF
--- a/core/components/sendex/elements/snippets/snippet.sendex.php
+++ b/core/components/sendex/elements/snippets/snippet.sendex.php
@@ -67,7 +67,8 @@ if (!empty($_REQUEST['sx_action'])) {
 						$placeholders['message'] = $modx->lexicon('sendex_subscribe_err_email_send');
 						$placeholders['error'] = 1;
 					} else {
-					    $params['sx_subscribed'] = 1;
+						$placeholders['message'] = $modx->lexicon('sendex_subscribe_email_subscribed');
+						$params['sx_subscribed'] = 1;
 					}
 				}
 			}
@@ -80,6 +81,7 @@ if (!empty($_REQUEST['sx_action'])) {
 		case 'confirm':
 			if (!empty($_REQUEST['hash'])) {
 				$response = $newsletter->confirmEmail($_REQUEST['hash']);
+				$placeholders['message'] = $modx->lexicon('sendex_subscribe_email_confirmed');
 				$params['sx_confirmed'] = 1;
 				unset($params['hash']);
 			}
@@ -87,6 +89,7 @@ if (!empty($_REQUEST['sx_action'])) {
 		case 'unsubscribe':
 			if (!empty($_REQUEST['code'])) {
 				$response = $newsletter->unSubscribe($_REQUEST['code']);
+				$placeholders['message'] = $modx->lexicon('sendex_subscribe_email_unsubscribed');
 				$params['sx_unsubscribed'] = 1;
 			}
 			unset($params['code']);

--- a/core/components/sendex/lexicon/en/default.inc.php
+++ b/core/components/sendex/lexicon/en/default.inc.php
@@ -98,6 +98,10 @@ $_lang['sendex_err_auth_req'] = 'You must be authorized for work with newsletter
 $_lang['sendex_subscribe_intro'] = 'You can subscribe to newsletter «[[+name]]»!';
 $_lang['sendex_unsubscribe_intro'] = 'You already subscribed to newsletter «[[+name]]». Do you want to unsubscribe?';
 
+$_lang['sendex_subscribe_email_subscribed'] = 'Letter was sent to the email with a confirmation link.';
+$_lang['sendex_subscribe_email_confirmed'] = 'Your email has been successfully subscribed.';
+$_lang['sendex_subscribe_email_unsubscribed'] = 'Your email has been successfully unsubscribed.';
+
 $_lang['sendex_subscribe_activate_subject'] = 'Confirm your email!';
 $_lang['sendex_subscribe_err_already'] = 'This email is already subscribed to newsletter.';
 $_lang['sendex_subscribe_err_email_wrong'] = 'Wrong email.';

--- a/core/components/sendex/lexicon/ru/default.inc.php
+++ b/core/components/sendex/lexicon/ru/default.inc.php
@@ -99,8 +99,8 @@ $_lang['sendex_err_auth_req'] = 'Вы должны быть авторизова
 $_lang['sendex_subscribe_intro'] = 'Вы можете подписаться на рассылку «[[+name]]»!';
 $_lang['sendex_unsubscribe_intro'] = 'Вы уже подписаны на рассылку «[[+name]]». Хотите отписаться?';
 
-$_lang['sendex_subscribe_email_subscribed'] = 'На указанный email отправлено письмо со ссылкой для его подтверждения.';
-$_lang['sendex_subscribe_email_confirmed'] = 'Ваш email успешно подписан рассылку.';
+$_lang['sendex_subscribe_email_subscribed'] = 'На указанный email отправлено письмо со ссылкой для подтверждения.';
+$_lang['sendex_subscribe_email_confirmed'] = 'Ваш email успешно подписан на рассылку.';
 $_lang['sendex_subscribe_email_unsubscribed'] = 'Ваш email успешно отписан от рассылки.';
 
 $_lang['sendex_subscribe_activate_subject'] = 'Подтвердите ваш email!';

--- a/core/components/sendex/lexicon/ru/default.inc.php
+++ b/core/components/sendex/lexicon/ru/default.inc.php
@@ -99,6 +99,10 @@ $_lang['sendex_err_auth_req'] = 'Вы должны быть авторизова
 $_lang['sendex_subscribe_intro'] = 'Вы можете подписаться на рассылку «[[+name]]»!';
 $_lang['sendex_unsubscribe_intro'] = 'Вы уже подписаны на рассылку «[[+name]]». Хотите отписаться?';
 
+$_lang['sendex_subscribe_email_subscribed'] = 'На указанный email отправлено письмо со ссылкой для его подтверждения.';
+$_lang['sendex_subscribe_email_confirmed'] = 'Ваш email успешно подписан рассылку.';
+$_lang['sendex_subscribe_email_unsubscribed'] = 'Ваш email успешно отписан от рассылки.';
+
 $_lang['sendex_subscribe_activate_subject'] = 'Подтвердите ваш email!';
 $_lang['sendex_subscribe_err_already'] = 'Этот email уже подписан на рассылку.';
 $_lang['sendex_subscribe_err_email_wrong'] = 'Неверный email.';


### PR DESCRIPTION
Не хватало сообщений для пользователя в плейсхолдере [[+message]], типа: на почту отправлено письмо для подтверждения, email подписан, отписан.