### PR TITLE
feat(mgr): Add search for subscribers and queues

### DIFF
--- a/assets/components/sendex/js/mgr/misc/utils.js
+++ b/assets/components/sendex/js/mgr/misc/utils.js
@@ -45,6 +45,45 @@ Sendex.utils.getMenu = function(actions, grid) {
     return menu;
 };
 
+Sendex.utils.getSearchField = function(grid, config) {
+    config = config || {};
+    var doSearch = function(field) {
+        var store = grid.getStore();
+        var value = field.getValue();
+        store.baseParams.query = value || '';
+        var pager = grid.getBottomToolbar();
+        if (pager && pager.changePage) {
+            pager.changePage(1);
+        } else {
+            store.reload();
+        }
+    };
+
+    return Ext.apply({
+        xtype: 'textfield'
+        ,name: 'query'
+        ,emptyText: _('sendex_search')
+        ,width: 200
+        ,enableKeyEvents: true
+        ,listeners: {
+            change: {
+                fn: function(field) {
+                    doSearch(field);
+                }
+                ,scope: grid
+            }
+            ,specialkey: {
+                fn: function(field, e) {
+                    if (e.getKey() === Ext.EventObject.ENTER) {
+                        doSearch(field);
+                    }
+                }
+                ,scope: grid
+            }
+        }
+    }, config);
+};
+
 Sendex.utils.onAjax = function(el) {
     Ext.Ajax.el = el;
     Ext.Ajax.on('beforerequest', Sendex.utils.beforerequest);

--- a/assets/components/sendex/js/mgr/widgets/newsletters.grid.js
+++ b/assets/components/sendex/js/mgr/widgets/newsletters.grid.js
@@ -388,7 +388,8 @@ Sendex.grid.NewsletterSubscribers = function(config) {
             }
         }
         ,'->'
-        , {
+        ,Sendex.utils.getSearchField(this)
+        ,{
             xtype: 'sendex-combo-group'
             ,name: 'group_id'
             ,hiddenName: 'group_id'

--- a/assets/components/sendex/js/mgr/widgets/queues.grid.js
+++ b/assets/components/sendex/js/mgr/widgets/queues.grid.js
@@ -34,6 +34,7 @@ Sendex.grid.Queues = function(config) {
                 }
             },
             '->',
+            Sendex.utils.getSearchField(this),
             {
                 xtype: 'button',
                 text: '<i class="' + (MODx.modx23 ? 'icon icon-trash-o' : 'fa fa-trash-o') + '"></i> ' + _('sendex_btn_remove_all'),
@@ -48,12 +49,12 @@ Sendex.grid.Queues = function(config) {
             }
         ]
         /*
-         listeners: {
-             rowDblClick: function(grid, rowIndex, e) {
-                 var row = grid.store.getAt(rowIndex);
-                 this.update(grid, e, row);
-             }
-         }
+        listeners: {
+            rowDblClick: function(grid, rowIndex, e) {
+                var row = grid.store.getAt(rowIndex);
+                this.update(grid, e, row);
+            }
+        }
          */
     });
 

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CSV cells that look like spreadsheet formulas are prefixed so Excel/LibreOffice do not execute them.
 
 ### Added
+- [#46] Search subscribers and queue by email or username.
 - [#44] Plugin events for subscribe/unsubscribe (`sxOnBeforeSubscribe`, `sxOnSubscribe`, `sxOnBeforeUnsubscribe`, `sxOnUnsubscribe`).
 - PHPUnit coverage for subscribe/unsubscribe events (stubs, no MODX install).
 

--- a/core/components/sendex/lexicon/en/default.inc.php
+++ b/core/components/sendex/lexicon/en/default.inc.php
@@ -16,6 +16,7 @@ $_lang['sendex_btn_send_all'] = 'Send all';
 $_lang['sendex_btn_remove_all'] = 'Remove all';
 $_lang['sendex_btn_subscrubers_export'] = 'Export';
 $_lang['sendex_select_user'] = 'Add user';
+$_lang['sendex_search'] = 'Email or username';
 $_lang['sendex_select_group'] = 'Add group';
 $_lang['sendex_select_newsletter'] = 'Add letters in the queue';
 

--- a/core/components/sendex/lexicon/ru/default.inc.php
+++ b/core/components/sendex/lexicon/ru/default.inc.php
@@ -16,6 +16,7 @@ $_lang['sendex_btn_send_all'] = 'Отправить все';
 $_lang['sendex_btn_remove_all'] = 'Удалить все';
 $_lang['sendex_btn_subscrubers_export'] = 'Экспорт';
 $_lang['sendex_select_user'] = 'Добавить пользователя';
+$_lang['sendex_search'] = 'Email или имя пользователя';
 $_lang['sendex_select_group'] = 'Добавить группу';
 $_lang['sendex_select_newsletter'] = 'Добавить письма рассылки в очередь';
 

--- a/core/components/sendex/processors/mgr/likequery.class.php
+++ b/core/components/sendex/processors/mgr/likequery.class.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Shared LIKE helpers for mgr getlist processors.
+ */
+class SendexLikeQuery
+{
+    /**
+     * Trim query and wrap for LIKE, escaping % and _.
+     *
+     * @param mixed $query
+     *
+     * @return string|null LIKE value, or null if empty after trim
+     */
+    public static function prepare($query)
+    {
+        $query = trim((string) $query);
+        if ($query === '') {
+            return null;
+        }
+
+        return '%' . str_replace(array('%', '_'), array('\\%', '\\_'), $query) . '%';
+    }
+}

--- a/core/components/sendex/processors/mgr/newsletter/subscriber/getlist.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/subscriber/getlist.class.php
@@ -4,6 +4,8 @@
  * Get a list of Subscribers
  */
 
+require_once dirname(dirname(__DIR__)) . '/likequery.class.php';
+
 class sxSubscriberGetListProcessor extends modObjectGetListProcessor
 {
     public $objectType = 'sxSubscriber';
@@ -25,6 +27,14 @@ class sxSubscriberGetListProcessor extends modObjectGetListProcessor
 
         $c->select($this->modx->getSelectColumns($this->classKey, $this->classKey));
         $c->select('modUser.username, modUserProfile.fullname');
+
+        $like = SendexLikeQuery::prepare($this->getProperty('query', ''));
+        if ($like !== null) {
+            $c->where(array(
+                'email:LIKE' => $like,
+                'OR:modUser.username:LIKE' => $like,
+            ));
+        }
 
         return $c;
     }

--- a/core/components/sendex/processors/mgr/queue/getlist.class.php
+++ b/core/components/sendex/processors/mgr/queue/getlist.class.php
@@ -4,6 +4,8 @@
  * Get a list of Queues
  */
 
+require_once dirname(__DIR__) . '/likequery.class.php';
+
 class sxQueueGetListProcessor extends modObjectGetListProcessor
 {
     public $objectType = 'sxQueue';
@@ -22,6 +24,16 @@ class sxQueueGetListProcessor extends modObjectGetListProcessor
         $c->innerJoin('sxNewsletter', 'sxNewsletter', 'sxNewsletter.id = sxQueue.newsletter_id');
         $c->select($this->modx->getSelectColumns('sxQueue', 'sxQueue'));
         $c->select('sxNewsletter.name as newsletter');
+
+        $like = SendexLikeQuery::prepare($this->getProperty('query', ''));
+        if ($like !== null) {
+            $c->leftJoin('sxSubscriber', 'sxSubscriber', 'sxSubscriber.id = sxQueue.subscriber_id');
+            $c->leftJoin('modUser', 'modUser', 'modUser.id = sxSubscriber.user_id');
+            $c->where(array(
+                'email_to:LIKE' => $like,
+                'OR:modUser.username:LIKE' => $like,
+            ));
+        }
 
         return $c;
     }


### PR DESCRIPTION
Add email/username search to the subscribers and queue grids in the manager.

Large newsletters and queues are hard to scan without a filter. This adds a shared search field and LIKE queries on email (or `email_to`) and linked `modUser.username`, with `%`/`_` escaped. Queue getlist joins Subscriber/User only when a query is present so the unfiltered list stays cheap.

Fixes #46