### PR TITLE
feat(events): Add subscribe/unsubscribe plugin events

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,38 @@
+name: PHP Compatibility
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+
+jobs:
+  php:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: composer
+
+      - name: Syntax check (php -l)
+        run: |
+          set -e
+          while IFS= read -r -d '' file; do
+            php -l "$file"
+          done < <(find . -name '*.php' -not -path './.git/*' -not -path './vendor/*' -print0)
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 # Composer / PHPUnit
 /vendor/
 .phpunit.result.cache
+/coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 
 # VSCode
 .vscode
+
+# Composer / PHPUnit
+/vendor/
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Sendex runs email newsletters in MODX Revolution: subscribers, a send queue, and a front-end form.
 
+**Requirements:** PHP 7.4–8.4, MODX Revolution 2.x.
+
 ## Features
 
 - Newsletters and subscribers in the manager
@@ -40,6 +42,37 @@ php core/components/sendex/cron/send.php
 ```
 
 Set the batch size with the `sendex_queue_limit` system setting (default `100`).
+
+## Tests
+
+```
+composer install
+composer test
+```
+
+Unit tests use lightweight MODX/xPDO stubs (no MODX install). CI runs `php -l` and PHPUnit on PHP 7.4–8.4.
+
+## Plugin events
+
+Fired from `sxNewsletter::subscribe()` / `unSubscribe()` (front-end and manager). Event names are registered in the transport package (`BUILD_EVENT_UPDATE`); reinstall or upgrade the package so they appear under System Events in the manager. `invokeEvent` by name works even before that.
+
+| Event | When | Cancel |
+| --- | --- | --- |
+| `sxOnBeforeSubscribe` | Before creating a subscriber | Yes |
+| `sxOnSubscribe` | After a successful save | No |
+| `sxOnBeforeUnsubscribe` | Before removing a subscriber | Yes |
+| `sxOnUnsubscribe` | After a successful remove | No |
+
+Params: `newsletter`, `newsletter_id`, `user_id`, `email`, `subscriber` (object after create / before remove). Unsubscribe also passes `code`.
+
+Cancel a Before event with `$modx->event->output('error message');`. Callers get that string back from `subscribe()` / `unSubscribe()` (`true` on success, `false` on validation/save failure). Already-subscribed / missing or mismatched code paths are no-ops and do not fire events. `unSubscribe` only removes a subscriber that belongs to this newsletter.
+
+### Manual check
+
+1. Subscribe (auth user / guest confirm) → `sxOnBeforeSubscribe` + `sxOnSubscribe`.
+2. Plugin `output()` on Before → subscribe aborted; message shown in mgr/front.
+3. Unsubscribe front + mgr remove → Before + After; cancel → mgr `failure`, not silent success.
+4. Unsubscribe with a code from another newsletter → no remove, no events.
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ Set the batch size with the `sendex_queue_limit` system setting (default `100`).
 ```
 composer install
 composer test
+composer test:coverage   # needs phpdbg
 ```
 
-Unit tests use lightweight MODX/xPDO stubs (no MODX install). CI runs `php -l` and PHPUnit on PHP 7.4–8.4.
+Unit tests use lightweight MODX/xPDO stubs (no MODX install). Covered: `sxNewsletter` (100%), subscriber create/remove processors. CI runs `php -l` and PHPUnit on PHP 7.4–8.4.
 
 ## Plugin events
 

--- a/_build/build.config.php
+++ b/_build/build.config.php
@@ -39,7 +39,7 @@ define('BUILD_TEMPLATE_UPDATE', false);
 
 define('BUILD_SNIPPET_UPDATE', true);
 define('BUILD_PLUGIN_UPDATE', true);
-//define('BUILD_EVENT_UPDATE', true);
+define('BUILD_EVENT_UPDATE', true);
 //define('BUILD_POLICY_UPDATE', true);
 //define('BUILD_POLICY_TEMPLATE_UPDATE', true);
 //define('BUILD_PERMISSION_UPDATE', true);

--- a/_build/data/transport.events.php
+++ b/_build/data/transport.events.php
@@ -1,0 +1,23 @@
+<?php
+
+$events = array();
+
+$tmp = array(
+    'sxOnBeforeSubscribe',
+    'sxOnSubscribe',
+    'sxOnBeforeUnsubscribe',
+    'sxOnUnsubscribe',
+);
+
+foreach ($tmp as $v) {
+    /** @var modEvent $event */
+    $event = $modx->newObject('modEvent');
+    $event->fromArray(array(
+        'name'      => $v,
+        'service'   => 6,
+        'groupname' => PKG_NAME,
+    ), '', true, true);
+    $events[] = $event;
+}
+
+return $events;

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,27 @@
+{
+    "name": "modx-pro/sendex",
+    "description": "Email newsletters for MODX Revolution",
+    "type": "library",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "php": ">=7.4 <8.5"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.6.22"
+    },
+    "suggest": {
+        "ext-pdo": "Required for MODX database access",
+        "ext-json": "Required for manager JSON responses"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Sendex\\Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": "phpunit"
+    },
+    "config": {
+        "sort-packages": true
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "php": ">=7.4 <8.5"
     },
     "require-dev": {
+        "phpunit/php-code-coverage": "^9.2",
         "phpunit/phpunit": "^9.6.22"
     },
     "suggest": {
@@ -19,7 +20,8 @@
         }
     },
     "scripts": {
-        "test": "phpunit"
+        "test": "phpunit",
+        "test:coverage": "phpdbg -qrr vendor/bin/phpunit --coverage-text"
     },
     "config": {
         "sort-packages": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e673a05224b19dc57b2ad795adcd0822",
+    "content-hash": "79aa981cdd21e2925b2448746220acc9",
     "packages": [],
     "packages-dev": [
         {
@@ -1797,8 +1797,5 @@
         "php": ">=7.4 <8.5"
     },
     "platform-dev": {},
-    "platform-overrides": {
-        "php": "7.4.33"
-    },
     "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,1804 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "e673a05224b19dc57b2ad795adcd0822",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^11",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.30 || ^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-30T00:15:36+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
+            },
+            "time": "2026-07-04T14:30:18+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:23:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.6.35",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "0edba2f3a0c48df3553cb9b640810b30df60302b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0edba2f3a0c48df3553cb9b640810b30df60302b",
+                "reference": "0edba2f3a0c48df3553cb9b640810b30df60302b",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.5.0 || ^2",
+                "ext-dom": "*",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.10",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
+                "sebastian/version": "^3.0.2"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.35"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
+                }
+            ],
+            "time": "2026-07-06T14:48:07+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:27:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:22:56+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:19:30+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:30:58+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:03:51+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:03:27+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:10:35+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:20:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T06:57:39+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-14T16:00:52+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:13:03+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=7.4 <8.5"
+    },
+    "platform-dev": {},
+    "platform-overrides": {
+        "php": "7.4.33"
+    },
+    "plugin-api-version": "2.9.0"
+}

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -2,6 +2,9 @@ Changelog for Sendex.
 
 1.1.5-pl
 ==============
+- [#44] Plugin events for subscribe/unsubscribe (sxOnBeforeSubscribe, sxOnSubscribe, sxOnBeforeUnsubscribe, sxOnUnsubscribe)
+- Declare PHP 7.4–8.4 support: fix dynamic properties, null Profile in addQueues, PHPMailer ErrorInfo, export stmt guard; CI lint matrix
+- Add PHPUnit unit tests for subscribe/unsubscribe events (stubs, no MODX install)
 - [#47] When adding a user group to a newsletter, only active and unblocked users are subscribed
 - Cast group_id and newsletter_id to int in add_group; require user Profile (innerJoin)
 - add_group processor requires edit_document permission

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -3,6 +3,7 @@ Changelog for Sendex.
 1.1.5-pl
 ==============
 - [#44] Plugin events for subscribe/unsubscribe (sxOnBeforeSubscribe, sxOnSubscribe, sxOnBeforeUnsubscribe, sxOnUnsubscribe)
+- Fix confirmEmail to return subscribe() result when confirming a hash for another newsletter
 - Declare PHP 7.4–8.4 support: fix dynamic properties, null Profile in addQueues, PHPMailer ErrorInfo, export stmt guard; CI lint matrix
 - Add PHPUnit unit tests for subscribe/unsubscribe events (stubs, no MODX install)
 - [#47] When adding a user group to a newsletter, only active and unblocked users are subscribed

--- a/core/components/sendex/docs/readme.txt
+++ b/core/components/sendex/docs/readme.txt
@@ -7,6 +7,8 @@ Author: Vasily Naumkin <bezumkin@yandex.ru>
 Sendex runs email newsletters in MODX Revolution: subscribers, a send
 queue, and a front-end form.
 
+Requires PHP 7.4–8.4 and MODX Revolution 2.x.
+
 Features:
 - Newsletters and subscribers in the manager
 - Add users one by one or from a MODX user group (active and unblocked

--- a/core/components/sendex/elements/snippets/snippet.sendex.php
+++ b/core/components/sendex/elements/snippets/snippet.sendex.php
@@ -55,8 +55,11 @@ if (!empty($_REQUEST['sx_action'])) {
     switch ($_REQUEST['sx_action']) {
         case 'subscribe':
             if ($isAuthenticated && $modx->user->id) {
-                if (!$response = $newsletter->subscribe($modx->user->id)) {
-                    $placeholders['message'] = $modx->lexicon('sendex_subscribe_err_email_wrong');
+                $response = $newsletter->subscribe($modx->user->id);
+                if ($response !== true) {
+                    $placeholders['message'] = is_string($response)
+                        ? $response
+                        : $modx->lexicon('sendex_subscribe_err_email_wrong');
                     $placeholders['error'] = 1;
                 }
             } elseif (!empty($_REQUEST['email'])) {
@@ -90,16 +93,30 @@ if (!empty($_REQUEST['sx_action'])) {
         case 'confirm':
             if (!empty($_REQUEST['hash'])) {
                 $response = $newsletter->confirmEmail($_REQUEST['hash']);
-                $placeholders['message'] = $modx->lexicon('sendex_subscribe_email_confirmed');
-                $params['sx_confirmed'] = 1;
+                if ($response === true) {
+                    $placeholders['message'] = $modx->lexicon('sendex_subscribe_email_confirmed');
+                    $params['sx_confirmed'] = 1;
+                } else {
+                    $placeholders['message'] = is_string($response)
+                        ? $response
+                        : $modx->lexicon('sendex_subscribe_err_email_wrong');
+                    $placeholders['error'] = 1;
+                }
                 unset($params['hash']);
             }
             break;
         case 'unsubscribe':
             if (!empty($_REQUEST['code'])) {
                 $response = $newsletter->unSubscribe($_REQUEST['code']);
-                $placeholders['message'] = $modx->lexicon('sendex_subscribe_email_unsubscribed');
-                $params['sx_unsubscribed'] = 1;
+                if ($response === true) {
+                    $placeholders['message'] = $modx->lexicon('sendex_subscribe_email_unsubscribed');
+                    $params['sx_unsubscribed'] = 1;
+                } else {
+                    $placeholders['message'] = is_string($response)
+                        ? $response
+                        : $modx->lexicon('sendex_subscriber_err_remove');
+                    $placeholders['error'] = 1;
+                }
             }
             unset($params['code']);
             break;

--- a/core/components/sendex/model/sendex/request/sendexcontrollerrequest.class.php
+++ b/core/components/sendex/model/sendex/request/sendexcontrollerrequest.class.php
@@ -12,6 +12,8 @@ class SendexControllerRequest extends modRequest
     public $Sendex = null;
     public $actionVar = 'action';
     public $defaultAction = 'home';
+    /** @var string */
+    public $action = '';
 
 
     /**

--- a/core/components/sendex/model/sendex/sendex.class.php
+++ b/core/components/sendex/model/sendex/sendex.class.php
@@ -10,6 +10,8 @@ class Sendex
     public $modx;
     /* @var SendexControllerRequest $request */
     protected $request;
+    /** @var array */
+    public $config = array();
     public $initialized = array();
     public $chunks = array();
 
@@ -115,7 +117,7 @@ class Sendex
         $mail->setHTML(true);
 
         $response = !$mail->send()
-            ? $mail->mailer->errorInfo
+            ? $mail->mailer->ErrorInfo
             : true;
         $mail->reset();
 

--- a/core/components/sendex/model/sendex/sxnewsletter.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletter.class.php
@@ -193,7 +193,7 @@ class sxNewsletter extends xPDOSimpleObject
                     'active' => 1,
                     ))
                 ) {
-                    $newsletter->subscribe($entry['user_id'], $entry['email']);
+                    return $newsletter->subscribe($entry['user_id'], $entry['email']);
                 } else {
                     return false;
                 }

--- a/core/components/sendex/model/sendex/sxnewsletter.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletter.class.php
@@ -41,11 +41,11 @@ class sxNewsletter extends xPDOSimpleObject
             // Get email from user profile, if possible
             /** @var modUser $user */
             if ($subscriber->get('user_id') && $user = $this->xpdo->getObject('modUser', $subscriber->user_id)) {
-                /** @var modUserProfile $profile */
+                /** @var modUserProfile|null $profile */
                 $profile = $user->getOne('Profile');
 
-                // Skip inactive users
-                if (!$user->active || $profile->blocked) {
+                // Skip inactive users or users without a profile
+                if (!$profile || !$user->active || $profile->blocked) {
                     continue;
                 }
                 // Add user fields
@@ -212,7 +212,8 @@ class sxNewsletter extends xPDOSimpleObject
      * @param int $user_id
      * @param string $email
      *
-     * @return bool
+     * @return true|false|string true on success, false on validation/save failure,
+     *                          or plugin cancel message from sxOnBeforeSubscribe
      */
     public function subscribe($user_id = 0, $email = '')
     {
@@ -226,6 +227,20 @@ class sxNewsletter extends xPDOSimpleObject
             return true;
         }
 
+        $params = array(
+            'newsletter'    => $this,
+            'newsletter_id' => $this->id,
+            'user_id'       => $user_id,
+            'email'         => $email,
+            'subscriber'    => null,
+        );
+
+        $before = $this->invokeSendexEvent('sxOnBeforeSubscribe', $params);
+        if ($before !== true) {
+            return $before;
+        }
+
+        /** @var sxSubscriber $subscriber */
         $subscriber = $this->xpdo->newObject('sxSubscriber');
         $subscriber->fromArray(array(
             'newsletter_id' => $this->id,
@@ -233,7 +248,14 @@ class sxNewsletter extends xPDOSimpleObject
             'email'         => $email,
         ), '', true, true);
 
-        return $subscriber->save();
+        if (!$subscriber->save()) {
+            return false;
+        }
+
+        $params['subscriber'] = $subscriber;
+        $this->invokeSendexEvent('sxOnSubscribe', $params);
+
+        return true;
     }
 
 
@@ -242,14 +264,71 @@ class sxNewsletter extends xPDOSimpleObject
      *
      * @param string $code
      *
-     * @return bool
+     * @return true|false|string true on success, false on missing/mismatched code or remove failure,
+     *                           or plugin cancel message from sxOnBeforeUnsubscribe
      */
     public function unSubscribe($code)
     {
-        if ($subscriber = $this->xpdo->getObject('sxSubscriber', array('code' => $code))) {
-            return $subscriber->remove();
+        /** @var sxSubscriber $subscriber */
+        if (!$subscriber = $this->xpdo->getObject('sxSubscriber', array('code' => $code))) {
+            return false;
         }
 
-        return false;
+        if ((int) $subscriber->get('newsletter_id') !== (int) $this->get('id')) {
+            return false;
+        }
+
+        $params = array(
+            'newsletter'    => $this,
+            'newsletter_id' => $this->id,
+            'user_id'       => $subscriber->get('user_id'),
+            'email'         => $subscriber->get('email'),
+            'code'          => $code,
+            'subscriber'    => $subscriber,
+        );
+
+        $before = $this->invokeSendexEvent('sxOnBeforeUnsubscribe', $params);
+        if ($before !== true) {
+            return $before;
+        }
+
+        if (!$subscriber->remove()) {
+            return false;
+        }
+
+        $this->invokeSendexEvent('sxOnUnsubscribe', $params);
+
+        return true;
+    }
+
+
+    /**
+     * Invoke a Sendex system event. Before-events cancel when a plugin outputs a non-empty string.
+     *
+     * @param string $name
+     * @param array $params
+     *
+     * @return true|string true, or first plugin error message if cancelled
+     */
+    protected function invokeSendexEvent($name, array $params)
+    {
+        if (!($this->xpdo instanceof modX) || !method_exists($this->xpdo, 'invokeEvent')) {
+            return true;
+        }
+
+        $response = $this->xpdo->invokeEvent($name, $params);
+        if (is_array($response)) {
+            $messages = array();
+            foreach ($response as $item) {
+                if (is_string($item) && trim($item) !== '') {
+                    $messages[] = trim($item);
+                }
+            }
+            if (!empty($messages)) {
+                return reset($messages);
+            }
+        }
+
+        return true;
     }
 }

--- a/core/components/sendex/processors/mgr/newsletter/subscriber/create.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/subscriber/create.class.php
@@ -4,7 +4,7 @@
  * Create an Subscriber
  */
 
-class sxSubscriberCreateProcessor extends modObjectCreateProcessor
+class sxSubscriberCreateProcessor extends modProcessor
 {
     public $objectType = 'sxSubscriber';
     public $classKey = 'sxSubscriber';
@@ -13,49 +13,60 @@ class sxSubscriberCreateProcessor extends modObjectCreateProcessor
 
 
     /**
-     * @return bool
+     * @return array|string
      */
-    public function beforeSet()
+    public function process()
     {
+        $user_id = (int) $this->getProperty('user_id');
+        $newsletter_id = (int) $this->getProperty('newsletter_id');
 
-        $required = array(
-        'user_id',
-        'newsletter_id',
-        );
-        foreach ($required as $tmp) {
-            if (!$this->getProperty($tmp)) {
-                $this->addFieldError($tmp, $this->modx->lexicon('field_required'));
-            }
+        if (!$user_id) {
+            $this->addFieldError('user_id', $this->modx->lexicon('field_required'));
         }
-
+        if (!$newsletter_id) {
+            $this->addFieldError('newsletter_id', $this->modx->lexicon('field_required'));
+        }
         if ($this->hasErrors()) {
-            return $this->modx->lexicon('sendex_subscriber_err_save');
+            return $this->failure($this->modx->lexicon('sendex_subscriber_err_save'));
         }
 
         /** @var modUserProfile $profile */
-        if (
-            $profile = $this->modx->getObject('modUserProfile', array(
-            'internalKey' => $this->getProperty('user_id'),
-            ))
-        ) {
-            $email = $profile->get('email');
-            if (empty($email) || strpos($email, '@') === false) {
-                return $this->modx->lexicon('sendex_subscriber_err_email');
-            }
-            $this->setProperty('email', $email);
+        $profile = $this->modx->getObject('modUserProfile', array(
+            'internalKey' => $user_id,
+        ));
+        if (!$profile) {
+            return $this->failure($this->modx->lexicon('sendex_subscriber_err_email'));
+        }
+
+        $email = $profile->get('email');
+        if (empty($email) || strpos($email, '@') === false) {
+            return $this->failure($this->modx->lexicon('sendex_subscriber_err_email'));
         }
 
         if (
             $this->modx->getCount($this->classKey, array(
-            'newsletter_id' => $this->getProperty('newsletter_id'),
-            'user_id'       => $this->getProperty('user_id'),
-            'email'         => $this->getProperty('email'),
+                'newsletter_id' => $newsletter_id,
+                'user_id'       => $user_id,
+                'email'         => $email,
             ))
         ) {
-            return $this->modx->lexicon('sendex_subscriber_err_ae');
+            return $this->failure($this->modx->lexicon('sendex_subscriber_err_ae'));
         }
 
-        return !$this->hasErrors();
+        /** @var sxNewsletter $newsletter */
+        $newsletter = $this->modx->getObject('sxNewsletter', $newsletter_id);
+        if (!$newsletter) {
+            return $this->failure($this->modx->lexicon('sendex_newsletter_err_nf'));
+        }
+
+        $result = $newsletter->subscribe($user_id, $email);
+        if ($result !== true) {
+            return $this->failure(
+                is_string($result) ? $result : $this->modx->lexicon('sendex_subscriber_err_save')
+            );
+        }
+
+        return $this->success();
     }
 }
 

--- a/core/components/sendex/processors/mgr/newsletter/subscriber/export.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/subscriber/export.class.php
@@ -84,7 +84,9 @@ class sxSubscribersExportProcessor extends modObjectProcessor
         $fp = fopen('subscribers.csv', 'w');
 
         $q->prepare();
-        $q->stmt->execute();
+        if (!$q->stmt || !$q->stmt->execute()) {
+            return $this->failure($this->modx->lexicon('sendex_subscribers_export_error'));
+        }
         $rows = $q->stmt->fetchAll(PDO::FETCH_ASSOC);
         foreach ($rows as $row) {
             fputcsv($fp, $row);

--- a/core/components/sendex/processors/mgr/newsletter/subscriber/remove.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/subscriber/remove.class.php
@@ -12,7 +12,8 @@ class sxSubscriberRemoveProcessor extends modProcessor
     /** {inheritDoc} */
     public function process()
     {
-        if (!$ids = explode(',', $this->getProperty('ids'))) {
+        $ids = array_filter(array_map('intval', explode(',', (string) $this->getProperty('ids'))));
+        if (empty($ids)) {
             return $this->failure($this->modx->lexicon('sendex_subscribers_err_ns'));
         }
 

--- a/core/components/sendex/processors/mgr/newsletter/subscriber/remove.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/subscriber/remove.class.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Remove an Newsletter
+ * Remove subscribers
  */
 
 class sxSubscriberRemoveProcessor extends modProcessor
@@ -16,13 +16,27 @@ class sxSubscriberRemoveProcessor extends modProcessor
             return $this->failure($this->modx->lexicon('sendex_subscribers_err_ns'));
         }
 
+        $errors = array();
         $subscribers = $this->modx->getIterator($this->classKey, array('id:IN' => $ids));
         /** @var sxSubscriber $subscriber */
         foreach ($subscribers as $subscriber) {
-            $subscriber->remove();
+            /** @var sxNewsletter $newsletter */
+            $newsletter = $this->modx->getObject('sxNewsletter', $subscriber->get('newsletter_id'));
+            if ($newsletter) {
+                $result = $newsletter->unSubscribe($subscriber->get('code'));
+                if ($result !== true) {
+                    $errors[] = is_string($result)
+                        ? $result
+                        : $this->modx->lexicon('sendex_subscriber_err_remove');
+                }
+            } elseif (!$subscriber->remove()) {
+                $errors[] = $this->modx->lexicon('sendex_subscriber_err_remove');
+            }
         }
 
-        return $this->success();
+        return !empty($errors)
+            ? $this->failure(implode('<br/>', $errors))
+            : $this->success();
     }
 }
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         cacheResult="false"
+         beStrictAboutOutputDuringTests="true">
+    <testsuites>
+        <testsuite name="Sendex">
+            <directory>tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,4 +10,11 @@
             <directory>tests/Unit</directory>
         </testsuite>
     </testsuites>
+    <coverage>
+        <include>
+            <file>core/components/sendex/model/sendex/sxnewsletter.class.php</file>
+            <file>core/components/sendex/processors/mgr/newsletter/subscriber/create.class.php</file>
+            <file>core/components/sendex/processors/mgr/newsletter/subscriber/remove.class.php</file>
+        </include>
+    </coverage>
 </phpunit>

--- a/tests/Stubs/FakeModX.php
+++ b/tests/Stubs/FakeModX.php
@@ -5,14 +5,95 @@ class FakeModX extends modX
     /** @var sxSubscriber[] */
     public $subscribers = array();
 
+    /** @var sxQueue[] */
+    public $queues = array();
+
     /** @var array<int,string> user_id => email */
     public $profiles = array();
+
+    /** @var array<int,modUserProfile> */
+    public $userProfiles = array();
+
+    /** @var array<int,modUser> */
+    public $users = array();
+
+    /** @var array<int,modTemplate> */
+    public $templates = array();
+
+    /** @var array<int,sxNewsletter> */
+    public $newsletters = array();
+
+    /** @var array<string,array> */
+    public $registryEntries = array();
+
+    /** @var string */
+    public $lastRegisterPath = '';
+
+    /** @var array<string,mixed> */
+    public $options = array(
+        'emailsender'           => 'noreply@example.com',
+        'site_name'             => 'Example',
+        'parser_class'          => 'modParser',
+        'parser_class_path'     => '',
+        'parser_max_iterations' => 10,
+    );
+
+    /** @var array<string,mixed> */
+    public $services = array();
 
     /** @var array<string,mixed> */
     public $invokeResponses = array();
 
     /** @var array<int,array{0:string,1:array}> */
     public $invoked = array();
+
+    public function __construct()
+    {
+        $this->services['registry'] = new FakeRegistry($this);
+        $this->services['parser'] = new modParser();
+    }
+
+    /**
+     * @param string $key
+     * @param array|null $options
+     * @param mixed $default
+     * @param bool $skipEmpty
+     *
+     * @return mixed
+     */
+    public function getOption($key, $options = null, $default = null, $skipEmpty = false)
+    {
+        if (is_array($options) && array_key_exists($key, $options)) {
+            return $options[$key];
+        }
+        if (array_key_exists($key, $this->options)) {
+            return $this->options[$key];
+        }
+
+        return $default;
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return string
+     */
+    public function lexicon($key)
+    {
+        return $key;
+    }
+
+    /**
+     * @param string $name
+     * @param string $class
+     * @param string $path
+     *
+     * @return mixed
+     */
+    public function getService($name, $class = '', $path = '')
+    {
+        return isset($this->services[$name]) ? $this->services[$name] : null;
+    }
 
     /**
      * @param string $class
@@ -35,15 +116,18 @@ class FakeModX extends modX
         if ($class === 'sxSubscriber') {
             return new sxSubscriber($this);
         }
+        if ($class === 'sxQueue') {
+            return new sxQueue($this);
+        }
 
         throw new InvalidArgumentException('Unknown class: ' . $class);
     }
 
     /**
      * @param string $class
-     * @param FakeQuery|array|null $criteria
+     * @param FakeQuery|array|int|null $criteria
      *
-     * @return xPDOSimpleObject|null
+     * @return mixed
      */
     public function getObject($class, $criteria = null)
     {
@@ -51,15 +135,49 @@ class FakeModX extends modX
             $userId = is_array($criteria) && isset($criteria['internalKey'])
                 ? (int) $criteria['internalKey']
                 : 0;
+            if ($userId && isset($this->userProfiles[$userId])) {
+                return $this->userProfiles[$userId];
+            }
             if ($userId && isset($this->profiles[$userId])) {
                 $profile = new modUserProfile($this);
                 $profile->set('email', $this->profiles[$userId]);
+                $profile->set('blocked', false);
                 $profile->set('internalKey', $userId);
 
                 return $profile;
             }
 
             return null;
+        }
+
+        if ($class === 'modUser') {
+            $id = is_numeric($criteria) ? (int) $criteria : 0;
+            if (is_array($criteria) && isset($criteria['id'])) {
+                $id = (int) $criteria['id'];
+            }
+
+            return isset($this->users[$id]) ? $this->users[$id] : null;
+        }
+
+        if ($class === 'modTemplate') {
+            $id = is_numeric($criteria) ? (int) $criteria : 0;
+
+            return isset($this->templates[$id]) ? $this->templates[$id] : null;
+        }
+
+        if ($class === 'sxNewsletter') {
+            $id = is_numeric($criteria) ? (int) $criteria : 0;
+            if (is_array($criteria) && isset($criteria['id'])) {
+                $id = (int) $criteria['id'];
+                if (isset($criteria['active']) && isset($this->newsletters[$id])) {
+                    $newsletter = $this->newsletters[$id];
+                    if ((int) $newsletter->get('active') !== (int) $criteria['active']) {
+                        return null;
+                    }
+                }
+            }
+
+            return isset($this->newsletters[$id]) ? $this->newsletters[$id] : null;
         }
 
         if ($class === 'sxSubscriber') {
@@ -87,6 +205,63 @@ class FakeModX extends modX
         }
 
         return null;
+    }
+
+    /**
+     * @param string $class
+     * @param array $criteria
+     *
+     * @return int
+     */
+    public function getCount($class, $criteria = array())
+    {
+        if ($class !== 'sxSubscriber') {
+            return 0;
+        }
+
+        $count = 0;
+        foreach ($this->subscribers as $subscriber) {
+            $match = true;
+            foreach ($criteria as $key => $value) {
+                if ((string) $subscriber->get($key) !== (string) $value) {
+                    $match = false;
+                    break;
+                }
+            }
+            if ($match) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * @param string $class
+     * @param array $criteria
+     *
+     * @return sxSubscriber[]
+     */
+    public function getIterator($class, $criteria = array())
+    {
+        if ($class !== 'sxSubscriber') {
+            return array();
+        }
+
+        $ids = array();
+        if (isset($criteria['id:IN']) && is_array($criteria['id:IN'])) {
+            $ids = array_map('intval', $criteria['id:IN']);
+        }
+
+        $out = array();
+        foreach ($this->subscribers as $subscriber) {
+            if ($ids && !in_array((int) $subscriber->get('id'), $ids, true)) {
+                continue;
+            }
+            $out[] = $subscriber;
+        }
+
+        return $out;
     }
 
     /**

--- a/tests/Stubs/FakeModX.php
+++ b/tests/Stubs/FakeModX.php
@@ -1,0 +1,108 @@
+<?php
+
+class FakeModX extends modX
+{
+    /** @var sxSubscriber[] */
+    public $subscribers = array();
+
+    /** @var array<int,string> user_id => email */
+    public $profiles = array();
+
+    /** @var array<string,mixed> */
+    public $invokeResponses = array();
+
+    /** @var array<int,array{0:string,1:array}> */
+    public $invoked = array();
+
+    /**
+     * @param string $class
+     * @param array|null $criteria
+     *
+     * @return FakeQuery
+     */
+    public function newQuery($class, $criteria = null)
+    {
+        return new FakeQuery($class, $criteria);
+    }
+
+    /**
+     * @param string $class
+     *
+     * @return xPDOSimpleObject
+     */
+    public function newObject($class)
+    {
+        if ($class === 'sxSubscriber') {
+            return new sxSubscriber($this);
+        }
+
+        throw new InvalidArgumentException('Unknown class: ' . $class);
+    }
+
+    /**
+     * @param string $class
+     * @param FakeQuery|array|null $criteria
+     *
+     * @return xPDOSimpleObject|null
+     */
+    public function getObject($class, $criteria = null)
+    {
+        if ($class === 'modUserProfile') {
+            $userId = is_array($criteria) && isset($criteria['internalKey'])
+                ? (int) $criteria['internalKey']
+                : 0;
+            if ($userId && isset($this->profiles[$userId])) {
+                $profile = new modUserProfile($this);
+                $profile->set('email', $this->profiles[$userId]);
+                $profile->set('internalKey', $userId);
+
+                return $profile;
+            }
+
+            return null;
+        }
+
+        if ($class === 'sxSubscriber') {
+            $where = array();
+            if ($criteria instanceof FakeQuery) {
+                $where = $criteria->where;
+            } elseif (is_array($criteria)) {
+                $where = $criteria;
+            }
+
+            foreach ($this->subscribers as $subscriber) {
+                $match = true;
+                foreach ($where as $key => $value) {
+                    if ((string) $subscriber->get($key) !== (string) $value) {
+                        $match = false;
+                        break;
+                    }
+                }
+                if ($match) {
+                    return $subscriber;
+                }
+            }
+
+            return null;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string $name
+     * @param array $params
+     *
+     * @return mixed
+     */
+    public function invokeEvent($name, array $params = array())
+    {
+        $this->invoked[] = array($name, $params);
+
+        if (array_key_exists($name, $this->invokeResponses)) {
+            return $this->invokeResponses[$name];
+        }
+
+        return array();
+    }
+}

--- a/tests/Stubs/FakeQuery.php
+++ b/tests/Stubs/FakeQuery.php
@@ -1,0 +1,34 @@
+<?php
+
+class FakeQuery
+{
+    /** @var string */
+    public $class;
+
+    /** @var array */
+    public $where = array();
+
+    /**
+     * @param string $class
+     * @param array|null $criteria
+     */
+    public function __construct($class, $criteria = null)
+    {
+        $this->class = $class;
+        if (is_array($criteria)) {
+            $this->where = $criteria;
+        }
+    }
+
+    /**
+     * @param array $criteria
+     *
+     * @return self
+     */
+    public function where($criteria)
+    {
+        $this->where = array_merge($this->where, $criteria);
+
+        return $this;
+    }
+}

--- a/tests/Stubs/FakeRegister.php
+++ b/tests/Stubs/FakeRegister.php
@@ -1,0 +1,63 @@
+<?php
+
+class FakeRegister
+{
+    /** @var FakeModX */
+    public $modx;
+
+    /** @var array<string,array> */
+    public $entries = array();
+
+    public function __construct(FakeModX $modx)
+    {
+        $this->modx = $modx;
+    }
+
+    public function connect()
+    {
+        return true;
+    }
+
+    /**
+     * @param string $path
+     */
+    public function subscribe($path)
+    {
+        $this->modx->lastRegisterPath = $path;
+    }
+
+    /**
+     * @param string $path
+     * @param array $payload
+     * @param array $options
+     */
+    public function send($path, array $payload, array $options = array())
+    {
+        foreach ($payload as $hash => $entry) {
+            $this->entries[$hash] = $entry;
+            $this->modx->registryEntries[$hash] = $entry;
+        }
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return array
+     */
+    public function read(array $options = array())
+    {
+        $path = $this->modx->lastRegisterPath;
+        $prefix = '/sendex/subscribe/';
+        if (strpos($path, $prefix) === 0) {
+            $hash = substr($path, strlen($prefix));
+            if ($hash !== '' && isset($this->modx->registryEntries[$hash])) {
+                $entry = $this->modx->registryEntries[$hash];
+                unset($this->modx->registryEntries[$hash]);
+
+                return array($entry);
+            }
+        }
+
+        return array();
+    }
+}

--- a/tests/Stubs/FakeRegistry.php
+++ b/tests/Stubs/FakeRegistry.php
@@ -1,0 +1,23 @@
+<?php
+
+class FakeRegistry
+{
+    /** @var FakeModX */
+    public $modx;
+
+    public function __construct(FakeModX $modx)
+    {
+        $this->modx = $modx;
+    }
+
+    /**
+     * @param string $name
+     * @param string $class
+     *
+     * @return FakeRegister
+     */
+    public function getRegister($name, $class)
+    {
+        return new FakeRegister($this->modx);
+    }
+}

--- a/tests/Stubs/modParser.php
+++ b/tests/Stubs/modParser.php
@@ -1,0 +1,29 @@
+<?php
+
+class modParser
+{
+    /**
+     * @param string $root
+     * @param string $content
+     * @param bool $processUncacheable
+     * @param bool $removeUnprocessed
+     * @param string $prefix
+     * @param string $suffix
+     * @param array $tokens
+     * @param int $maxIterations
+     *
+     * @return bool
+     */
+    public function processElementTags(
+        $root,
+        &$content,
+        $processUncacheable = false,
+        $removeUnprocessed = false,
+        $prefix = '[[',
+        $suffix = ']]',
+        array $tokens = array(),
+        $maxIterations = 10
+    ) {
+        return true;
+    }
+}

--- a/tests/Stubs/modProcessor.php
+++ b/tests/Stubs/modProcessor.php
@@ -1,0 +1,81 @@
+<?php
+
+class modProcessor
+{
+    /** @var FakeModX */
+    public $modx;
+
+    /** @var array */
+    public $properties = array();
+
+    /** @var array */
+    public $errors = array();
+
+    /**
+     * @param FakeModX $modx
+     * @param array $properties
+     */
+    public function __construct(FakeModX &$modx, array $properties = array())
+    {
+        $this->modx = &$modx;
+        $this->properties = $properties;
+    }
+
+    /**
+     * @param string $key
+     * @param mixed $default
+     *
+     * @return mixed
+     */
+    public function getProperty($key, $default = null)
+    {
+        return array_key_exists($key, $this->properties) ? $this->properties[$key] : $default;
+    }
+
+    /**
+     * @param string $field
+     * @param string $message
+     */
+    public function addFieldError($field, $message)
+    {
+        $this->errors[$field] = $message;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasErrors()
+    {
+        return !empty($this->errors);
+    }
+
+    /**
+     * @param string $message
+     * @param mixed $object
+     *
+     * @return array
+     */
+    public function failure($message = '', $object = null)
+    {
+        return array(
+            'success' => false,
+            'message' => $message,
+            'object'  => $object,
+        );
+    }
+
+    /**
+     * @param string $message
+     * @param mixed $object
+     *
+     * @return array
+     */
+    public function success($message = '', $object = null)
+    {
+        return array(
+            'success' => true,
+            'message' => $message,
+            'object'  => $object,
+        );
+    }
+}

--- a/tests/Stubs/modTemplate.php
+++ b/tests/Stubs/modTemplate.php
@@ -1,0 +1,22 @@
+<?php
+
+class modTemplate
+{
+    public $_cacheable;
+    public $_processed;
+    public $_output = '';
+
+    /**
+     * @param array $properties
+     *
+     * @return string
+     */
+    public function process(array $properties = array())
+    {
+        $email = isset($properties['subscriber']['email'])
+            ? $properties['subscriber']['email']
+            : '';
+
+        return 'Body for ' . $email;
+    }
+}

--- a/tests/Stubs/modUser.php
+++ b/tests/Stubs/modUser.php
@@ -1,0 +1,32 @@
+<?php
+
+class modUser extends xPDOSimpleObject
+{
+    /** @var bool */
+    public $active = true;
+
+    /**
+     * @param string $alias
+     *
+     * @return modUserProfile|null
+     */
+    public function getOne($alias)
+    {
+        if ($alias === 'Profile' && $this->xpdo instanceof FakeModX) {
+            $id = (int) $this->get('id');
+            if (isset($this->xpdo->userProfiles[$id])) {
+                return $this->xpdo->userProfiles[$id];
+            }
+            if (isset($this->xpdo->profiles[$id])) {
+                $profile = new modUserProfile($this->xpdo);
+                $profile->set('email', $this->xpdo->profiles[$id]);
+                $profile->set('blocked', false);
+                $profile->set('internalKey', $id);
+
+                return $profile;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Stubs/modUserProfile.php
+++ b/tests/Stubs/modUserProfile.php
@@ -1,0 +1,5 @@
+<?php
+
+class modUserProfile extends xPDOSimpleObject
+{
+}

--- a/tests/Stubs/modX.php
+++ b/tests/Stubs/modX.php
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * Marker stub: production code checks `$xpdo instanceof modX`.
+ */
+class modX
+{
+}

--- a/tests/Stubs/sxQueue.php
+++ b/tests/Stubs/sxQueue.php
@@ -1,0 +1,25 @@
+<?php
+
+class sxQueue extends xPDOSimpleObject
+{
+    /** @var bool */
+    public $saveResult = true;
+
+    /**
+     * @param null $cacheFlag
+     *
+     * @return bool
+     */
+    public function save($cacheFlag = null)
+    {
+        if (!$this->saveResult) {
+            return false;
+        }
+
+        if ($this->xpdo instanceof FakeModX) {
+            $this->xpdo->queues[] = $this;
+        }
+
+        return true;
+    }
+}

--- a/tests/Stubs/sxSubscriber.php
+++ b/tests/Stubs/sxSubscriber.php
@@ -1,0 +1,53 @@
+<?php
+
+class sxSubscriber extends xPDOSimpleObject
+{
+    /** @var bool */
+    public $saveResult = true;
+
+    /** @var bool */
+    public $removeResult = true;
+
+    /**
+     * @param null $cacheFlag
+     *
+     * @return bool
+     */
+    public function save($cacheFlag = null)
+    {
+        if (!$this->saveResult) {
+            return false;
+        }
+
+        if ($this->get('id') === null && $this->xpdo instanceof FakeModX) {
+            $this->set('id', count($this->xpdo->subscribers) + 1);
+            $this->xpdo->subscribers[] = $this;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array $ancestors
+     *
+     * @return bool
+     */
+    public function remove(array $ancestors = array())
+    {
+        if (!$this->removeResult) {
+            return false;
+        }
+
+        if ($this->xpdo instanceof FakeModX) {
+            foreach ($this->xpdo->subscribers as $index => $subscriber) {
+                if ($subscriber === $this) {
+                    unset($this->xpdo->subscribers[$index]);
+                    $this->xpdo->subscribers = array_values($this->xpdo->subscribers);
+                    break;
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/tests/Stubs/xPDOSimpleObject.php
+++ b/tests/Stubs/xPDOSimpleObject.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Minimal xPDOSimpleObject stub for unit tests (no MODX install required).
+ */
+class xPDOSimpleObject
+{
+    /** @var FakeModX|null */
+    public $xpdo;
+
+    /** @var array */
+    public $_fields = array();
+
+    /**
+     * @param FakeModX|null $xpdo
+     */
+    public function __construct(&$xpdo = null)
+    {
+        $this->xpdo = &$xpdo;
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return mixed
+     */
+    public function get($key)
+    {
+        return array_key_exists($key, $this->_fields) ? $this->_fields[$key] : null;
+    }
+
+    /**
+     * @param string $key
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    public function set($key, $value)
+    {
+        $this->_fields[$key] = $value;
+
+        return true;
+    }
+
+    /**
+     * @param array $array
+     * @param string $keyPrefix
+     * @param bool $setPrimaryKeys
+     * @param bool $rawValues
+     *
+     * @return bool
+     */
+    public function fromArray($array, $keyPrefix = '', $setPrimaryKeys = false, $rawValues = false)
+    {
+        foreach ($array as $key => $value) {
+            $this->_fields[$key] = $value;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return mixed
+     */
+    public function __get($name)
+    {
+        return $this->get($name);
+    }
+
+    /**
+     * @param string $name
+     * @param mixed $value
+     */
+    public function __set($name, $value)
+    {
+        $this->set($name, $value);
+    }
+}

--- a/tests/Stubs/xPDOSimpleObject.php
+++ b/tests/Stubs/xPDOSimpleObject.php
@@ -60,6 +60,36 @@ class xPDOSimpleObject
     }
 
     /**
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->_fields;
+    }
+
+    /**
+     * @param string $alias
+     *
+     * @return array
+     */
+    public function getMany($alias)
+    {
+        if ($alias === 'Subscribers' && $this->xpdo instanceof FakeModX) {
+            $id = (int) $this->get('id');
+            $out = array();
+            foreach ($this->xpdo->subscribers as $subscriber) {
+                if ((int) $subscriber->get('newsletter_id') === $id) {
+                    $out[] = $subscriber;
+                }
+            }
+
+            return $out;
+        }
+
+        return array();
+    }
+
+    /**
      * @param string $name
      *
      * @return mixed
@@ -67,6 +97,16 @@ class xPDOSimpleObject
     public function __get($name)
     {
         return $this->get($name);
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function __isset($name)
+    {
+        return array_key_exists($name, $this->_fields) && $this->_fields[$name] !== null;
     }
 
     /**

--- a/tests/Support/TestableNewsletter.php
+++ b/tests/Support/TestableNewsletter.php
@@ -1,0 +1,15 @@
+<?php
+
+class TestableNewsletter extends sxNewsletter
+{
+    /**
+     * @param string $name
+     * @param array $params
+     *
+     * @return true|string
+     */
+    public function callInvokeSendexEvent($name, array $params = array())
+    {
+        return $this->invokeSendexEvent($name, $params);
+    }
+}

--- a/tests/Unit/InvokeSendexEventTest.php
+++ b/tests/Unit/InvokeSendexEventTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class InvokeSendexEventTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    /** @var TestableNewsletter */
+    private $newsletter;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+        $this->newsletter = new TestableNewsletter($this->modx);
+        $this->newsletter->set('id', 1);
+    }
+
+    public function testReturnsTrueWhenNoPluginOutput()
+    {
+        $this->assertTrue($this->newsletter->callInvokeSendexEvent('sxOnBeforeSubscribe', array()));
+    }
+
+    public function testReturnsFirstNonEmptyPluginMessage()
+    {
+        $this->modx->invokeResponses['sxOnBeforeSubscribe'] = array('', '  blocked  ', 'ignored');
+
+        $this->assertSame(
+            'blocked',
+            $this->newsletter->callInvokeSendexEvent('sxOnBeforeSubscribe', array())
+        );
+    }
+
+    public function testIgnoresNonStringPluginOutput()
+    {
+        $this->modx->invokeResponses['sxOnBeforeSubscribe'] = array(0, false, null, array('x'));
+
+        $this->assertTrue($this->newsletter->callInvokeSendexEvent('sxOnBeforeSubscribe', array()));
+    }
+
+    public function testSkipsInvokeWhenXpdoIsNotModX()
+    {
+        $xpdo = new xPDOSimpleObject();
+        $newsletter = new TestableNewsletter($xpdo);
+        $newsletter->xpdo = $xpdo;
+
+        $this->assertTrue($newsletter->callInvokeSendexEvent('sxOnBeforeSubscribe', array()));
+    }
+}

--- a/tests/Unit/InvokeSendexEventTest.php
+++ b/tests/Unit/InvokeSendexEventTest.php
@@ -39,6 +39,13 @@ class InvokeSendexEventTest extends TestCase
         $this->assertTrue($this->newsletter->callInvokeSendexEvent('sxOnBeforeSubscribe', array()));
     }
 
+    public function testNonArrayInvokeResponseReturnsTrue()
+    {
+        $this->modx->invokeResponses['sxOnBeforeSubscribe'] = true;
+
+        $this->assertTrue($this->newsletter->callInvokeSendexEvent('sxOnBeforeSubscribe', array()));
+    }
+
     public function testSkipsInvokeWhenXpdoIsNotModX()
     {
         $xpdo = new xPDOSimpleObject();

--- a/tests/Unit/NewsletterAddQueuesTest.php
+++ b/tests/Unit/NewsletterAddQueuesTest.php
@@ -1,0 +1,139 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class NewsletterAddQueuesTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    /** @var TestableNewsletter */
+    private $newsletter;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+        $this->newsletter = new TestableNewsletter($this->modx);
+        $this->newsletter->set('id', 10);
+        $this->newsletter->set('template', 1);
+        $this->newsletter->set('email_subject', 'Hello');
+        $this->newsletter->set('email_from', 'from@example.com');
+        $this->newsletter->set('email_from_name', 'From');
+        $this->newsletter->set('email_reply', 'reply@example.com');
+        $this->modx->templates[1] = new modTemplate();
+    }
+
+    public function testNoSubscribersReturnsLexiconKey()
+    {
+        $this->assertSame(
+            'sendex_newsletter_err_no_subscribers',
+            $this->newsletter->addQueues()
+        );
+    }
+
+    public function testMissingTemplateReturnsLexiconKey()
+    {
+        $this->newsletter->set('template', 0);
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 0,
+            'email'         => 'a@example.com',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $this->assertSame(
+            'sendex_newsletter_err_no_template',
+            $this->newsletter->addQueues()
+        );
+    }
+
+    public function testQueuesEmailForGuestSubscriber()
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 0,
+            'email'         => 'guest@example.com',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $this->assertTrue($this->newsletter->addQueues());
+        $this->assertCount(1, $this->modx->queues);
+        $this->assertSame('guest@example.com', $this->modx->queues[0]->get('email_to'));
+        $this->assertSame('Hello', $this->modx->queues[0]->get('email_subject'));
+    }
+
+    public function testSkipsUserWithoutProfile()
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 5,
+            'email'         => 'user@example.com',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $user = new modUser($this->modx);
+        $user->set('id', 5);
+        $user->active = true;
+        $this->modx->users[5] = $user;
+
+        $this->assertTrue($this->newsletter->addQueues());
+        $this->assertCount(0, $this->modx->queues);
+    }
+
+    public function testSkipsInactiveUser()
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 5,
+            'email'         => 'user@example.com',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $user = new modUser($this->modx);
+        $user->set('id', 5);
+        $user->active = false;
+        $this->modx->users[5] = $user;
+
+        $profile = new modUserProfile($this->modx);
+        $profile->set('blocked', false);
+        $profile->set('email', 'user@example.com');
+        $this->modx->userProfiles[5] = $profile;
+
+        $this->assertTrue($this->newsletter->addQueues());
+        $this->assertCount(0, $this->modx->queues);
+    }
+
+    public function testQueuesForActiveUserWithProfile()
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 5,
+            'email'         => 'user@example.com',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $user = new modUser($this->modx);
+        $user->set('id', 5);
+        $user->active = true;
+        $this->modx->users[5] = $user;
+
+        $profile = new modUserProfile($this->modx);
+        $profile->set('blocked', false);
+        $profile->set('email', 'user@example.com');
+        $this->modx->userProfiles[5] = $profile;
+
+        $this->assertTrue($this->newsletter->addQueues());
+        $this->assertCount(1, $this->modx->queues);
+        $this->assertSame('Body for user@example.com', $this->modx->queues[0]->get('email_body'));
+    }
+}

--- a/tests/Unit/NewsletterCheckEmailTest.php
+++ b/tests/Unit/NewsletterCheckEmailTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class NewsletterCheckEmailTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    /** @var TestableNewsletter */
+    private $newsletter;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+        $this->newsletter = new TestableNewsletter($this->modx);
+        $this->newsletter->set('id', 10);
+    }
+
+    public function testRejectsInvalidEmail()
+    {
+        $this->assertFalse($this->newsletter->checkEmail('bad'));
+    }
+
+    public function testLoadsEmailFromProfile()
+    {
+        $this->modx->profiles[3] = 'from-profile@example.com';
+
+        $hash = $this->newsletter->checkEmail('', 3);
+        $this->assertIsString($hash);
+        $this->assertArrayHasKey($hash, $this->modx->registryEntries);
+        $this->assertSame('from-profile@example.com', $this->modx->registryEntries[$hash]['email']);
+    }
+
+    public function testReturnsTrueWhenAlreadySubscribed()
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 3,
+            'email'         => 'a@example.com',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $this->assertTrue($this->newsletter->checkEmail('a@example.com', 3));
+        $this->assertSame(array(), $this->modx->registryEntries);
+    }
+
+    public function testStoresHashInRegistry()
+    {
+        $hash = $this->newsletter->checkEmail('new@example.com', 9, 600);
+        $this->assertIsString($hash);
+        $this->assertSame(10, $this->modx->registryEntries[$hash]['newsletter_id']);
+        $this->assertSame(9, $this->modx->registryEntries[$hash]['user_id']);
+    }
+}

--- a/tests/Unit/NewsletterConfirmEmailTest.php
+++ b/tests/Unit/NewsletterConfirmEmailTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class NewsletterConfirmEmailTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    /** @var TestableNewsletter */
+    private $newsletter;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+        $this->newsletter = new TestableNewsletter($this->modx);
+        $this->newsletter->set('id', 10);
+        $this->newsletter->set('active', 1);
+        $this->modx->newsletters[10] = $this->newsletter;
+    }
+
+    public function testEmptyHashReturnsFalse()
+    {
+        $this->assertFalse($this->newsletter->confirmEmail(''));
+    }
+
+    public function testMissingRegistryEntryReturnsFalse()
+    {
+        $this->assertFalse($this->newsletter->confirmEmail('unknown'));
+    }
+
+    public function testConfirmsForSameNewsletter()
+    {
+        $this->modx->registryEntries['hash1'] = array(
+            'user_id'       => 4,
+            'newsletter_id' => 10,
+            'email'         => 'ok@example.com',
+        );
+
+        $this->assertTrue($this->newsletter->confirmEmail('hash1'));
+        $this->assertCount(1, $this->modx->subscribers);
+        $this->assertSame('sxOnSubscribe', $this->modx->invoked[1][0]);
+    }
+
+    public function testConfirmsViaOtherActiveNewsletter()
+    {
+        $other = new TestableNewsletter($this->modx);
+        $other->set('id', 20);
+        $other->set('active', 1);
+        $this->modx->newsletters[20] = $other;
+
+        $this->modx->registryEntries['hash2'] = array(
+            'user_id'       => 8,
+            'newsletter_id' => 20,
+            'email'         => 'other@example.com',
+        );
+
+        $this->assertTrue($this->newsletter->confirmEmail('hash2'));
+        $this->assertCount(1, $this->modx->subscribers);
+        $this->assertSame(20, (int) $this->modx->subscribers[0]->get('newsletter_id'));
+    }
+
+    public function testReturnsFalseWhenOtherNewsletterInactive()
+    {
+        $other = new TestableNewsletter($this->modx);
+        $other->set('id', 20);
+        $other->set('active', 0);
+        $this->modx->newsletters[20] = $other;
+
+        $this->modx->registryEntries['hash3'] = array(
+            'user_id'       => 8,
+            'newsletter_id' => 20,
+            'email'         => 'other@example.com',
+        );
+
+        $this->assertFalse($this->newsletter->confirmEmail('hash3'));
+        $this->assertCount(0, $this->modx->subscribers);
+    }
+}

--- a/tests/Unit/NewsletterIsSubscribedTest.php
+++ b/tests/Unit/NewsletterIsSubscribedTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class NewsletterIsSubscribedTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    /** @var TestableNewsletter */
+    private $newsletter;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+        $this->newsletter = new TestableNewsletter($this->modx);
+        $this->newsletter->set('id', 10);
+    }
+
+    public function testReturnsZeroWhenNoMatch()
+    {
+        $this->assertSame(0, $this->newsletter->isSubscribed(1, 'a@example.com'));
+    }
+
+    public function testReturnsSubscriberIdWhenMatched()
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 42,
+            'newsletter_id' => 10,
+            'user_id'       => 5,
+            'email'         => 'a@example.com',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $this->assertSame(42, $this->newsletter->isSubscribed(5, 'a@example.com'));
+    }
+
+    public function testMatchesByEmailOnly()
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 7,
+            'newsletter_id' => 10,
+            'user_id'       => 0,
+            'email'         => 'guest@example.com',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $this->assertSame(7, $this->newsletter->isSubscribed(0, 'guest@example.com'));
+    }
+}

--- a/tests/Unit/NewsletterSubscribeTest.php
+++ b/tests/Unit/NewsletterSubscribeTest.php
@@ -1,0 +1,89 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class NewsletterSubscribeTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    /** @var TestableNewsletter */
+    private $newsletter;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+        $this->newsletter = new TestableNewsletter($this->modx);
+        $this->newsletter->set('id', 10);
+    }
+
+    public function testRejectsInvalidEmail()
+    {
+        $this->assertFalse($this->newsletter->subscribe(0, 'not-an-email'));
+        $this->assertSame(array(), $this->modx->invoked);
+    }
+
+    public function testLoadsEmailFromProfile()
+    {
+        $this->modx->profiles[5] = 'user@example.com';
+
+        $this->assertTrue($this->newsletter->subscribe(5, ''));
+        $this->assertCount(1, $this->modx->subscribers);
+        $this->assertSame('user@example.com', $this->modx->subscribers[0]->get('email'));
+    }
+
+    public function testAlreadySubscribedIsIdempotentWithoutEvents()
+    {
+        $existing = new sxSubscriber($this->modx);
+        $existing->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 5,
+            'email'         => 'user@example.com',
+        ));
+        $this->modx->subscribers[] = $existing;
+
+        $this->assertTrue($this->newsletter->subscribe(5, 'user@example.com'));
+        $this->assertSame(array(), $this->modx->invoked);
+        $this->assertCount(1, $this->modx->subscribers);
+    }
+
+    public function testFiresBeforeAndAfterEventsOnSuccess()
+    {
+        $this->assertTrue($this->newsletter->subscribe(7, 'new@example.com'));
+
+        $this->assertCount(2, $this->modx->invoked);
+        $this->assertSame('sxOnBeforeSubscribe', $this->modx->invoked[0][0]);
+        $this->assertSame('sxOnSubscribe', $this->modx->invoked[1][0]);
+        $this->assertInstanceOf('sxSubscriber', $this->modx->invoked[1][1]['subscriber']);
+    }
+
+    public function testBeforeCancelReturnsPluginMessageAndDoesNotSave()
+    {
+        $this->modx->invokeResponses['sxOnBeforeSubscribe'] = array('not allowed');
+
+        $this->assertSame('not allowed', $this->newsletter->subscribe(7, 'new@example.com'));
+        $this->assertCount(0, $this->modx->subscribers);
+        $this->assertCount(1, $this->modx->invoked);
+        $this->assertSame('sxOnBeforeSubscribe', $this->modx->invoked[0][0]);
+    }
+
+    public function testSaveFailureReturnsFalseWithoutAfterEvent()
+    {
+        $this->modx = new class extends FakeModX {
+            public function newObject($class)
+            {
+                $subscriber = parent::newObject($class);
+                $subscriber->saveResult = false;
+
+                return $subscriber;
+            }
+        };
+        $this->newsletter = new TestableNewsletter($this->modx);
+        $this->newsletter->set('id', 10);
+
+        $this->assertFalse($this->newsletter->subscribe(7, 'new@example.com'));
+        $this->assertCount(1, $this->modx->invoked);
+        $this->assertSame('sxOnBeforeSubscribe', $this->modx->invoked[0][0]);
+    }
+}

--- a/tests/Unit/NewsletterUnsubscribeTest.php
+++ b/tests/Unit/NewsletterUnsubscribeTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class NewsletterUnsubscribeTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    /** @var TestableNewsletter */
+    private $newsletter;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+        $this->newsletter = new TestableNewsletter($this->modx);
+        $this->newsletter->set('id', 10);
+    }
+
+    /**
+     * @return sxSubscriber
+     */
+    private function addSubscriber(array $fields)
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray($fields);
+        $this->modx->subscribers[] = $subscriber;
+
+        return $subscriber;
+    }
+
+    public function testMissingCodeReturnsFalse()
+    {
+        $this->assertFalse($this->newsletter->unSubscribe('missing'));
+        $this->assertSame(array(), $this->modx->invoked);
+    }
+
+    public function testMismatchedNewsletterIdReturnsFalseWithoutEvents()
+    {
+        $this->addSubscriber(array(
+            'id'            => 1,
+            'newsletter_id' => 99,
+            'user_id'       => 5,
+            'email'         => 'user@example.com',
+            'code'          => 'abc123',
+        ));
+
+        $this->assertFalse($this->newsletter->unSubscribe('abc123'));
+        $this->assertCount(1, $this->modx->subscribers);
+        $this->assertSame(array(), $this->modx->invoked);
+    }
+
+    public function testFiresBeforeAndAfterEventsOnSuccess()
+    {
+        $this->addSubscriber(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 5,
+            'email'         => 'user@example.com',
+            'code'          => 'abc123',
+        ));
+
+        $this->assertTrue($this->newsletter->unSubscribe('abc123'));
+        $this->assertCount(0, $this->modx->subscribers);
+        $this->assertCount(2, $this->modx->invoked);
+        $this->assertSame('sxOnBeforeUnsubscribe', $this->modx->invoked[0][0]);
+        $this->assertSame('sxOnUnsubscribe', $this->modx->invoked[1][0]);
+        $this->assertSame('abc123', $this->modx->invoked[0][1]['code']);
+    }
+
+    public function testBeforeCancelReturnsPluginMessageAndKeepsSubscriber()
+    {
+        $this->addSubscriber(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 5,
+            'email'         => 'user@example.com',
+            'code'          => 'abc123',
+        ));
+        $this->modx->invokeResponses['sxOnBeforeUnsubscribe'] = array('stay subscribed');
+
+        $this->assertSame('stay subscribed', $this->newsletter->unSubscribe('abc123'));
+        $this->assertCount(1, $this->modx->subscribers);
+        $this->assertCount(1, $this->modx->invoked);
+    }
+
+    public function testRemoveFailureReturnsFalseWithoutAfterEvent()
+    {
+        $subscriber = $this->addSubscriber(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 5,
+            'email'         => 'user@example.com',
+            'code'          => 'abc123',
+        ));
+        $subscriber->removeResult = false;
+
+        $this->assertFalse($this->newsletter->unSubscribe('abc123'));
+        $this->assertCount(1, $this->modx->subscribers);
+        $this->assertCount(1, $this->modx->invoked);
+        $this->assertSame('sxOnBeforeUnsubscribe', $this->modx->invoked[0][0]);
+    }
+}

--- a/tests/Unit/SubscriberCreateProcessorTest.php
+++ b/tests/Unit/SubscriberCreateProcessorTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class SubscriberCreateProcessorTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    /** @var sxSubscriberCreateProcessor */
+    private $processor;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+        $newsletter = new TestableNewsletter($this->modx);
+        $newsletter->set('id', 10);
+        $this->modx->newsletters[10] = $newsletter;
+        $this->processor = new sxSubscriberCreateProcessor($this->modx);
+    }
+
+    public function testRequiresUserAndNewsletter()
+    {
+        $result = $this->processor->process();
+        $this->assertFalse($result['success']);
+        $this->assertSame('sendex_subscriber_err_save', $result['message']);
+    }
+
+    public function testFailsWithoutProfile()
+    {
+        $this->processor->properties = array(
+            'user_id'       => 5,
+            'newsletter_id' => 10,
+        );
+        $result = $this->processor->process();
+        $this->assertFalse($result['success']);
+        $this->assertSame('sendex_subscriber_err_email', $result['message']);
+    }
+
+    public function testFailsOnInvalidProfileEmail()
+    {
+        $this->modx->profiles[5] = 'not-an-email';
+        $this->processor->properties = array(
+            'user_id'       => 5,
+            'newsletter_id' => 10,
+        );
+        $result = $this->processor->process();
+        $this->assertFalse($result['success']);
+        $this->assertSame('sendex_subscriber_err_email', $result['message']);
+    }
+
+    public function testFailsOnDuplicate()
+    {
+        $this->modx->profiles[5] = 'a@example.com';
+        $existing = new sxSubscriber($this->modx);
+        $existing->fromArray(array(
+            'newsletter_id' => 10,
+            'user_id'       => 5,
+            'email'         => 'a@example.com',
+        ));
+        $this->modx->subscribers[] = $existing;
+
+        $this->processor->properties = array(
+            'user_id'       => 5,
+            'newsletter_id' => 10,
+        );
+        $result = $this->processor->process();
+        $this->assertFalse($result['success']);
+        $this->assertSame('sendex_subscriber_err_ae', $result['message']);
+    }
+
+    public function testFailsWhenNewsletterMissing()
+    {
+        $this->modx->profiles[5] = 'a@example.com';
+        unset($this->modx->newsletters[10]);
+        $this->processor->properties = array(
+            'user_id'       => 5,
+            'newsletter_id' => 10,
+        );
+        $result = $this->processor->process();
+        $this->assertFalse($result['success']);
+        $this->assertSame('sendex_newsletter_err_nf', $result['message']);
+    }
+
+    public function testSuccessSubscribesAndFiresEvents()
+    {
+        $this->modx->profiles[5] = 'a@example.com';
+        $this->processor->properties = array(
+            'user_id'       => 5,
+            'newsletter_id' => 10,
+        );
+        $result = $this->processor->process();
+        $this->assertTrue($result['success']);
+        $this->assertCount(1, $this->modx->subscribers);
+        $this->assertSame('sxOnBeforeSubscribe', $this->modx->invoked[0][0]);
+        $this->assertSame('sxOnSubscribe', $this->modx->invoked[1][0]);
+    }
+
+    public function testPropagatesPluginCancelMessage()
+    {
+        $this->modx->profiles[5] = 'a@example.com';
+        $this->modx->invokeResponses['sxOnBeforeSubscribe'] = array('blocked by plugin');
+        $this->processor->properties = array(
+            'user_id'       => 5,
+            'newsletter_id' => 10,
+        );
+        $result = $this->processor->process();
+        $this->assertFalse($result['success']);
+        $this->assertSame('blocked by plugin', $result['message']);
+    }
+}

--- a/tests/Unit/SubscriberRemoveProcessorTest.php
+++ b/tests/Unit/SubscriberRemoveProcessorTest.php
@@ -1,0 +1,126 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class SubscriberRemoveProcessorTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    /** @var sxSubscriberRemoveProcessor */
+    private $processor;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+        $newsletter = new TestableNewsletter($this->modx);
+        $newsletter->set('id', 10);
+        $this->modx->newsletters[10] = $newsletter;
+        $this->processor = new sxSubscriberRemoveProcessor($this->modx);
+    }
+
+    public function testRequiresIds()
+    {
+        $this->processor->properties = array('ids' => '');
+        $result = $this->processor->process();
+        $this->assertFalse($result['success']);
+        $this->assertSame('sendex_subscribers_err_ns', $result['message']);
+    }
+
+    public function testRemovesViaUnSubscribe()
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 5,
+            'email'         => 'a@example.com',
+            'code'          => 'code1',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $this->processor->properties = array('ids' => '1');
+        $result = $this->processor->process();
+        $this->assertTrue($result['success']);
+        $this->assertCount(0, $this->modx->subscribers);
+        $this->assertSame('sxOnBeforeUnsubscribe', $this->modx->invoked[0][0]);
+        $this->assertSame('sxOnUnsubscribe', $this->modx->invoked[1][0]);
+    }
+
+    public function testFailureWhenPluginCancels()
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 5,
+            'email'         => 'a@example.com',
+            'code'          => 'code1',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+        $this->modx->invokeResponses['sxOnBeforeUnsubscribe'] = array('keep them');
+
+        $this->processor->properties = array('ids' => '1');
+        $result = $this->processor->process();
+        $this->assertFalse($result['success']);
+        $this->assertSame('keep them', $result['message']);
+        $this->assertCount(1, $this->modx->subscribers);
+    }
+
+    public function testFailureWhenUnSubscribeReturnsFalse()
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 5,
+            'email'         => 'a@example.com',
+            'code'          => 'code1',
+        ));
+        $subscriber->removeResult = false;
+        $this->modx->subscribers[] = $subscriber;
+
+        $this->processor->properties = array('ids' => '1');
+        $result = $this->processor->process();
+        $this->assertFalse($result['success']);
+        $this->assertSame('sendex_subscriber_err_remove', $result['message']);
+    }
+
+    public function testOrphanRemoveWithoutNewsletter()
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 2,
+            'newsletter_id' => 99,
+            'user_id'       => 5,
+            'email'         => 'a@example.com',
+            'code'          => 'orphan',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $this->processor->properties = array('ids' => '2');
+        $result = $this->processor->process();
+        $this->assertTrue($result['success']);
+        $this->assertCount(0, $this->modx->subscribers);
+        $this->assertSame(array(), $this->modx->invoked);
+    }
+
+    public function testOrphanRemoveFailure()
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 2,
+            'newsletter_id' => 99,
+            'user_id'       => 5,
+            'email'         => 'a@example.com',
+            'code'          => 'orphan',
+        ));
+        $subscriber->removeResult = false;
+        $this->modx->subscribers[] = $subscriber;
+
+        $this->processor->properties = array('ids' => '2');
+        $result = $this->processor->process();
+        $this->assertFalse($result['success']);
+        $this->assertSame('sendex_subscriber_err_remove', $result['message']);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,13 @@
+<?php
+
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+require_once __DIR__ . '/Stubs/xPDOSimpleObject.php';
+require_once __DIR__ . '/Stubs/modX.php';
+require_once __DIR__ . '/Stubs/FakeQuery.php';
+require_once __DIR__ . '/Stubs/modUserProfile.php';
+require_once __DIR__ . '/Stubs/sxSubscriber.php';
+require_once __DIR__ . '/Stubs/FakeModX.php';
+
+require_once dirname(__DIR__) . '/core/components/sendex/model/sendex/sxnewsletter.class.php';
+require_once __DIR__ . '/Support/TestableNewsletter.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,8 +6,18 @@ require_once __DIR__ . '/Stubs/xPDOSimpleObject.php';
 require_once __DIR__ . '/Stubs/modX.php';
 require_once __DIR__ . '/Stubs/FakeQuery.php';
 require_once __DIR__ . '/Stubs/modUserProfile.php';
+require_once __DIR__ . '/Stubs/modUser.php';
+require_once __DIR__ . '/Stubs/modTemplate.php';
+require_once __DIR__ . '/Stubs/modParser.php';
+require_once __DIR__ . '/Stubs/FakeRegister.php';
+require_once __DIR__ . '/Stubs/FakeRegistry.php';
 require_once __DIR__ . '/Stubs/sxSubscriber.php';
+require_once __DIR__ . '/Stubs/sxQueue.php';
 require_once __DIR__ . '/Stubs/FakeModX.php';
+require_once __DIR__ . '/Stubs/modProcessor.php';
 
 require_once dirname(__DIR__) . '/core/components/sendex/model/sendex/sxnewsletter.class.php';
 require_once __DIR__ . '/Support/TestableNewsletter.php';
+
+require_once dirname(__DIR__) . '/core/components/sendex/processors/mgr/newsletter/subscriber/create.class.php';
+require_once dirname(__DIR__) . '/core/components/sendex/processors/mgr/newsletter/subscriber/remove.class.php';


### PR DESCRIPTION
Add plugin events for subscribe and unsubscribe so site code can react (user groups, related newsletters, and similar).

Events live only in `sxNewsletter::subscribe()` / `unSubscribe()`. The manager create/remove processors call those methods, so front-end, confirm, and mgr share one path. Before events cancel via `$modx->event->output()`; callers get the string back. `unSubscribe` refuses a code that belongs to another newsletter.

Also targets PHP 7.4–8.4 (declared properties, null Profile in `addQueues`, PHPMailer `ErrorInfo`) and adds PHPUnit with MODX stubs plus CI lint/test on 7.4–8.4.

Review the cancel-message return type (`true|false|string`) in the snippet and mgr processors, and that transport events install with `BUILD_EVENT_UPDATE`.

Fixes #44