### PR TITLE
fix(security): authenticated subscriber CSV export (#51)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 
 # VSCode
 .vscode
+
+/vendor/
+/coverage/
+composer.lock

--- a/assets/components/sendex/js/mgr/widgets/newsletters.grid.js
+++ b/assets/components/sendex/js/mgr/widgets/newsletters.grid.js
@@ -493,35 +493,63 @@ Ext.extend(Sendex.grid.NewsletterSubscribers,MODx.grid.Grid, {
     }
 
     ,exportSubscribers: function() {
-        MODx.msg.confirm({
-            title: _('sendex_subscribers_export_confirm_title')
-            ,text: _('sendex_subscribers_export_confirm_text')
-            ,url: Sendex.config.connector_url
-            ,params: {
-                action: 'mgr/newsletter/subscriber/export'
-                ,newsletter_id: this.config.record.id
-            }
-            ,listeners: {
-                'success': {
-                    fn: function (data) {
-                        var date = new Date().format('Ymd-His');
-                        var newlink = document.createElement('a');
-                        newlink.setAttribute('target', '_blank');
-                        newlink.setAttribute('download', 'subscribers_' + date + '.csv');
-                        newlink.setAttribute('href',data.url);
-                        newlink.click()
-                    }, scope: this
-                },
-                'error': {
-                    fn: function (data) {
-                        MODx.msg.status({
-                            title: _('error'),
-                            message: _('sendex_subscribers_export_error')
-                        });
-                    }, scope: this
+        Ext.Msg.confirm(
+            _('sendex_subscribers_export_confirm_title')
+            ,_('sendex_subscribers_export_confirm_text')
+            ,function(btn) {
+                if (btn !== 'yes') {
+                    return;
                 }
+                MODx.Ajax.request({
+                    url: Sendex.config.connector_url
+                    ,params: {
+                        action: 'mgr/newsletter/subscriber/export'
+                        ,newsletter_id: this.config.record.id
+                    }
+                    ,listeners: {
+                        success: {
+                            fn: function(r) {
+                                var payload = r.object || r;
+                                if (typeof payload.csv === 'undefined' || payload.csv === null) {
+                                    MODx.msg.status({
+                                        title: _('error')
+                                        ,message: _('sendex_subscribers_export_error')
+                                    });
+                                    return;
+                                }
+                                this.saveCsvFile(
+                                    payload.filename || ('subscribers_' + new Date().format('Ymd-His') + '.csv')
+                                    ,payload.csv
+                                );
+                            }
+                            ,scope: this
+                        }
+                        ,failure: {
+                            fn: function() {
+                                MODx.msg.status({
+                                    title: _('error')
+                                    ,message: _('sendex_subscribers_export_error')
+                                });
+                            }
+                            ,scope: this
+                        }
+                    }
+                });
             }
-        });
+            ,this
+        );
+    }
+
+    ,saveCsvFile: function(filename, csv) {
+        var blob = new Blob([csv], {type: 'text/csv;charset=utf-8;'});
+        var url = window.URL.createObjectURL(blob);
+        var link = document.createElement('a');
+        link.setAttribute('href', url);
+        link.setAttribute('download', filename);
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        window.URL.revokeObjectURL(url);
     }
 
 });

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,43 @@
+{
+    "name": "modx-pro/sendex",
+    "description": "Email newsletters for MODX Revolution",
+    "type": "library",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "php": ">=7.4 <8.5"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.6.22",
+        "squizlabs/php_codesniffer": "3.13.4"
+    },
+    "scripts": {
+        "test": "phpunit",
+        "phpcs": "phpcs --standard=phpcs.xml"
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "repositories": [
+        {
+            "type": "package",
+            "package": {
+                "name": "squizlabs/php_codesniffer",
+                "version": "3.13.4",
+                "type": "library",
+                "dist": {
+                    "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer/archive/refs/tags/3.13.4.zip",
+                    "type": "zip"
+                },
+                "bin": [
+                    "bin/phpcs",
+                    "bin/phpcbf"
+                ],
+                "autoload": {
+                    "classmap": [
+                        "."
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -1,60 +1,91 @@
-Changelog for Sendex.
+# Changelog
 
-1.1.5-pl
-==============
-- [#47] When adding a user group to a newsletter, only active and unblocked users are subscribed
-- Cast group_id and newsletter_id to int in add_group; require user Profile (innerJoin)
-- add_group processor requires edit_document permission
-- Renamed newsletter create processor class to sxNewsletterCreateProcessor
-- Renamed subscribe() method to camelCase (PHP method names are case-insensitive; Subscribe() calls still work)
+All notable changes to this project will be documented in this file.
 
-1.1.4-pl
-==============
-- Fix css bug for usergroup combo
-- [#37] Added functionality to export email addresses
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-1.1.3-pl
-==============
-- [#32, #33] Added parameter &msgClass for placeholder [[+class]]
-- [#31] Added messages for frontend
-- [#30] Change phptype text to string
+## [1.1.5-pl] - 2026-07-24
 
-1.1.2-pl
-==============
-- [#23] Added button for removing all letters from queue
+### Security
+- [#51] Subscriber export goes through the authenticated manager connector (no public CSV under `assets/`); processor requires `edit_document`.
+- CSV cells that look like spreadsheet formulas are prefixed so Excel/LibreOffice do not execute them.
 
-1.1.1-pl
-==============
-- Fixed modUserProfile getting on creating subscriber
+### Fixed
+- [#47] Adding a user group to a newsletter subscribes only active and unblocked users.
+- `add_group`: cast `group_id` and `newsletter_id` to int; require user Profile (`innerJoin`).
 
-1.1.0-pl
-==============
-- Improved installation script for MODX 2.4.
+### Changed
+- `add_group` processor requires `edit_document` permission.
+- Newsletter create processor class renamed to `sxNewsletterCreateProcessor`.
+- `subscribe()` method name normalized to camelCase (PHP method names are case-insensitive; `Subscribe()` calls still work).
 
-1.1.0-rc
-==============
+## [1.1.4-pl] - 2022-12-23
+
+### Added
+- [#37] Export subscriber email addresses from the manager.
+
+### Fixed
+- CSS bug for the usergroup combo.
+
+## [1.1.3-pl] - 2019-08-24
+
+### Added
+- [#32], [#33] Snippet property `&msgClass` for placeholder `[[+class]]`.
+- [#31] Frontend messages.
+
+### Changed
+- [#30] Schema: `phptype` `text` → `string`.
+
+## [1.1.2-pl] - 2015-10-23
+
+### Added
+- [#23] Button to remove all letters from the queue.
+
+## [1.1.1-pl] - 2015-09-10
+
+### Fixed
+- Loading `modUserProfile` when creating a subscriber.
+
+## [1.1.0-pl] - 2015-08-19
+
+### Changed
+- Installation script improved for MODX 2.4.
+
+## [1.1.0-rc] - 2014-08-19
+
+### Added
+- Add all users of a group to a newsletter.
+- Multiselect in all grids.
+- Subscriber count in the newsletters grid.
+- Grid buttons for touch devices.
+- Font Awesome icons for MODX < 2.3.
+- [#20] “Send all” button on the queues grid.
+
+### Changed
 - UI improvements.
-- Ability to add all users of the group to the newsletter.
-- Added multiselect in all grids.
-- Added subscribers count in newsletters grid.
-- Added buttons to grids for touch devices.
-- Added Font Awesome icons for MODX < 2.3.
 - [#21] Compatibility with MODX 2.3.
-- [#20] Added "send all" button to queues grid.
 
-1.0.0-pl
-==============
-- Added multiremoving and multisending
-- [#11]Added $_GET's subscribed, unsubscribed, confirmed
-- [#1] Fixed urls of images
+## [1.0.0-pl] - 2014-03-27
 
-1.0.0-rc2
-==============
+### Added
+- Multi-remove and multi-send.
+- [#11] `$_GET` flags `subscribed`, `unsubscribed`, `confirmed`.
+
+### Fixed
+- [#1] Image URLs.
+
+## [1.0.0-rc2] - 2014-03-07
+
+### Fixed
 - Various small fixes.
 
-==============
-- Fixed caching of template.
+## [1.0.0-rc1] - 2013-12-30
 
-1.0.0-beta
-==============
+### Fixed
+- Template caching.
+
+## [1.0.0-beta] - 2013-12-19
+
+### Added
 - Initial release.

--- a/core/components/sendex/lexicon/en/default.inc.php
+++ b/core/components/sendex/lexicon/en/default.inc.php
@@ -121,3 +121,4 @@ $_lang['sendex_action_sendQueue'] = 'Send email';
 $_lang['sendex_subscribers_export_confirm_title'] = 'Confirm export';
 $_lang['sendex_subscribers_export_confirm_text'] = 'Export email addresses?';
 $_lang['sendex_subscribers_export_error'] = 'Error while exporting subscribers!';
+$_lang['sendex_subscribers_export_fields_err'] = 'No valid export fields configured.';

--- a/core/components/sendex/lexicon/ru/default.inc.php
+++ b/core/components/sendex/lexicon/ru/default.inc.php
@@ -123,3 +123,4 @@ $_lang['sendex_action_sendQueue'] = 'Отправить письмо';
 $_lang['sendex_subscribers_export_confirm_title'] = 'Подтвердите экспорт';
 $_lang['sendex_subscribers_export_confirm_text'] = 'Экспортировать email адреса?';
 $_lang['sendex_subscribers_export_error'] = 'Ошибка при экспорте подписчиков!';
+$_lang['sendex_subscribers_export_fields_err'] = 'В настройках нет допустимых полей для экспорта.';

--- a/core/components/sendex/model/sendex/sxsubscribercsv.class.php
+++ b/core/components/sendex/model/sendex/sxsubscribercsv.class.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * Builds subscriber CSV payloads without touching the filesystem.
+ */
+class sxSubscriberCsv
+{
+    public const ALLOWED_FIELDS = array(
+        'id',
+        'user_id',
+        'email',
+        'username',
+        'fullname',
+        'phone',
+        'mobilephone',
+    );
+
+    public const PROFILE_FIELDS = array('fullname', 'phone', 'mobilephone');
+
+    /**
+     * @param string $optionCsv Comma-separated setting value
+     * @return string[]
+     */
+    public static function resolveFields($optionCsv)
+    {
+        $requested = array_filter(array_map('trim', explode(',', (string) $optionCsv)));
+        return array_values(array_intersect($requested, self::ALLOWED_FIELDS));
+    }
+
+    /**
+     * @param string[] $fields
+     * @return bool
+     */
+    public static function needsUserJoin(array $fields)
+    {
+        return in_array('username', $fields, true);
+    }
+
+    /**
+     * @param string[] $fields
+     * @return bool
+     */
+    public static function needsProfileJoin(array $fields)
+    {
+        return (bool) array_intersect($fields, self::PROFILE_FIELDS);
+    }
+
+    /**
+     * @param string[] $fields
+     * @param string $subscriberAlias
+     * @return string[]
+     */
+    public static function selectColumns(array $fields, $subscriberAlias = 'sxSubscriber')
+    {
+        $columns = array();
+        foreach ($fields as $field) {
+            if (in_array($field, self::PROFILE_FIELDS, true)) {
+                $columns[] = 'Profile.' . $field;
+            } elseif ($field === 'username') {
+                $columns[] = 'User.' . $field;
+            } else {
+                $columns[] = $subscriberAlias . '.' . $field;
+            }
+        }
+
+        return $columns;
+    }
+
+    /**
+     * @param array[] $rows Associative rows in export field order
+     * @return string
+     */
+    public static function encode(array $rows)
+    {
+        $fp = fopen('php://temp', 'r+');
+        if ($fp === false) {
+            return '';
+        }
+
+        foreach ($rows as $row) {
+            $cells = array();
+            foreach (array_values($row) as $value) {
+                $cells[] = self::neutralizeCsvCell($value);
+            }
+            fputcsv($fp, $cells, ',', '"', '\\');
+        }
+        rewind($fp);
+        $csv = stream_get_contents($fp);
+        fclose($fp);
+
+        return $csv === false ? '' : $csv;
+    }
+
+    /**
+     * Prefix formula-like values so Excel/LibreOffice do not execute them.
+     *
+     * @param mixed $value
+     * @return string
+     */
+    public static function neutralizeCsvCell($value)
+    {
+        $value = (string) $value;
+        if ($value !== '' && preg_match('/^[=+\-@\t\r]/', $value) === 1) {
+            return "'" . $value;
+        }
+
+        return $value;
+    }
+}

--- a/core/components/sendex/processors/mgr/newsletter/subscriber/export.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/subscriber/export.class.php
@@ -1,97 +1,80 @@
 <?php
 
 /**
- * Export Subscribers
+ * Export subscribers as CSV through the authenticated mgr connector.
+ * Does not write files under assets/ or return a public URL.
  */
+
+require_once dirname(__FILE__, 5) . '/model/sendex/sxsubscribercsv.class.php';
 
 class sxSubscribersExportProcessor extends modObjectProcessor
 {
     public $objectType = 'sxSubscriber';
     public $classKey = 'sxSubscriber';
     public $languageTopics = array('sendex');
-    public $permission = '';
+    /** Matches other newsletter mutation processors; blocks anonymous connector calls. */
+    public $permission = 'edit_document';
 
 
     /**
-     * @return json
+     * @return array|string
      */
     public function process()
     {
-
-        if (!$newsletter_id = $this->getProperty('newsletter_id')) {
+        $newsletterId = (int) $this->getProperty('newsletter_id');
+        if (!$newsletterId) {
             return $this->failure($this->modx->lexicon('sendex_newsletter_err_ns'));
         }
 
-        $assetsUrl = $this->modx->getOption(
-            'sendex_assets_url',
-            null,
-            $this->modx->getOption('assets_url') . 'components/sendex/',
-            true
+        $fields = sxSubscriberCsv::resolveFields(
+            $this->modx->getOption('sendex_export_fields', null, 'email', true)
         );
+        if (empty($fields)) {
+            return $this->failure($this->modx->lexicon('sendex_subscribers_export_fields_err'));
+        }
 
-        $optionFields = array_map(
-            'trim',
-            explode(
-                ',',
-                $this->modx->getOption('sendex_export_fields', null, 'email', true)
-            )
-        );
-        $allowedFields = [
-        'id',
-        'user_id',
-        'email',
-        'username',
-        'fullname',
-        'phone',
-        'mobilephone',
-        ];
-        $exportFields = array_intersect($optionFields, $allowedFields);
-        $selectfields = [];
+        $rows = $this->fetchRows($newsletterId, $fields);
+        if ($rows === null) {
+            return $this->failure($this->modx->lexicon('sendex_subscribers_export_error'));
+        }
 
+        $filename = 'subscribers_' . date('Ymd-His') . '.csv';
+
+        return $this->success('', array(
+            'filename' => $filename,
+            'csv' => sxSubscriberCsv::encode($rows),
+        ));
+    }
+
+
+    /**
+     * @param int $newsletterId
+     * @param string[] $fields
+     * @return array[]|null Null when the query cannot be executed
+     */
+    protected function fetchRows($newsletterId, array $fields)
+    {
         $q = $this->modx->newQuery($this->classKey);
+        $q->select(sxSubscriberCsv::selectColumns($fields, $this->classKey));
 
-        foreach ($exportFields as $field) {
-            if (in_array($field, ['fullname', 'phone', 'mobilephone'])) {
-                $selectfields[] = 'Profile.' . $field;
-            } elseif ($field == 'username') {
-                $selectfields[] = 'User.' . $field;
-            } else {
-                $selectfields[] =  $this->classKey . '.' . $field;
-            }
+        if (sxSubscriberCsv::needsUserJoin($fields)) {
+            $q->leftJoin('modUser', 'User', '`User`.`id`=`sxSubscriber`.`user_id`');
+        }
+        if (sxSubscriberCsv::needsProfileJoin($fields)) {
+            $q->leftJoin(
+                'modUserProfile',
+                'Profile',
+                'Profile.internalKey = sxSubscriber.user_id'
+            );
         }
 
-        foreach ($exportFields as $field) {
-            if ($field == 'username') {
-                $q->leftJoin('modUser', 'User', '`User`.`id`=`sxSubscriber`.`user_id`');
-                break;
-            }
+        $q->where(array('sxSubscriber.newsletter_id' => $newsletterId));
+        if (!$q->prepare() || !is_object($q->stmt) || !$q->stmt->execute()) {
+            return null;
         }
 
-        foreach ($exportFields as $field) {
-            if (in_array($field, ['fullname', 'phone', 'mobilephone'])) {
-                $q->leftJoin('modUserProfile', 'Profile', 'Profile.internalKey = sxSubscriber.user_id');
-                break;
-            }
-        }
-
-        $q->select($selectfields);
-        $q->where(array('sxSubscriber.newsletter_id' => $newsletter_id));
-
-        $out = [
-            'success' => true,
-            'url'     => $assetsUrl . 'subscribers.csv?' . time(),
-        ];
-        $fp = fopen('subscribers.csv', 'w');
-
-        $q->prepare();
-        $q->stmt->execute();
         $rows = $q->stmt->fetchAll(PDO::FETCH_ASSOC);
-        foreach ($rows as $row) {
-            fputcsv($fp, $row);
-        }
-        fclose($fp);
-
-        return json_encode($out, 256);
+        return is_array($rows) ? $rows : array();
     }
 }
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+    bootstrap="tests/bootstrap.php"
+    colors="true"
+    cacheResult="false">
+    <testsuites>
+        <testsuite name="Sendex">
+            <directory>tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/Unit/SubscriberCsvTest.php
+++ b/tests/Unit/SubscriberCsvTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sxsubscribercsv.class.php';
+
+class SubscriberCsvTest extends TestCase
+{
+    public function testResolveFieldsKeepsOnlyAllowed(): void
+    {
+        $fields = sxSubscriberCsv::resolveFields('email, username, hack, phone');
+        $this->assertSame(array('email', 'username', 'phone'), $fields);
+    }
+
+    public function testResolveFieldsEmptyWhenNoneValid(): void
+    {
+        $this->assertSame(array(), sxSubscriberCsv::resolveFields('foo,bar'));
+    }
+
+    public function testJoinFlags(): void
+    {
+        $this->assertTrue(sxSubscriberCsv::needsUserJoin(array('username')));
+        $this->assertFalse(sxSubscriberCsv::needsUserJoin(array('email')));
+        $this->assertTrue(sxSubscriberCsv::needsProfileJoin(array('email', 'phone')));
+        $this->assertFalse(sxSubscriberCsv::needsProfileJoin(array('email')));
+    }
+
+    public function testSelectColumns(): void
+    {
+        $columns = sxSubscriberCsv::selectColumns(array('email', 'username', 'fullname'));
+        $this->assertSame(
+            array('sxSubscriber.email', 'User.username', 'Profile.fullname'),
+            $columns
+        );
+    }
+
+    public function testEncodeCsv(): void
+    {
+        $csv = sxSubscriberCsv::encode(array(
+            array('email' => 'a@example.com', 'name' => 'Ann'),
+            array('email' => 'b@example.com', 'name' => "Be,e"),
+        ));
+        $this->assertStringContainsString('a@example.com', $csv);
+        $this->assertStringContainsString('b@example.com', $csv);
+        $this->assertStringContainsString('"Be,e"', $csv);
+    }
+
+    public function testEncodeNeutralizesFormulaCells(): void
+    {
+        $this->assertSame("'=1+1", sxSubscriberCsv::neutralizeCsvCell('=1+1'));
+        $this->assertSame("'+1234", sxSubscriberCsv::neutralizeCsvCell('+1234'));
+        $this->assertSame('safe@example.com', sxSubscriberCsv::neutralizeCsvCell('safe@example.com'));
+
+        $csv = sxSubscriberCsv::encode(array(
+            array('email' => '=1+1', 'name' => 'Ann'),
+        ));
+        $this->assertStringContainsString("'=1+1", $csv);
+    }
+
+    public function testExportProcessorContract(): void
+    {
+        $processorFile = dirname(__DIR__, 2)
+            . '/core/components/sendex/processors/mgr/newsletter/subscriber/export.class.php';
+        $source = file_get_contents($processorFile);
+        $this->assertNotFalse($source);
+        $this->assertStringContainsString("permission = 'edit_document'", $source);
+        $this->assertStringNotContainsString('subscribers.csv', $source);
+        $this->assertStringNotContainsString('assets_url', $source);
+        $this->assertStringNotContainsString('fopen(', $source);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+declare(strict_types=1);


### PR DESCRIPTION
## Summary
- Export no longer writes `subscribers.csv` or returns a public `assets/` URL
- CSV is returned through the mgr connector (`edit_document`); manager downloads a Blob
- Formula-like cells are neutralized; query failures return a processor failure
- Unit tests for field allowlist, encode, formula escape, and processor contract

## Test plan
- [ ] Manager with `edit_document`: confirm export → CSV downloads
- [ ] Anonymous / no permission: export fails
- [ ] Empty newsletter: empty CSV still downloads
- [ ] `composer test` (SubscriberCsvTest)
- [ ] Confirm no `assets/components/sendex/subscribers.csv` is created

Fixes #51