### PR TITLE
fix(snippet): Guard missing Profile for authenticated users

### DIFF
--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPUnit coverage for subscribe/unsubscribe events (stubs, no MODX install).
 
 ### Fixed
+- [#53] Snippet: authenticated user without Profile no longer triggers TypeError on PHP 8 (`getOne('Profile')` before merge).
 - [#47] Adding a user group to a newsletter subscribes only active and unblocked users.
 - `add_group`: cast `group_id` and `newsletter_id` to int; require user Profile (`innerJoin`).
 - `confirmEmail` returns the `subscribe()` result when confirming a hash for another newsletter.

--- a/core/components/sendex/elements/snippets/snippet.sendex.php
+++ b/core/components/sendex/elements/snippets/snippet.sendex.php
@@ -35,15 +35,15 @@ $placeholders = $newsletter->toArray();
 $placeholders['message'] = '';
 $placeholders['class'] = '';
 $placeholders['error'] = 0;
-if ($modx->user->isAuthenticated($modx->context->key)) {
-    $placeholders = array_merge(
-        $modx->user->toArray(),
-        $modx->user->Profile->toArray(),
-        $placeholders
-    );
-}
-
 $isAuthenticated = $modx->user->isAuthenticated($modx->context->key);
+if ($isAuthenticated) {
+    $userData = $modx->user->toArray();
+    $profile = $modx->user->getOne('Profile');
+    if ($profile) {
+        $userData = array_merge($userData, $profile->toArray());
+    }
+    $placeholders = array_merge($userData, $placeholders);
+}
 
 if (!empty($_REQUEST['sx_action'])) {
     $isAjax = isset($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] == 'XMLHttpRequest';


### PR DESCRIPTION
На PHP 8 обращение к `$modx->user->Profile->toArray()` без Profile даёт TypeError и роняет форму подписки. Сниппет больше не считает Profile обязательным свойством.

## Что сделано
- Profile через `getOne('Profile')`; merge только если объект есть
- Порядок плейсхолдеров как раньше: user → profile → newsletter
- `isAuthenticated` считается один раз

## Почему так
Минимальный guard в сниппете, без нового слоя абстракции.

## Проверка
- `composer test` — OK (54 tests, exit 0)
- `phpcs --standard=phpcs.xml` на сниппет — exit 0

Fixes #53