### PR TITLE
fix(subscribers): Match subscription by user OR email

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,4 +1,4 @@
-name: PHP Compatibility
+name: PHP
 
 on:
   push:
@@ -34,5 +34,8 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist
 
-      - name: Run PHPUnit
-        run: vendor/bin/phpunit
+      - name: PHPUnit
+        run: composer test
+
+      - name: PHPCS
+        run: composer phpcs

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,7 +15,7 @@ jobs:
         php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/_build/resolvers/resolve.tables.php
+++ b/_build/resolvers/resolve.tables.php
@@ -38,6 +38,20 @@ if ($object->xpdo) {
             break;
 
         case xPDOTransport::ACTION_UPGRADE:
+            $modelPath = $modx->getOption(
+                'sendex_core_path',
+                null,
+                $modx->getOption('core_path') . 'components/sendex/'
+            ) . 'model/';
+            $modx->addPackage('sendex', $modelPath);
+            $manager = $modx->getManager();
+            $level = $modx->getLogLevel();
+            $modx->setLogLevel(xPDO::LOG_LEVEL_FATAL);
+            // Unique (newsletter_id, email): one address per newsletter (#54).
+            // Fails if duplicate emails already exist — clean manually, then re-run upgrade.
+            $manager->removeIndex('sxSubscriber', 'key');
+            $manager->addIndex('sxSubscriber', 'key');
+            $modx->setLogLevel($level);
             break;
 
         case xPDOTransport::ACTION_UNINSTALL:

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "scripts": {
         "test": "phpunit",
         "test:coverage": "phpdbg -qrr vendor/bin/phpunit --coverage-text",
-        "phpcs": "phpcs --standard=phpcs.xml"
+        "phpcs": "phpcs --standard=phpcs.xml -n"
     },
     "config": {
         "sort-packages": true

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPUnit coverage for subscribe/unsubscribe events (stubs, no MODX install).
 
 ### Fixed
+- [#54] `isSubscribed` matches by `user_id` OR `email` within a newsletter; unique key is `(newsletter_id, email)`; guest rows attach `user_id` when the same email confirms as a user (also covers main #39 cases; activate-merge handler still open).
 - [#58] `confirmEmail` restores registry hash when `subscribe()` fails so the confirm link stays usable; remaining TTL kept via `_expires`; `checkEmail` shares `sxSubscribeRegistry::store`.
 - [#61] `sxSubscriber::save` keeps existing `code` (generate only when empty) so unsubscribe links stay valid.
 - [#53] Snippet: authenticated user without Profile no longer triggers TypeError on PHP 8; merge via `sxUserPlaceholders`.

--- a/core/components/sendex/model/schema/sendex.mysql.schema.xml
+++ b/core/components/sendex/model/schema/sendex.mysql.schema.xml
@@ -35,7 +35,6 @@
 
         <index alias="key" name="key" primary="false" unique="true" type="BTREE">
             <column key="newsletter_id" length="" collation="A" null="false" />
-            <column key="user_id" length="" collation="A" null="false" />
             <column key="email" length="" collation="A" null="false" />
         </index>
         <index alias="code" name="code" primary="false" unique="true" type="BTREE">

--- a/core/components/sendex/model/sendex/mysql/sxsubscriber.map.inc.php
+++ b/core/components/sendex/model/sendex/mysql/sxsubscriber.map.inc.php
@@ -65,12 +65,6 @@ $xpdo_meta_map['sxSubscriber'] = array(
           'collation' => 'A',
           'null'      => false,
         ),
-        'user_id'       =>
-        array(
-          'length'    => '',
-          'collation' => 'A',
-          'null'      => false,
-        ),
         'email'         =>
         array(
           'length'    => '',

--- a/core/components/sendex/model/sendex/sxnewsletter.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletter.class.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once dirname(__FILE__) . '/sxsubscriberegistry.class.php';
+require_once dirname(__FILE__) . '/sxsubscribermatch.class.php';
 
 class sxNewsletter extends xPDOSimpleObject
 {
@@ -101,21 +102,32 @@ class sxNewsletter extends xPDOSimpleObject
      */
     public function isSubscribed($user_id = 0, $email = '')
     {
-        $q = $this->xpdo->newQuery('sxSubscriber', array('newsletter_id' => $this->get('id')));
+        $user_id = (int) $user_id;
+        $email = sxSubscriberMatch::normalizeEmail($email);
 
-        if (!empty($user_id)) {
-            $q->where(array('user_id' => $user_id));
-        }
-        if (!empty($email)) {
-            $q->where(array('email' => $email));
+        if ($email === '' && $user_id > 0) {
+            /** @var modUserProfile $profile */
+            $profile = $this->xpdo->getObject('modUserProfile', array('internalKey' => $user_id));
+            if ($profile) {
+                $email = sxSubscriberMatch::normalizeEmail($profile->get('email'));
+            }
         }
 
-        /** @var sxSubscriber $subscriber */
-        if ($subscriber = $this->xpdo->getObject('sxSubscriber', $q)) {
-            return $subscriber->id;
-        } else {
+        $where = sxSubscriberMatch::whereClause($this->get('id'), $user_id, $email);
+        if ($where === null) {
             return 0;
         }
+
+        $q = $this->xpdo->newQuery('sxSubscriber');
+        $q->where($where);
+
+        /** @var sxSubscriber $subscriber */
+        $subscriber = $this->xpdo->getObject('sxSubscriber', $q);
+        if ($subscriber) {
+            return (int) $subscriber->id;
+        }
+
+        return 0;
     }
 
 
@@ -212,9 +224,16 @@ class sxNewsletter extends xPDOSimpleObject
             $email = $profile->get('email');
         }
 
-        if (empty($email) || !preg_match('/.+@.+\..+/i', $email)) {
+        $email = sxSubscriberMatch::normalizeEmail($email);
+        if ($email === '' || !preg_match('/.+@.+\..+/i', $email)) {
             return false;
-        } elseif ($this->isSubscribed($user_id, $email)) {
+        }
+
+        $user_id = sxSubscriberMatch::resolveUserId($this->xpdo, $user_id, $email);
+
+        if ($subscriberId = $this->isSubscribed($user_id, $email)) {
+            $this->attachUserToSubscriber($subscriberId, $user_id, $email);
+
             return true;
         }
 
@@ -247,6 +266,43 @@ class sxNewsletter extends xPDOSimpleObject
         $this->invokeSendexEvent('sxOnSubscribe', $params);
 
         return true;
+    }
+
+    /**
+     * Promote guest row / refresh email when identity already exists.
+     *
+     * @param int $subscriberId
+     * @param int $userId
+     * @param string $email
+     */
+    protected function attachUserToSubscriber($subscriberId, $userId, $email)
+    {
+        $userId = (int) $userId;
+        if ($userId <= 0 && $email === '') {
+            return;
+        }
+
+        /** @var sxSubscriber $subscriber */
+        $subscriber = $this->xpdo->getObject('sxSubscriber', (int) $subscriberId);
+        if (!$subscriber) {
+            return;
+        }
+
+        $changed = false;
+        if ($userId > 0 && (int) $subscriber->get('user_id') === 0) {
+            $subscriber->set('user_id', $userId);
+            $changed = true;
+        }
+        if ($email !== '' && strcasecmp((string) $subscriber->get('email'), $email) !== 0) {
+            if ($userId > 0 && (int) $subscriber->get('user_id') === $userId) {
+                $subscriber->set('email', $email);
+                $changed = true;
+            }
+        }
+
+        if ($changed) {
+            $subscriber->save();
+        }
     }
 
 

--- a/core/components/sendex/model/sendex/sxsubscribermatch.class.php
+++ b/core/components/sendex/model/sendex/sxsubscribermatch.class.php
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * Subscriber identity within one newsletter: match by user_id OR email.
+ */
+class sxSubscriberMatch
+{
+    /**
+     * @param int $userId
+     * @param string $email
+     * @return bool
+     */
+    public static function hasIdentity($userId, $email)
+    {
+        return (int) $userId > 0 || self::normalizeEmail($email) !== '';
+    }
+
+    /**
+     * @param mixed $email
+     * @return string
+     */
+    public static function normalizeEmail($email)
+    {
+        return is_string($email) ? trim($email) : '';
+    }
+
+    /**
+     * Whether a subscriber row matches the identity (OR when both set).
+     *
+     * @param int $newsletterId
+     * @param int $userId
+     * @param string $email
+     * @param int $rowNewsletterId
+     * @param int $rowUserId
+     * @param string $rowEmail
+     * @return bool
+     */
+    public static function rowMatches(
+        $newsletterId,
+        $userId,
+        $email,
+        $rowNewsletterId,
+        $rowUserId,
+        $rowEmail
+    ) {
+        if ((int) $rowNewsletterId !== (int) $newsletterId) {
+            return false;
+        }
+
+        $userId = (int) $userId;
+        $email = self::normalizeEmail($email);
+        $rowUserId = (int) $rowUserId;
+        $rowEmail = self::normalizeEmail($rowEmail);
+
+        if ($userId > 0 && $email !== '') {
+            return $rowUserId === $userId || strcasecmp($rowEmail, $email) === 0;
+        }
+        if ($userId > 0) {
+            return $rowUserId === $userId;
+        }
+        if ($email !== '') {
+            return strcasecmp($rowEmail, $email) === 0;
+        }
+
+        return false;
+    }
+
+    /**
+     * xPDO where for newsletter + optional OR(user_id, email).
+     *
+     * @param int $newsletterId
+     * @param int $userId
+     * @param string $email
+     * @return array|null
+     */
+    public static function whereClause($newsletterId, $userId, $email)
+    {
+        $userId = (int) $userId;
+        $email = self::normalizeEmail($email);
+
+        if (!self::hasIdentity($userId, $email)) {
+            return null;
+        }
+
+        $where = array(
+            'newsletter_id' => (int) $newsletterId,
+        );
+
+        if ($userId > 0 && $email !== '') {
+            $where[] = array(
+                'user_id'      => $userId,
+                'OR:email:='   => $email,
+            );
+        } elseif ($userId > 0) {
+            $where['user_id'] = $userId;
+        } else {
+            $where['email'] = $email;
+        }
+
+        return $where;
+    }
+
+    /**
+     * Evaluate FakeQuery/xPDO-like where against a subscriber row (tests + stubs).
+     *
+     * @param array $where
+     * @param object $subscriber
+     * @return bool
+     */
+    public static function matchesWhere(array $where, $subscriber)
+    {
+        foreach ($where as $key => $value) {
+            if (is_int($key) && is_array($value)) {
+                if (!self::matchesOrGroup($value, $subscriber)) {
+                    return false;
+                }
+                continue;
+            }
+
+            if ((string) $subscriber->get($key) !== (string) $value) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array $group
+     * @param object $subscriber
+     * @return bool
+     */
+    private static function matchesOrGroup(array $group, $subscriber)
+    {
+        foreach ($group as $key => $value) {
+            if (strpos($key, 'OR:') === 0) {
+                $field = self::fieldFromOrKey($key);
+                if ($field !== '' && strcasecmp((string) $subscriber->get($field), (string) $value) === 0) {
+                    return true;
+                }
+                continue;
+            }
+
+            if ((string) $subscriber->get($key) === (string) $value) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $key e.g. OR:email:=
+     * @return string
+     */
+    private static function fieldFromOrKey($key)
+    {
+        $parts = explode(':', $key);
+        return isset($parts[1]) ? $parts[1] : '';
+    }
+
+    /**
+     * If user_id empty, resolve modUser by profile email.
+     *
+     * @param object $xpdo
+     * @param int $userId
+     * @param string $email
+     * @return int
+     */
+    public static function resolveUserId($xpdo, $userId, $email)
+    {
+        $userId = (int) $userId;
+        if ($userId > 0) {
+            return $userId;
+        }
+
+        $email = self::normalizeEmail($email);
+        if ($email === '') {
+            return 0;
+        }
+
+        $profile = $xpdo->getObject('modUserProfile', array('email' => $email));
+        if (!$profile) {
+            return 0;
+        }
+
+        return (int) $profile->get('internalKey');
+    }
+}

--- a/core/components/sendex/processors/mgr/newsletter/subscriber/create.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/subscriber/create.class.php
@@ -43,20 +43,14 @@ class sxSubscriberCreateProcessor extends modProcessor
             return $this->failure($this->modx->lexicon('sendex_subscriber_err_email'));
         }
 
-        if (
-            $this->modx->getCount($this->classKey, array(
-                'newsletter_id' => $newsletter_id,
-                'user_id'       => $user_id,
-                'email'         => $email,
-            ))
-        ) {
-            return $this->failure($this->modx->lexicon('sendex_subscriber_err_ae'));
-        }
-
         /** @var sxNewsletter $newsletter */
         $newsletter = $this->modx->getObject('sxNewsletter', $newsletter_id);
         if (!$newsletter) {
             return $this->failure($this->modx->lexicon('sendex_newsletter_err_nf'));
+        }
+
+        if ($newsletter->isSubscribed($user_id, $email)) {
+            return $this->failure($this->modx->lexicon('sendex_subscriber_err_ae'));
         }
 
         $result = $newsletter->subscribe($user_id, $email);

--- a/tests/Stubs/FakeModX.php
+++ b/tests/Stubs/FakeModX.php
@@ -135,6 +135,27 @@ class FakeModX extends modX
     public function getObject($class, $criteria = null)
     {
         if ($class === 'modUserProfile') {
+            if (is_array($criteria) && isset($criteria['email'])) {
+                $want = strtolower((string) $criteria['email']);
+                foreach ($this->userProfiles as $userId => $profile) {
+                    if (strtolower((string) $profile->get('email')) === $want) {
+                        return $profile;
+                    }
+                }
+                foreach ($this->profiles as $userId => $email) {
+                    if (strtolower((string) $email) === $want) {
+                        $profile = new modUserProfile($this);
+                        $profile->set('email', $email);
+                        $profile->set('blocked', false);
+                        $profile->set('internalKey', $userId);
+
+                        return $profile;
+                    }
+                }
+
+                return null;
+            }
+
             $userId = is_array($criteria) && isset($criteria['internalKey'])
                 ? (int) $criteria['internalKey']
                 : 0;
@@ -184,6 +205,17 @@ class FakeModX extends modX
         }
 
         if ($class === 'sxSubscriber') {
+            if (is_numeric($criteria)) {
+                $id = (int) $criteria;
+                foreach ($this->subscribers as $subscriber) {
+                    if ((int) $subscriber->get('id') === $id) {
+                        return $subscriber;
+                    }
+                }
+
+                return null;
+            }
+
             $where = array();
             if ($criteria instanceof FakeQuery) {
                 $where = $criteria->where;
@@ -192,14 +224,7 @@ class FakeModX extends modX
             }
 
             foreach ($this->subscribers as $subscriber) {
-                $match = true;
-                foreach ($where as $key => $value) {
-                    if ((string) $subscriber->get($key) !== (string) $value) {
-                        $match = false;
-                        break;
-                    }
-                }
-                if ($match) {
+                if (sxSubscriberMatch::matchesWhere($where, $subscriber)) {
                     return $subscriber;
                 }
             }

--- a/tests/Stubs/FakeQuery.php
+++ b/tests/Stubs/FakeQuery.php
@@ -27,7 +27,13 @@ class FakeQuery
      */
     public function where($criteria)
     {
-        $this->where = array_merge($this->where, $criteria);
+        foreach ($criteria as $key => $value) {
+            if (is_int($key)) {
+                $this->where[] = $value;
+                continue;
+            }
+            $this->where[$key] = $value;
+        }
 
         return $this;
     }

--- a/tests/Unit/NewsletterIsSubscribedTest.php
+++ b/tests/Unit/NewsletterIsSubscribedTest.php
@@ -49,4 +49,47 @@ class NewsletterIsSubscribedTest extends TestCase
 
         $this->assertSame(7, $this->newsletter->isSubscribed(0, 'guest@example.com'));
     }
+
+    public function testMatchesByUserIdWhenEmailChanged()
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 11,
+            'newsletter_id' => 10,
+            'user_id'       => 5,
+            'email'         => 'old@example.com',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $this->assertSame(11, $this->newsletter->isSubscribed(5, 'new@example.com'));
+    }
+
+    public function testMatchesGuestEmailWhenUserSubscribesSameAddress()
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 12,
+            'newsletter_id' => 10,
+            'user_id'       => 0,
+            'email'         => 'same@example.com',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $this->assertSame(12, $this->newsletter->isSubscribed(9, 'same@example.com'));
+    }
+
+    public function testUserIdOnlyUsesProfileEmailForOrLookup()
+    {
+        $this->modx->profiles[5] = 'profile@example.com';
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 15,
+            'newsletter_id' => 10,
+            'user_id'       => 0,
+            'email'         => 'profile@example.com',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $this->assertSame(15, $this->newsletter->isSubscribed(5));
+    }
 }

--- a/tests/Unit/NewsletterSubscribeTest.php
+++ b/tests/Unit/NewsletterSubscribeTest.php
@@ -86,4 +86,46 @@ class NewsletterSubscribeTest extends TestCase
         $this->assertCount(1, $this->modx->invoked);
         $this->assertSame('sxOnBeforeSubscribe', $this->modx->invoked[0][0]);
     }
+
+    public function testDoesNotCreateSecondRowWhenEmailChangedForSameUser()
+    {
+        $existing = new sxSubscriber($this->modx);
+        $existing->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 5,
+            'email'         => 'old@example.com',
+        ));
+        $this->modx->subscribers[] = $existing;
+
+        $this->assertTrue($this->newsletter->subscribe(5, 'new@example.com'));
+        $this->assertCount(1, $this->modx->subscribers);
+        $this->assertSame('new@example.com', $this->modx->subscribers[0]->get('email'));
+        $this->assertSame(array(), $this->modx->invoked);
+    }
+
+    public function testPromotesGuestRowWhenUserConfirmsSameEmail()
+    {
+        $existing = new sxSubscriber($this->modx);
+        $existing->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 0,
+            'email'         => 'same@example.com',
+        ));
+        $this->modx->subscribers[] = $existing;
+
+        $this->assertTrue($this->newsletter->subscribe(8, 'same@example.com'));
+        $this->assertCount(1, $this->modx->subscribers);
+        $this->assertSame(8, (int) $this->modx->subscribers[0]->get('user_id'));
+    }
+
+    public function testAnonymousSubscribeResolvesExistingUserByEmail()
+    {
+        $this->modx->profiles[4] = 'member@example.com';
+
+        $this->assertTrue($this->newsletter->subscribe(0, 'member@example.com'));
+        $this->assertCount(1, $this->modx->subscribers);
+        $this->assertSame(4, (int) $this->modx->subscribers[0]->get('user_id'));
+    }
 }

--- a/tests/Unit/SubscriberCreateProcessorTest.php
+++ b/tests/Unit/SubscriberCreateProcessorTest.php
@@ -54,6 +54,7 @@ class SubscriberCreateProcessorTest extends TestCase
         $this->modx->profiles[5] = 'a@example.com';
         $existing = new sxSubscriber($this->modx);
         $existing->fromArray(array(
+            'id'            => 3,
             'newsletter_id' => 10,
             'user_id'       => 5,
             'email'         => 'a@example.com',
@@ -107,5 +108,27 @@ class SubscriberCreateProcessorTest extends TestCase
         $result = $this->processor->process();
         $this->assertFalse($result['success']);
         $this->assertSame('blocked by plugin', $result['message']);
+    }
+
+    public function testFailsOnDuplicateByEmailAcrossUserIds()
+    {
+        $this->modx->profiles[5] = 'a@example.com';
+        $existing = new sxSubscriber($this->modx);
+        $existing->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 0,
+            'email'         => 'a@example.com',
+        ));
+        $this->modx->subscribers[] = $existing;
+
+        $this->processor->properties = array(
+            'user_id'       => 5,
+            'newsletter_id' => 10,
+        );
+        $result = $this->processor->process();
+        $this->assertFalse($result['success']);
+        $this->assertSame('sendex_subscriber_err_ae', $result['message']);
+        $this->assertCount(1, $this->modx->subscribers);
     }
 }

--- a/tests/Unit/SubscriberMatchTest.php
+++ b/tests/Unit/SubscriberMatchTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sxsubscribermatch.class.php';
+
+class SubscriberMatchTest extends TestCase
+{
+    public function testRowMatchesOrWhenBothIdentityPartsSet(): void
+    {
+        $this->assertTrue(sxSubscriberMatch::rowMatches(
+            10,
+            5,
+            'new@example.com',
+            10,
+            5,
+            'old@example.com'
+        ));
+        $this->assertTrue(sxSubscriberMatch::rowMatches(
+            10,
+            9,
+            'guest@example.com',
+            10,
+            0,
+            'guest@example.com'
+        ));
+        $this->assertFalse(sxSubscriberMatch::rowMatches(
+            10,
+            5,
+            'a@example.com',
+            10,
+            8,
+            'b@example.com'
+        ));
+    }
+
+    public function testWhereClauseBuildsOrGroup(): void
+    {
+        $where = sxSubscriberMatch::whereClause(3, 4, 'a@example.com');
+        $this->assertSame(3, $where['newsletter_id']);
+        $this->assertSame(
+            array(
+                'user_id'    => 4,
+                'OR:email:=' => 'a@example.com',
+            ),
+            $where[0]
+        );
+    }
+
+    public function testResolveUserIdFromProfileEmail(): void
+    {
+        $modx = new FakeModX();
+        $modx->profiles[12] = 'user@example.com';
+
+        $this->assertSame(12, sxSubscriberMatch::resolveUserId($modx, 0, 'user@example.com'));
+        $this->assertSame(7, sxSubscriberMatch::resolveUserId($modx, 7, 'user@example.com'));
+        $this->assertSame(0, sxSubscriberMatch::resolveUserId($modx, 0, 'missing@example.com'));
+    }
+}


### PR DESCRIPTION
### Кратко

`isSubscribed` требовал AND по `user_id` и `email`, из‑за этого появлялись дубли и двойные письма в очереди. Lookup теперь OR в рамках newsletter; unique — `(newsletter_id, email)`.

## Что сделано
- `sxSubscriberMatch` (OR where, resolve user по email, row match)
- `isSubscribed` / `subscribe` / mgr create через OR; guest→`user_id` при том же email
- schema/map + upgrade resolver (пересоздаёт unique `key`)
- тесты: `SubscriberMatchTest`, IsSubscribed/Subscribe/CreateProcessor

## Почему так

Один инвариант: в newsletter один email (и/или user). #39 activate-merge handler не в этом PR.

## Review
- Medium+: нет
- Low: upgrade молчит, если дубли email уже есть — чистить вручную; полный cleanup → #67
- Low: `OnBeforeUserActivate` merge → остаётся в #39

## Проверка
- `composer test` — exit 0 (79 tests)
- `vendor/bin/phpcs --standard=phpcs.xml` — exit 0

## Связанные issue

Fixes #54  
Refs #39