### PR TITLE
chore(db): Phinx migrations, InnoDB schema, queue subscriber_id

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -34,6 +34,10 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist
 
+      - name: Install component Phinx deps
+        run: composer install --no-interaction --no-dev --prefer-dist
+        working-directory: core/components/sendex
+
       - name: PHPUnit
         run: composer test
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@
 
 # Composer / PHPUnit
 /vendor/
+core/components/sendex/vendor/
 .phpunit.result.cache
 /coverage/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,33 @@ Sendex runs email newsletters in MODX Revolution: subscribers, a send queue, and
 
 Install the transport package through Package Management, or build one from `_build/`.
 
+### Database migrations (Phinx)
+
+Schema changes ship as Phinx migrations (same pattern as MiniShop3):
+
+- Config: `core/components/sendex/phinx.php`
+- Migrations: `core/components/sendex/migrations/`
+- Metadata table: `{table_prefix}sendex_migrations`
+
+Before building the transport package, install runtime deps into the component:
+
+```
+cd core/components/sendex
+composer install --no-dev
+cd ../../..
+php _build/build.transport.php
+```
+
+On install/upgrade the `migrations` resolver runs `phinx migrate`. CLI on a live site:
+
+```
+cd core/components/sendex
+composer install --no-dev
+vendor/bin/phinx migrate -c phinx.php
+```
+
+Root `composer.json` remains for PHPUnit/phpcs only.
+
 ## Front-end
 
 ```
@@ -51,7 +78,7 @@ composer test
 composer test:coverage   # needs phpdbg
 ```
 
-Unit tests use lightweight MODX/xPDO stubs (no MODX install). Covered: `sxNewsletter` (100%), subscriber create/remove processors. CI runs `php -l` and PHPUnit on PHP 7.4–8.4.
+Unit tests use lightweight MODX/xPDO stubs (no MODX install). Covered: `sxNewsletter` (100%), subscriber create/remove processors. CI runs `php -l`, PHPUnit, and phpcs on PHP 7.4–8.4.
 
 ## Plugin events
 

--- a/_build/build.config.php
+++ b/_build/build.config.php
@@ -50,6 +50,6 @@ define('BUILD_PLUGIN_STATIC', false);
 define('BUILD_TEMPLATE_STATIC', false);
 
 $BUILD_RESOLVERS = array(
-    'tables',
+    'migrations',
     //'setup',
 );

--- a/_build/resolvers/resolve.migrations.php
+++ b/_build/resolvers/resolve.migrations.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * Run Phinx migrations on package install/upgrade (shared hosting safe, no CLI).
+ */
+
+use Phinx\Config\Config;
+use Phinx\Migration\Manager;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * Reconnect if MySQL wait_timeout killed the PDO handle.
+ *
+ * @param modX $modx
+ */
+function sendexReconnectMigrations($modx)
+{
+    if ($modx->pdo === null) {
+        $modx->connect();
+
+        return;
+    }
+
+    try {
+        $result = @$modx->pdo->query('SELECT 1');
+        if ($result !== false) {
+            return;
+        }
+    } catch (PDOException $e) {
+        // Connection lost
+    }
+
+    $modx->log(modX::LOG_LEVEL_WARN, '[Sendex] DB connection lost, reconnecting...');
+    $modx->pdo = null;
+    if ($modx->connection) {
+        $modx->connection->pdo = null;
+    }
+    $modx->connect();
+}
+
+/** @var xPDOTransport $object */
+/** @var array $options */
+/** @var modX $modx */
+
+if ($object->xpdo) {
+    $modx = $object->xpdo;
+
+    switch ($options[xPDOTransport::PACKAGE_ACTION]) {
+        case xPDOTransport::ACTION_INSTALL:
+        case xPDOTransport::ACTION_UPGRADE:
+            @ini_set('max_execution_time', '300');
+            @ini_set('memory_limit', '256M');
+
+            $componentPath = MODX_CORE_PATH . 'components/sendex/';
+            $vendorAutoload = $componentPath . 'vendor/autoload.php';
+            $phinxConfig = $componentPath . 'phinx.php';
+
+            if (!file_exists($vendorAutoload)) {
+                $modx->log(
+                    modX::LOG_LEVEL_ERROR,
+                    '[Sendex] Phinx vendor/autoload.php not found at: ' . $vendorAutoload
+                );
+                $modx->log(
+                    modX::LOG_LEVEL_ERROR,
+                    '[Sendex] Run "composer install --no-dev" in: ' . $componentPath . ' before building the package.'
+                );
+                break;
+            }
+
+            if (!file_exists($phinxConfig)) {
+                $modx->log(modX::LOG_LEVEL_ERROR, '[Sendex] Phinx config not found at: ' . $phinxConfig);
+                break;
+            }
+
+            sendexReconnectMigrations($modx);
+
+            try {
+                if (!class_exists('Phinx\\Config\\Config')) {
+                    require_once $vendorAutoload;
+                }
+
+                $configArray = require $phinxConfig;
+                if (!isset($configArray['paths']['migrations'])) {
+                    $modx->log(modX::LOG_LEVEL_ERROR, '[Sendex] Invalid Phinx config: missing migrations path');
+                    break;
+                }
+
+                $config = new Config($configArray);
+                $input = new StringInput('');
+                $output = new BufferedOutput();
+                $manager = new Manager($config, $input, $output);
+
+                $modx->log(modX::LOG_LEVEL_INFO, '[Sendex] Starting database migrations...');
+
+                try {
+                    $manager->migrate('production');
+                } catch (Exception $migrateEx) {
+                    $modx->log(
+                        modX::LOG_LEVEL_ERROR,
+                        '[Sendex] Migration execution failed: ' . $migrateEx->getMessage()
+                    );
+                    throw $migrateEx;
+                }
+
+                $outputText = $output->fetch();
+                if (!empty($outputText)) {
+                    foreach (explode("\n", $outputText) as $line) {
+                        if (trim($line) !== '') {
+                            $modx->log(modX::LOG_LEVEL_INFO, '  ' . $line);
+                        }
+                    }
+                }
+
+                $modx->log(modX::LOG_LEVEL_INFO, '[Sendex] Database migrations completed');
+            } catch (Exception $e) {
+                $modx->log(modX::LOG_LEVEL_ERROR, '[Sendex] Migration error: ' . $e->getMessage());
+                $modx->log(modX::LOG_LEVEL_ERROR, '[Sendex] Stack trace: ' . $e->getTraceAsString());
+            }
+
+            sendexReconnectMigrations($modx);
+            break;
+
+        case xPDOTransport::ACTION_UNINSTALL:
+            $modx->log(modX::LOG_LEVEL_INFO, '[Sendex] Database tables are preserved during uninstall');
+            break;
+    }
+}
+
+return true;

--- a/_build/resolvers/resolve.tables.php
+++ b/_build/resolvers/resolve.tables.php
@@ -1,61 +1,26 @@
 <?php
 
+/**
+ * Legacy tables resolver — schema is applied by Phinx (resolve.migrations).
+ * Kept as a no-op so older build docs that mention "tables" stay harmless.
+ */
+
 if ($object->xpdo) {
     /* @var modX $modx */
     $modx =& $object->xpdo;
 
     switch ($options[xPDOTransport::PACKAGE_ACTION]) {
         case xPDOTransport::ACTION_INSTALL:
-            $modelPath = $modx->getOption(
-                'sendex_core_path',
-                null,
-                $modx->getOption('core_path') . 'components/sendex/'
-            ) . 'model/';
-            $modx->addPackage('sendex', $modelPath);
-
-            $manager = $modx->getManager();
-            $objects = array(
-                'sxNewsletter',
-                'sxSubscriber',
-                'sxQueue',
-            );
-            foreach ($objects as $tmp) {
-                $manager->createObjectContainer($tmp);
-            }
-
-            /*
-            $level = $modx->getLogLevel();
-            $modx->setLogLevel(xPDO::LOG_LEVEL_FATAL);
-
-            $manager->addField('sxQueue', 'hash');
-            $manager->addIndex('sxQueue', 'hash');
-
-            $manager->addField('sxSubscriber', 'code');
-            $manager->addIndex('sxSubscriber', 'code');
-
-            $modx->setLogLevel($level);
-            */
-            break;
-
         case xPDOTransport::ACTION_UPGRADE:
-            $modelPath = $modx->getOption(
-                'sendex_core_path',
-                null,
-                $modx->getOption('core_path') . 'components/sendex/'
-            ) . 'model/';
-            $modx->addPackage('sendex', $modelPath);
-            $manager = $modx->getManager();
-            $level = $modx->getLogLevel();
-            $modx->setLogLevel(xPDO::LOG_LEVEL_FATAL);
-            // Unique (newsletter_id, email): one address per newsletter (#54).
-            // Fails if duplicate emails already exist — clean manually, then re-run upgrade.
-            $manager->removeIndex('sxSubscriber', 'key');
-            $manager->addIndex('sxSubscriber', 'key');
-            $modx->setLogLevel($level);
+            $modx->log(
+                modX::LOG_LEVEL_INFO,
+                '[Sendex] Schema managed by Phinx (see resolve.migrations / core/components/sendex/migrations).'
+            );
             break;
 
         case xPDOTransport::ACTION_UNINSTALL:
             break;
     }
 }
+
 return true;

--- a/core/components/sendex/composer.json
+++ b/core/components/sendex/composer.json
@@ -8,6 +8,9 @@
         "robmorgan/phinx": "^0.14"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "platform": {
+            "php": "7.4.33"
+        }
     }
 }

--- a/core/components/sendex/composer.json
+++ b/core/components/sendex/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "modx-pro/sendex-component",
+    "description": "Sendex component runtime (Phinx migrations)",
+    "type": "library",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "php": ">=7.4 <8.5",
+        "robmorgan/phinx": "^0.14"
+    },
+    "config": {
+        "sort-packages": true
+    }
+}

--- a/core/components/sendex/composer.lock
+++ b/core/components/sendex/composer.lock
@@ -1,0 +1,1325 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "18da6292ec3b5c1f6a8e52eaf5ca898e",
+    "packages": [
+        {
+            "name": "cakephp/core",
+            "version": "4.6.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/core.git",
+                "reference": "c2f4dff110d41e475d1041f2abe236f1c62d0cd0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/core/zipball/c2f4dff110d41e475d1041f2abe236f1c62d0cd0",
+                "reference": "c2f4dff110d41e475d1041f2abe236f1c62d0cd0",
+                "shasum": ""
+            },
+            "require": {
+                "cakephp/utility": "^4.0",
+                "php": ">=7.4.0"
+            },
+            "provide": {
+                "psr/container-implementation": "^1.0 || ^2.0"
+            },
+            "suggest": {
+                "cakephp/cache": "To use Configure::store() and restore().",
+                "cakephp/event": "To use PluginApplicationInterface or plugin applications.",
+                "league/container": "To use Container and ServiceProvider classes"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "functions.php"
+                ],
+                "psr-4": {
+                    "Cake\\Core\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "CakePHP Community",
+                    "homepage": "https://github.com/cakephp/core/graphs/contributors"
+                }
+            ],
+            "description": "CakePHP Framework Core classes",
+            "homepage": "https://cakephp.org",
+            "keywords": [
+                "cakephp",
+                "core",
+                "framework"
+            ],
+            "support": {
+                "forum": "https://stackoverflow.com/tags/cakephp",
+                "irc": "irc://irc.freenode.org/cakephp",
+                "issues": "https://github.com/cakephp/cakephp/issues",
+                "source": "https://github.com/cakephp/core"
+            },
+            "time": "2023-10-21T13:30:46+00:00"
+        },
+        {
+            "name": "cakephp/database",
+            "version": "4.6.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/database.git",
+                "reference": "bf6ee82ce031033eb6b0d5f2ef97c5990ed85cc4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/database/zipball/bf6ee82ce031033eb6b0d5f2ef97c5990ed85cc4",
+                "reference": "bf6ee82ce031033eb6b0d5f2ef97c5990ed85cc4",
+                "shasum": ""
+            },
+            "require": {
+                "cakephp/core": "^4.0",
+                "cakephp/datasource": "^4.0",
+                "php": ">=7.4.0"
+            },
+            "suggest": {
+                "cakephp/i18n": "If you are using locale-aware datetime formats or Chronos types.",
+                "cakephp/log": "If you want to use query logging without providing a logger yourself."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cake\\Database\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "CakePHP Community",
+                    "homepage": "https://github.com/cakephp/database/graphs/contributors"
+                }
+            ],
+            "description": "Flexible and powerful Database abstraction library with a familiar PDO-like API",
+            "homepage": "https://cakephp.org",
+            "keywords": [
+                "abstraction",
+                "cakephp",
+                "database",
+                "database abstraction",
+                "pdo"
+            ],
+            "support": {
+                "forum": "https://stackoverflow.com/tags/cakephp",
+                "irc": "irc://irc.freenode.org/cakephp",
+                "issues": "https://github.com/cakephp/cakephp/issues",
+                "source": "https://github.com/cakephp/database"
+            },
+            "time": "2026-07-03T20:53:51+00:00"
+        },
+        {
+            "name": "cakephp/datasource",
+            "version": "4.6.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/datasource.git",
+                "reference": "72a36edbf99a5364211ca0e081f878ba68eb2c99"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/datasource/zipball/72a36edbf99a5364211ca0e081f878ba68eb2c99",
+                "reference": "72a36edbf99a5364211ca0e081f878ba68eb2c99",
+                "shasum": ""
+            },
+            "require": {
+                "cakephp/core": "^4.0",
+                "php": ">=7.4.0",
+                "psr/log": "^1.0 || ^2.0",
+                "psr/simple-cache": "^1.0 || ^2.0"
+            },
+            "suggest": {
+                "cakephp/cache": "If you decide to use Query caching.",
+                "cakephp/collection": "If you decide to use ResultSetInterface.",
+                "cakephp/utility": "If you decide to use EntityTrait."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cake\\Datasource\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "CakePHP Community",
+                    "homepage": "https://github.com/cakephp/datasource/graphs/contributors"
+                }
+            ],
+            "description": "Provides connection managing and traits for Entities and Queries that can be reused for different datastores",
+            "homepage": "https://cakephp.org",
+            "keywords": [
+                "cakephp",
+                "connection management",
+                "datasource",
+                "entity",
+                "query"
+            ],
+            "support": {
+                "forum": "https://stackoverflow.com/tags/cakephp",
+                "irc": "irc://irc.freenode.org/cakephp",
+                "issues": "https://github.com/cakephp/cakephp/issues",
+                "source": "https://github.com/cakephp/datasource"
+            },
+            "time": "2024-11-19T19:41:00+00:00"
+        },
+        {
+            "name": "cakephp/utility",
+            "version": "4.6.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/utility.git",
+                "reference": "708929115e5b400e1b5b76d8120ca2e51e2de199"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/utility/zipball/708929115e5b400e1b5b76d8120ca2e51e2de199",
+                "reference": "708929115e5b400e1b5b76d8120ca2e51e2de199",
+                "shasum": ""
+            },
+            "require": {
+                "cakephp/core": "^4.0",
+                "php": ">=7.4.0"
+            },
+            "suggest": {
+                "ext-intl": "To use Text::transliterate() or Text::slug()",
+                "lib-ICU": "To use Text::transliterate() or Text::slug()"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Cake\\Utility\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "CakePHP Community",
+                    "homepage": "https://github.com/cakephp/utility/graphs/contributors"
+                }
+            ],
+            "description": "CakePHP Utility classes such as Inflector, String, Hash, and Security",
+            "homepage": "https://cakephp.org",
+            "keywords": [
+                "cakephp",
+                "hash",
+                "inflector",
+                "security",
+                "string",
+                "utility"
+            ],
+            "support": {
+                "forum": "https://stackoverflow.com/tags/cakephp",
+                "irc": "irc://irc.freenode.org/cakephp",
+                "issues": "https://github.com/cakephp/cakephp/issues",
+                "source": "https://github.com/cakephp/utility"
+            },
+            "time": "2024-06-23T00:11:14+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
+            },
+            "time": "2021-11-05T16:47:00+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/ef29f6d262798707a9edd554e2b82517ef3a9376",
+                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/2.0.0"
+            },
+            "time": "2021-07-14T16:41:46+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "8707bf3cea6f710bf6ef05491234e3ab06f6432a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/8707bf3cea6f710bf6ef05491234e3ab06f6432a",
+                "reference": "8707bf3cea6f710bf6ef05491234e3ab06f6432a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/2.0.0"
+            },
+            "time": "2021-10-29T13:22:09+00:00"
+        },
+        {
+            "name": "robmorgan/phinx",
+            "version": "0.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/phinx.git",
+                "reference": "7bc24bae664b2124f3d5b8d1e98fdb8abaf70e87"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/phinx/zipball/7bc24bae664b2124f3d5b8d1e98fdb8abaf70e87",
+                "reference": "7bc24bae664b2124f3d5b8d1e98fdb8abaf70e87",
+                "shasum": ""
+            },
+            "require": {
+                "cakephp/database": "^4.0",
+                "php-64bit": ">=7.3",
+                "psr/container": "^1.0 || ^2.0",
+                "symfony/config": "^3.4|^4.0|^5.0|^6.0",
+                "symfony/console": "^3.4|^4.0|^5.0|^6.0"
+            },
+            "require-dev": {
+                "cakephp/cakephp-codesniffer": "^4.0",
+                "ext-json": "*",
+                "ext-pdo": "*",
+                "phpunit/phpunit": "^9.5",
+                "sebastian/comparator": ">=1.2.3",
+                "symfony/yaml": "^3.4|^4.0|^5.0"
+            },
+            "suggest": {
+                "ext-json": "Install if using JSON configuration format",
+                "ext-pdo": "PDO extension is needed",
+                "symfony/yaml": "Install if using YAML configuration format"
+            },
+            "bin": [
+                "bin/phinx"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Phinx\\": "src/Phinx/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rob Morgan",
+                    "email": "robbym@gmail.com",
+                    "homepage": "https://robmorgan.id.au",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "email": "woody.gilk@gmail.com",
+                    "homepage": "https://shadowhand.me",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Richard Quadling",
+                    "email": "rquadling@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "CakePHP Community",
+                    "homepage": "https://github.com/cakephp/phinx/graphs/contributors",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Phinx makes it ridiculously easy to manage the database migrations for your PHP app.",
+            "homepage": "https://phinx.org",
+            "keywords": [
+                "database",
+                "database migrations",
+                "db",
+                "migrations",
+                "phinx"
+            ],
+            "support": {
+                "issues": "https://github.com/cakephp/phinx/issues",
+                "source": "https://github.com/cakephp/phinx/tree/0.14.0"
+            },
+            "time": "2023-09-07T14:26:14+00:00"
+        },
+        {
+            "name": "symfony/config",
+            "version": "v6.4.42",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/config.git",
+                "reference": "922d980c90a69ffdd63e6ee551efb338b58be677"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/config/zipball/922d980c90a69ffdd63e6ee551efb338b58be677",
+                "reference": "922d980c90a69ffdd63e6ee551efb338b58be677",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/filesystem": "^5.4|^6.0|^7.0",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/finder": "<5.4",
+                "symfony/service-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/finder": "^5.4|^6.0|^7.0",
+                "symfony/messenger": "^5.4|^6.0|^7.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/yaml": "^5.4|^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Config\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/config/tree/v6.4.42"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-09T07:36:15+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v6.4.42",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "9ef84af84a7b66396da483634227650506428639"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/9ef84af84a7b66396da483634227650506428639",
+                "reference": "9ef84af84a7b66396da483634227650506428639",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/string": "^5.4|^6.0|^7.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<5.4",
+                "symfony/dotenv": "<5.4",
+                "symfony/event-dispatcher": "<5.4",
+                "symfony/lock": "<5.4",
+                "symfony/process": "<5.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/lock": "^5.4|^6.0|^7.0",
+                "symfony/messenger": "^5.4|^6.0|^7.0",
+                "symfony/process": "^5.4|^6.0|^7.0",
+                "symfony/stopwatch": "^5.4|^6.0|^7.0",
+                "symfony/var-dumper": "^5.4|^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command-line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v6.4.42"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-15T05:35:29+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-05T06:23:12+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v7.4.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.11"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-11T16:38:44+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-26T05:58:03+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.38.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-25T13:48:31+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.38.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-27T06:59:30+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-16T09:55:08+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v7.4.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.33",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/translation-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/emoji": "^7.1|^8.0",
+                "symfony/http-client": "^6.4|^7.0|^8.0",
+                "symfony/intl": "^6.4|^7.0|^8.0",
+                "symfony/translation-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v7.4.13"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-23T15:23:29+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=7.4 <8.5"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
+}

--- a/core/components/sendex/composer.lock
+++ b/core/components/sendex/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "18da6292ec3b5c1f6a8e52eaf5ca898e",
+    "content-hash": "7be93c230837d704db3cad8af677bf1d",
     "packages": [
         {
             "name": "cakephp/core",
@@ -294,30 +294,30 @@
         },
         {
             "name": "psr/log",
-            "version": "2.0.0",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376"
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/ef29f6d262798707a9edd554e2b82517ef3a9376",
-                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.0"
+                "php": ">=5.3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "src"
+                    "Psr\\Log\\": "Psr/Log/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -338,31 +338,31 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/2.0.0"
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
             },
-            "time": "2021-07-14T16:41:46+00:00"
+            "time": "2021-05-03T11:20:27+00:00"
         },
         {
             "name": "psr/simple-cache",
-            "version": "2.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/simple-cache.git",
-                "reference": "8707bf3cea6f710bf6ef05491234e3ab06f6432a"
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/8707bf3cea6f710bf6ef05491234e3ab06f6432a",
-                "reference": "8707bf3cea6f710bf6ef05491234e3ab06f6432a",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.0"
+                "php": ">=5.3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
@@ -377,7 +377,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
+                    "homepage": "http://www.php-fig.org/"
                 }
             ],
             "description": "Common interfaces for simple caching",
@@ -389,9 +389,9 @@
                 "simple-cache"
             ],
             "support": {
-                "source": "https://github.com/php-fig/simple-cache/tree/2.0.0"
+                "source": "https://github.com/php-fig/simple-cache/tree/master"
             },
-            "time": "2021-10-29T13:22:09+00:00"
+            "time": "2017-10-23T01:57:42+00:00"
         },
         {
             "name": "robmorgan/phinx",
@@ -481,34 +481,38 @@
         },
         {
             "name": "symfony/config",
-            "version": "v6.4.42",
+            "version": "v5.4.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "922d980c90a69ffdd63e6ee551efb338b58be677"
+                "reference": "977c88a02d7d3f16904a81907531b19666a08e78"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/922d980c90a69ffdd63e6ee551efb338b58be677",
-                "reference": "922d980c90a69ffdd63e6ee551efb338b58be677",
+                "url": "https://api.github.com/repos/symfony/config/zipball/977c88a02d7d3f16904a81907531b19666a08e78",
+                "reference": "977c88a02d7d3f16904a81907531b19666a08e78",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/filesystem": "^5.4|^6.0|^7.0",
-                "symfony/polyfill-ctype": "~1.8"
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/filesystem": "^4.4|^5.0|^6.0",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/polyfill-php81": "^1.22"
             },
             "conflict": {
-                "symfony/finder": "<5.4",
-                "symfony/service-contracts": "<2.5"
+                "symfony/finder": "<4.4"
             },
             "require-dev": {
-                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
-                "symfony/finder": "^5.4|^6.0|^7.0",
-                "symfony/messenger": "^5.4|^6.0|^7.0",
-                "symfony/service-contracts": "^2.5|^3",
-                "symfony/yaml": "^5.4|^6.0|^7.0"
+                "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
+                "symfony/finder": "^4.4|^5.0|^6.0",
+                "symfony/messenger": "^4.4|^5.0|^6.0",
+                "symfony/service-contracts": "^1.1|^2|^3",
+                "symfony/yaml": "^4.4|^5.0|^6.0"
+            },
+            "suggest": {
+                "symfony/yaml": "To use the yaml reference dumper"
             },
             "type": "library",
             "autoload": {
@@ -536,7 +540,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v6.4.42"
+                "source": "https://github.com/symfony/config/tree/v5.4.46"
             },
             "funding": [
                 {
@@ -548,59 +552,60 @@
                     "type": "github"
                 },
                 {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-09T07:36:15+00:00"
+            "time": "2024-10-30T07:58:02+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.42",
+            "version": "v5.4.47",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "9ef84af84a7b66396da483634227650506428639"
+                "reference": "c4ba980ca61a9eb18ee6bcc73f28e475852bb1ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/9ef84af84a7b66396da483634227650506428639",
-                "reference": "9ef84af84a7b66396da483634227650506428639",
+                "url": "https://api.github.com/repos/symfony/console/zipball/c4ba980ca61a9eb18ee6bcc73f28e475852bb1ed",
+                "reference": "c4ba980ca61a9eb18ee6bcc73f28e475852bb1ed",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "symfony/deprecation-contracts": "^2.5|^3",
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^5.4|^6.0|^7.0"
+                "symfony/polyfill-php73": "^1.9",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/service-contracts": "^1.1|^2|^3",
+                "symfony/string": "^5.1|^6.0"
             },
             "conflict": {
-                "symfony/dependency-injection": "<5.4",
-                "symfony/dotenv": "<5.4",
-                "symfony/event-dispatcher": "<5.4",
-                "symfony/lock": "<5.4",
-                "symfony/process": "<5.4"
+                "psr/log": ">=3",
+                "symfony/dependency-injection": "<4.4",
+                "symfony/dotenv": "<5.1",
+                "symfony/event-dispatcher": "<4.4",
+                "symfony/lock": "<4.4",
+                "symfony/process": "<4.4"
             },
             "provide": {
-                "psr/log-implementation": "1.0|2.0|3.0"
+                "psr/log-implementation": "1.0|2.0"
             },
             "require-dev": {
-                "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0|^7.0",
-                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
-                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
-                "symfony/http-foundation": "^6.4|^7.0",
-                "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/lock": "^5.4|^6.0|^7.0",
-                "symfony/messenger": "^5.4|^6.0|^7.0",
-                "symfony/process": "^5.4|^6.0|^7.0",
-                "symfony/stopwatch": "^5.4|^6.0|^7.0",
-                "symfony/var-dumper": "^5.4|^6.0|^7.0"
+                "psr/log": "^1|^2",
+                "symfony/config": "^4.4|^5.0|^6.0",
+                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
+                "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
+                "symfony/lock": "^4.4|^5.0|^6.0",
+                "symfony/process": "^4.4|^5.0|^6.0",
+                "symfony/var-dumper": "^4.4|^5.0|^6.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
             },
             "type": "library",
             "autoload": {
@@ -634,7 +639,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.42"
+                "source": "https://github.com/symfony/console/tree/v5.4.47"
             },
             "funding": [
                 {
@@ -646,32 +651,28 @@
                     "type": "github"
                 },
                 {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-15T05:35:29+00:00"
+            "time": "2024-11-06T11:30:55+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.7.1",
+            "version": "v2.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
+                "reference": "605389f2a7e5625f273b53960dc46aeaf9c62918"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
-                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/605389f2a7e5625f273b53960dc46aeaf9c62918",
+                "reference": "605389f2a7e5625f273b53960dc46aeaf9c62918",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
@@ -680,7 +681,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.7-dev"
+                    "dev-main": "2.5-dev"
                 }
             },
             "autoload": {
@@ -705,7 +706,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.4"
             },
             "funding": [
                 {
@@ -717,37 +718,34 @@
                     "type": "github"
                 },
                 {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-05T06:23:12+00:00"
+            "time": "2024-09-25T14:11:13+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.4.11",
+            "version": "v5.4.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50"
+                "reference": "57c8294ed37d4a055b77057827c67f9558c95c54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
-                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/57c8294ed37d4a055b77057827c67f9558c95c54",
+                "reference": "57c8294ed37d4a055b77057827c67f9558c95c54",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=7.2.5",
                 "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.8"
+                "symfony/polyfill-mbstring": "~1.8",
+                "symfony/polyfill-php80": "^1.16"
             },
             "require-dev": {
-                "symfony/process": "^6.4|^7.0|^8.0"
+                "symfony/process": "^5.4|^6.4"
             },
             "type": "library",
             "autoload": {
@@ -775,7 +773,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.4.11"
+                "source": "https://github.com/symfony/filesystem/tree/v5.4.45"
             },
             "funding": [
                 {
@@ -787,15 +785,11 @@
                     "type": "github"
                 },
                 {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-11T16:38:44+00:00"
+            "time": "2024-10-22T13:05:35+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1133,44 +1127,280 @@
             "time": "2026-05-27T06:59:30+00:00"
         },
         {
-            "name": "symfony/service-contracts",
-            "version": "v3.7.1",
+            "name": "symfony/polyfill-php73",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0"
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/c0a284bab1ed8aa0417e3d69250ab437739563a0",
-                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "psr/container": "^1.1|^2.0",
-                "symfony/deprecation-contracts": "^2.5|^3"
-            },
-            "conflict": {
-                "ext-psr": "<1.1|>=2"
+                "php": ">=7.2"
             },
             "type": "library",
             "extra": {
                 "thanks": {
-                    "url": "https://github.com/symfony/contracts",
-                    "name": "symfony/contracts"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
                 },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php81",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php81.git",
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-26T12:45:58+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "191afdcb5804db960d26d8566b7e9a2843cab3a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/191afdcb5804db960d26d8566b7e9a2843cab3a0",
+                "reference": "191afdcb5804db960d26d8566b7e9a2843cab3a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "suggest": {
+                "psr/container": "",
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
                 "branch-alias": {
-                    "dev-main": "3.7-dev"
+                    "dev-master": "1.1-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Contracts\\Service\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Test/"
-                ]
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1197,59 +1427,40 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.7.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v1.1.2"
             },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-06-16T09:55:08+00:00"
+            "time": "2019-05-28T07:50:59+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v7.4.13",
+            "version": "v5.4.47",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde"
+                "reference": "136ca7d72f72b599f2631aca474a4f8e26719799"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
-                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
+                "url": "https://api.github.com/repos/symfony/string/zipball/136ca7d72f72b599f2631aca474a4f8e26719799",
+                "reference": "136ca7d72f72b599f2631aca474a4f8e26719799",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "php": ">=7.2.5",
                 "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-intl-grapheme": "~1.33",
+                "symfony/polyfill-intl-grapheme": "~1.0",
                 "symfony/polyfill-intl-normalizer": "~1.0",
-                "symfony/polyfill-mbstring": "~1.0"
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php80": "~1.15"
             },
             "conflict": {
-                "symfony/translation-contracts": "<2.5"
+                "symfony/translation-contracts": ">=3.0"
             },
             "require-dev": {
-                "symfony/emoji": "^7.1|^8.0",
-                "symfony/http-client": "^6.4|^7.0|^8.0",
-                "symfony/intl": "^6.4|^7.0|^8.0",
-                "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^6.4|^7.0|^8.0"
+                "symfony/error-handler": "^4.4|^5.0|^6.0",
+                "symfony/http-client": "^4.4|^5.0|^6.0",
+                "symfony/translation-contracts": "^1.1|^2",
+                "symfony/var-exporter": "^4.4|^5.0|^6.0"
             },
             "type": "library",
             "autoload": {
@@ -1288,7 +1499,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.4.13"
+                "source": "https://github.com/symfony/string/tree/v5.4.47"
             },
             "funding": [
                 {
@@ -1300,15 +1511,11 @@
                     "type": "github"
                 },
                 {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-23T15:23:29+00:00"
+            "time": "2024-11-10T20:33:58+00:00"
         }
     ],
     "packages-dev": [],
@@ -1321,5 +1528,8 @@
         "php": ">=7.4 <8.5"
     },
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "7.4.33"
+    },
     "plugin-api-version": "2.9.0"
 }

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#46] Search subscribers and queue by email or username.
 - [#44] Plugin events for subscribe/unsubscribe (`sxOnBeforeSubscribe`, `sxOnSubscribe`, `sxOnBeforeUnsubscribe`, `sxOnUnsubscribe`).
 - PHPUnit coverage for subscribe/unsubscribe events (stubs, no MODX install).
+- Phinx migrations (MiniShop3-style): `core/components/sendex/phinx.php`, `migrations/`, install/upgrade resolver; metadata table `{prefix}sendex_migrations`.
 
 ### Fixed
 - [#54] `isSubscribed` matches by `user_id` OR `email` within a newsletter; unique key is `(newsletter_id, email)`; guest rows attach `user_id` when the same email confirms as a user (also covers main #39 cases; activate-merge handler still open).
@@ -32,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `subscribe()` method name normalized to camelCase (PHP method names are case-insensitive; `Subscribe()` calls still work).
 - Declared PHP 7.4–8.4 support; CI lint matrix.
 - Track `composer.lock` in git (removed from `.gitignore`) for reproducible CI installs.
+- Package schema install/upgrade runs via Phinx instead of ad-hoc `resolve.tables` Manager calls.
 
 ## [1.1.4-pl] - 2022-12-23
 

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -15,9 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#46] Search subscribers and queue by email or username.
 - [#44] Plugin events for subscribe/unsubscribe (`sxOnBeforeSubscribe`, `sxOnSubscribe`, `sxOnBeforeUnsubscribe`, `sxOnUnsubscribe`).
 - PHPUnit coverage for subscribe/unsubscribe events (stubs, no MODX install).
-- Phinx migrations (MiniShop3-style): `core/components/sendex/phinx.php`, `migrations/`, install/upgrade resolver; metadata table `{prefix}sendex_migrations`.
+- Phinx migrations: `core/components/sendex/phinx.php`, `migrations/`, install/upgrade resolver; metadata table `{prefix}sendex_migrations`.
 
 ### Fixed
+- [#67] / [#52] Schema and upgrade: Sendex tables use InnoDB; queue index renamed `user_id` → `subscriber_id`; `addQueues` stores `sxSubscriber.id` (not `user_id`); Phinx backfill remaps legacy queue rows (by user_id, guests by email).
 - [#54] `isSubscribed` matches by `user_id` OR `email` within a newsletter; unique key is `(newsletter_id, email)`; guest rows attach `user_id` when the same email confirms as a user (also covers main #39 cases; activate-merge handler still open).
 - [#58] `confirmEmail` restores registry hash when `subscribe()` fails so the confirm link stays usable; remaining TTL kept via `_expires`; `checkEmail` shares `sxSubscribeRegistry::store`.
 - [#61] `sxSubscriber::save` keeps existing `code` (generate only when empty) so unsubscribe links stay valid.
@@ -28,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHP 7.4–8.4: dynamic properties, null Profile in `addQueues`, PHPMailer `ErrorInfo`.
 
 ### Changed
+- **Breaking (DB):** existing `sendex_*` tables are converted to InnoDB on upgrade; queue `subscriber_id` meaning is `sxSubscriber.id` after backfill (join Queue→Subscriber for guests works). Soft FK to core `modUser` tables are not added.
 - `add_group` processor requires `edit_document` permission.
 - Newsletter create processor class renamed to `sxNewsletterCreateProcessor`.
 - `subscribe()` method name normalized to camelCase (PHP method names are case-insensitive; `Subscribe()` calls still work).

--- a/core/components/sendex/docs/readme.txt
+++ b/core/components/sendex/docs/readme.txt
@@ -9,6 +9,10 @@ queue, and a front-end form.
 
 Requires PHP 7.4–8.4 and MODX Revolution 2.x.
 
+Build note: before php _build/build.transport.php, run
+  cd core/components/sendex && composer install --no-dev
+so Phinx is packaged under vendor/ for install-time migrations.
+
 Features:
 - Newsletters and subscribers in the manager
 - Add users one by one or from a MODX user group (active and unblocked

--- a/core/components/sendex/migrations/20260724120000_initial_schema.php
+++ b/core/components/sendex/migrations/20260724120000_initial_schema.php
@@ -1,0 +1,69 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Create Sendex tables via xPDO Manager from model metadata.
+ */
+class InitialSchema extends AbstractMigration
+{
+    /** @var string[] */
+    protected $modelClasses = array(
+        'sxNewsletter',
+        'sxSubscriber',
+        'sxQueue',
+    );
+
+    public function up()
+    {
+        $modx = $this->bootModx();
+        $modelPath = MODX_CORE_PATH . 'components/sendex/model/';
+        $modx->addPackage('sendex', $modelPath);
+        $manager = $modx->getManager();
+
+        foreach ($this->modelClasses as $className) {
+            $tableName = $modx->getTableName($className);
+            $bare = trim($tableName, '`');
+
+            $sql = "SHOW TABLES LIKE " . $this->adapter->getConnection()->quote($bare);
+            $stmt = $this->adapter->getConnection()->query($sql);
+            if ($stmt && $stmt->fetch()) {
+                continue;
+            }
+
+            $manager->createObjectContainer($className);
+        }
+    }
+
+    public function down()
+    {
+        // Keep data: do not drop tables on rollback.
+    }
+
+    /**
+     * @return modX
+     */
+    protected function bootModx()
+    {
+        $modxConfigPath = dirname(__FILE__, 5) . '/config.core.php';
+        if (!file_exists($modxConfigPath)) {
+            throw new RuntimeException('MODX config.core.php not found');
+        }
+
+        if (!defined('MODX_CORE_PATH')) {
+            require_once $modxConfigPath;
+        }
+        if (!defined('MODX_CORE_PATH')) {
+            throw new RuntimeException('MODX_CORE_PATH not defined');
+        }
+
+        if (!class_exists('modX')) {
+            require_once MODX_CORE_PATH . 'model/modx/modx.class.php';
+        }
+
+        $modx = new modX();
+        $modx->initialize('mgr');
+
+        return $modx;
+    }
+}

--- a/core/components/sendex/migrations/20260724120100_subscriber_unique_email.php
+++ b/core/components/sendex/migrations/20260724120100_subscriber_unique_email.php
@@ -1,0 +1,51 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Unique subscriber key: (newsletter_id, email) — one address per newsletter (#54).
+ */
+class SubscriberUniqueEmail extends AbstractMigration
+{
+    public function up()
+    {
+        $table = $this->table('sendex_subscribers');
+
+        if ($table->hasIndexByName('key')) {
+            $table->removeIndexByName('key')->update();
+        }
+
+        if (!$table->hasIndexByName('key')) {
+            $table
+                ->addIndex(
+                    array('newsletter_id', 'email'),
+                    array(
+                        'unique' => true,
+                        'name' => 'key',
+                    )
+                )
+                ->update();
+        }
+    }
+
+    public function down()
+    {
+        $table = $this->table('sendex_subscribers');
+
+        if ($table->hasIndexByName('key')) {
+            $table->removeIndexByName('key')->update();
+        }
+
+        if (!$table->hasIndexByName('key')) {
+            $table
+                ->addIndex(
+                    array('newsletter_id', 'user_id', 'email'),
+                    array(
+                        'unique' => true,
+                        'name' => 'key',
+                    )
+                )
+                ->update();
+        }
+    }
+}

--- a/core/components/sendex/migrations/20260724130000_innodb_queue_subscriber_link.php
+++ b/core/components/sendex/migrations/20260724130000_innodb_queue_subscriber_link.php
@@ -1,0 +1,138 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * InnoDB for Sendex tables; queue index rename; backfill subscriber_id → sxSubscriber.id (#67 / #52).
+ */
+class InnodbQueueSubscriberLink extends AbstractMigration
+{
+    /** @var string[] */
+    protected $tables = array(
+        'sendex_newsletters',
+        'sendex_subscribers',
+        'sendex_queue',
+    );
+
+    public function up()
+    {
+        foreach ($this->tables as $tableName) {
+            $this->convertToInnoDb($tableName);
+        }
+
+        $this->renameQueueSubscriberIndex();
+        $this->backfillQueueSubscriberIds();
+    }
+
+    public function down()
+    {
+        $table = $this->table('sendex_queue');
+
+        if ($table->hasIndexByName('subscriber_id')) {
+            $table->removeIndexByName('subscriber_id')->update();
+        }
+
+        if (!$table->hasIndexByName('user_id')) {
+            $table
+                ->addIndex(
+                    array('subscriber_id'),
+                    array(
+                        'name' => 'user_id',
+                    )
+                )
+                ->update();
+        }
+
+        // Engine and data remaps are not reverted.
+    }
+
+    /**
+     * @param string $tableName Bare name without MODX prefix
+     */
+    protected function convertToInnoDb($tableName)
+    {
+        if (!$this->hasTable($tableName)) {
+            return;
+        }
+
+        $this->execute('ALTER TABLE ' . $this->quotedTableName($tableName) . ' ENGINE=InnoDB');
+    }
+
+    /**
+     * @param string $tableName Bare name without MODX prefix
+     * @return string Quoted physical table name (with prefix)
+     */
+    protected function quotedTableName($tableName)
+    {
+        $adapter = $this->getAdapter();
+        if (method_exists($adapter, 'getAdapterTableName')) {
+            $tableName = $adapter->getAdapterTableName($tableName);
+        } elseif ($adapter->hasOption('table_prefix')) {
+            $tableName = (string) $adapter->getOption('table_prefix') . $tableName;
+        }
+
+        return $adapter->quoteTableName($tableName);
+    }
+
+    protected function renameQueueSubscriberIndex()
+    {
+        if (!$this->hasTable('sendex_queue')) {
+            return;
+        }
+
+        $table = $this->table('sendex_queue');
+
+        if ($table->hasIndexByName('user_id')) {
+            $table->removeIndexByName('user_id')->update();
+        }
+
+        if (!$table->hasIndexByName('subscriber_id')) {
+            $table
+                ->addIndex(
+                    array('subscriber_id'),
+                    array(
+                        'name' => 'subscriber_id',
+                    )
+                )
+                ->update();
+        }
+    }
+
+    /**
+     * Legacy rows stored modUser.id (or 0 for guests). Prefer correct sxSubscriber.id.
+     */
+    protected function backfillQueueSubscriberIds()
+    {
+        if (!$this->hasTable('sendex_queue') || !$this->hasTable('sendex_subscribers')) {
+            return;
+        }
+
+        $queue = $this->quotedTableName('sendex_queue');
+        $subscribers = $this->quotedTableName('sendex_subscribers');
+
+        // user_id → subscriber PK when stored value is not already a PK in this newsletter
+        $this->execute(
+            'UPDATE ' . $queue . ' AS q'
+            . ' INNER JOIN ' . $subscribers . ' AS s'
+            . '   ON s.newsletter_id = q.newsletter_id'
+            . '  AND s.user_id = q.subscriber_id'
+            . '  AND q.subscriber_id > 0'
+            . ' LEFT JOIN ' . $subscribers . ' AS already'
+            . '   ON already.id = q.subscriber_id'
+            . '  AND already.newsletter_id = q.newsletter_id'
+            . ' SET q.subscriber_id = s.id'
+            . ' WHERE already.id IS NULL'
+        );
+
+        // guests / zero: match by email within newsletter
+        $this->execute(
+            'UPDATE ' . $queue . ' AS q'
+            . ' INNER JOIN ' . $subscribers . ' AS s'
+            . '   ON s.newsletter_id = q.newsletter_id'
+            . '  AND s.email = q.email_to'
+            . '  AND q.email_to <> \'\''
+            . ' SET q.subscriber_id = s.id'
+            . ' WHERE q.subscriber_id = 0'
+        );
+    }
+}

--- a/core/components/sendex/model/schema/sendex.mysql.schema.xml
+++ b/core/components/sendex/model/schema/sendex.mysql.schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model package="sendex" baseClass="xPDOObject" platform="mysql" defaultEngine="MyISAM" phpdoc-package="sendex" version="1.1">
+<model package="sendex" baseClass="xPDOObject" platform="mysql" defaultEngine="InnoDB" phpdoc-package="sendex" version="1.1">
 
     <object class="sxNewsletter" table="sendex_newsletters" extends="xPDOSimpleObject">
         <field key="name" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
@@ -63,7 +63,7 @@
         <index alias="newsletter_id" name="newsletter_id" primary="false" unique="false" type="BTREE">
             <column key="newsletter_id" length="" collation="A" null="false" />
         </index>
-        <index alias="subscriber_id" name="user_id" primary="false" unique="false" type="BTREE">
+        <index alias="subscriber_id" name="subscriber_id" primary="false" unique="false" type="BTREE">
             <column key="subscriber_id" length="" collation="A" null="false" />
         </index>
         <index alias="timestamp" name="timestamp" primary="false" unique="false" type="BTREE">

--- a/core/components/sendex/model/sendex/mysql/sxqueue.map.inc.php
+++ b/core/components/sendex/model/sendex/mysql/sxqueue.map.inc.php
@@ -119,7 +119,7 @@ $xpdo_meta_map['sxQueue'] = array(
         ),
       ),
     ),
-    'user_id'       =>
+    'subscriber_id' =>
     array(
       'alias'   => 'subscriber_id',
       'primary' => false,

--- a/core/components/sendex/model/sendex/sxnewsletter.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletter.class.php
@@ -2,6 +2,7 @@
 
 require_once dirname(__FILE__) . '/sxsubscriberegistry.class.php';
 require_once dirname(__FILE__) . '/sxsubscribermatch.class.php';
+require_once dirname(__FILE__) . '/sxqueuelink.class.php';
 
 class sxNewsletter extends xPDOSimpleObject
 {
@@ -76,7 +77,7 @@ class sxNewsletter extends xPDOSimpleObject
             /** @var sxQueue $queue */
             $queue = $this->xpdo->newObject('sxQueue');
             $queue->fromArray(array(
-                'subscriber_id'   => $subscriber->user_id,
+                'subscriber_id'   => sxQueueLink::subscriberIdFromSubscriber($subscriber),
                 'newsletter_id'   => $this->id,
                 'email_to'        => $email,
                 'email_subject'   => $subject,

--- a/core/components/sendex/model/sendex/sxphinxconfig.class.php
+++ b/core/components/sendex/model/sendex/sxphinxconfig.class.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Phinx / MySQL charset helpers for Sendex (MODX 2, PHP 7.4+).
+ */
+class sxPhinxConfig
+{
+    /**
+     * @param string|null $dsn
+     * @return string|null
+     */
+    public static function extractDsnCharset($dsn)
+    {
+        if ($dsn === null || $dsn === '') {
+            return null;
+        }
+
+        if (preg_match('/(?:^|;)charset=([^;]+)/i', $dsn, $matches) !== 1) {
+            return null;
+        }
+
+        return trim($matches[1]);
+    }
+
+    /**
+     * @param string|null $charset
+     * @param bool $preferUtf8mb4
+     * @return string
+     */
+    public static function normalizeMysqlCharset($charset, $preferUtf8mb4 = false)
+    {
+        $normalized = strtolower(trim((string) $charset));
+        $normalized = str_replace('-', '', $normalized);
+
+        if ($normalized === '' || $normalized === 'utf8' || $normalized === 'utf8mb3') {
+            return $preferUtf8mb4 ? 'utf8mb4' : 'utf8';
+        }
+
+        if ($normalized === 'utf8mb4') {
+            return 'utf8mb4';
+        }
+
+        $safe = preg_replace('/[^a-z0-9_]/', '', $normalized);
+
+        return $safe !== null && $safe !== '' ? $safe : 'utf8mb4';
+    }
+
+    /**
+     * @param string $charset
+     * @return string
+     */
+    public static function defaultMysqlCollation($charset)
+    {
+        if ($charset === 'utf8') {
+            return 'utf8_general_ci';
+        }
+        if ($charset === 'utf8mb4') {
+            return 'utf8mb4_unicode_ci';
+        }
+
+        return $charset . '_general_ci';
+    }
+
+    /**
+     * @param string $tablePrefix
+     * @return string
+     */
+    public static function migrationTableName($tablePrefix)
+    {
+        return (string) $tablePrefix . 'sendex_migrations';
+    }
+
+    /**
+     * Build Phinx environments DB config from a MODX-like options getter.
+     *
+     * @param object $modx object with getOption($key, $options = null, $default = null)
+     * @return array
+     */
+    public static function buildDbConfig($modx)
+    {
+        $dsnCharset = self::extractDsnCharset($modx->getOption('database_dsn', null, null));
+        $databaseCharset = $modx->getOption('database_charset', null, null);
+
+        if ($dsnCharset !== null) {
+            $mysqlCharset = self::normalizeMysqlCharset($dsnCharset);
+        } elseif ($databaseCharset !== null && trim((string) $databaseCharset) !== '') {
+            $mysqlCharset = self::normalizeMysqlCharset($databaseCharset);
+        } else {
+            $mysqlCharset = self::normalizeMysqlCharset($modx->getOption('charset', null, 'utf8mb4'), true);
+        }
+
+        $mysqlCollation = $modx->getOption(
+            'database_collation',
+            null,
+            $modx->getOption(
+                'collation',
+                null,
+                self::defaultMysqlCollation($mysqlCharset)
+            )
+        );
+
+        return array(
+            'adapter' => 'mysql',
+            'host' => $modx->getOption('host', null, 'localhost'),
+            'name' => $modx->getOption('dbname'),
+            'user' => $modx->getOption('username'),
+            'pass' => $modx->getOption('password'),
+            'port' => $modx->getOption('port', null, '3306'),
+            'charset' => $mysqlCharset,
+            'collation' => $mysqlCollation,
+            'table_prefix' => $modx->getOption('table_prefix', null, ''),
+        );
+    }
+}

--- a/core/components/sendex/model/sendex/sxqueuelink.class.php
+++ b/core/components/sendex/model/sendex/sxqueuelink.class.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Queue row → sxSubscriber link: subscriber_id is always sxSubscriber.id (#52 / #67).
+ */
+class sxQueueLink
+{
+    /**
+     * Canonical value for new queue rows.
+     *
+     * @param object $subscriber xPDOObject / stub with get('id')
+     * @return int
+     */
+    public static function subscriberIdFromSubscriber($subscriber)
+    {
+        return (int) $subscriber->get('id');
+    }
+
+    /**
+     * Remap legacy queue.subscriber_id (often modUser.id) to sxSubscriber.id.
+     *
+     * Prefer an existing subscriber PK for the newsletter. Otherwise treat the
+     * stored value as user_id. For 0 / guests, fall back to email_to.
+     *
+     * @param int $stored
+     * @param int $newsletterId
+     * @param string $emailTo
+     * @param callable $findById function (int $id, int $newsletterId): ?object
+     * @param callable $findByUserId function (int $userId, int $newsletterId): ?object
+     * @param callable $findByEmail function (string $email, int $newsletterId): ?object
+     * @return int Resolved sxSubscriber.id, or unchanged $stored when unknown (>0), or 0
+     */
+    public static function remapStoredSubscriberId(
+        $stored,
+        $newsletterId,
+        $emailTo,
+        $findById,
+        $findByUserId,
+        $findByEmail
+    ) {
+        $stored = (int) $stored;
+        $newsletterId = (int) $newsletterId;
+
+        if ($stored > 0) {
+            $byId = call_user_func($findById, $stored, $newsletterId);
+            if ($byId !== null) {
+                return (int) $byId->get('id');
+            }
+
+            $byUser = call_user_func($findByUserId, $stored, $newsletterId);
+            if ($byUser !== null) {
+                return (int) $byUser->get('id');
+            }
+
+            return $stored;
+        }
+
+        $email = trim((string) $emailTo);
+        if ($email === '') {
+            return 0;
+        }
+
+        $byEmail = call_user_func($findByEmail, $email, $newsletterId);
+        if ($byEmail !== null) {
+            return (int) $byEmail->get('id');
+        }
+
+        return 0;
+    }
+}

--- a/core/components/sendex/phinx.php
+++ b/core/components/sendex/phinx.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Phinx configuration for Sendex (MODX Revolution 2).
+ *
+ * Uses MODX database settings. CLI: vendor/bin/phinx migrate -c phinx.php
+ */
+
+require_once __DIR__ . '/model/sendex/sxphinxconfig.class.php';
+
+if (!isset($modx)) {
+    $modxConfigPath = dirname(__FILE__, 4) . '/config.core.php';
+
+    if (!file_exists($modxConfigPath)) {
+        die('MODX config.core.php not found. Please ensure MODX is properly installed.');
+    }
+
+    if (!defined('MODX_CORE_PATH')) {
+        require_once $modxConfigPath;
+    }
+
+    if (!defined('MODX_CORE_PATH')) {
+        die('MODX_CORE_PATH not defined in config.core.php');
+    }
+
+    if (!class_exists('modX')) {
+        require_once MODX_CORE_PATH . 'model/modx/modx.class.php';
+    }
+
+    $modx = new modX();
+    $modx->initialize('mgr');
+}
+
+$dbConfig = sxPhinxConfig::buildDbConfig($modx);
+$migrationTable = sxPhinxConfig::migrationTableName($dbConfig['table_prefix']);
+
+return array(
+    'paths' => array(
+        'migrations' => __DIR__ . '/migrations',
+        'seeds' => __DIR__ . '/seeds',
+    ),
+    'environments' => array(
+        'default_migration_table' => $migrationTable,
+        'default_environment' => 'production',
+        'production' => $dbConfig,
+        'development' => $dbConfig,
+    ),
+    'version_order' => 'creation',
+);

--- a/tests/Unit/NewsletterAddQueuesTest.php
+++ b/tests/Unit/NewsletterAddQueuesTest.php
@@ -64,6 +64,7 @@ class NewsletterAddQueuesTest extends TestCase
         $this->assertCount(1, $this->modx->queues);
         $this->assertSame('guest@example.com', $this->modx->queues[0]->get('email_to'));
         $this->assertSame('Hello', $this->modx->queues[0]->get('email_subject'));
+        $this->assertSame(1, $this->modx->queues[0]->get('subscriber_id'));
     }
 
     public function testSkipsUserWithoutProfile()
@@ -135,5 +136,24 @@ class NewsletterAddQueuesTest extends TestCase
         $this->assertTrue($this->newsletter->addQueues());
         $this->assertCount(1, $this->modx->queues);
         $this->assertSame('Body for user@example.com', $this->modx->queues[0]->get('email_body'));
+        // Must be sxSubscriber.id (1), not modUser.id (5)
+        $this->assertSame(1, $this->modx->queues[0]->get('subscriber_id'));
+    }
+
+    public function testSchemaQueueIndexNameMatchesSubscriberIdColumn()
+    {
+        $schema = file_get_contents(
+            dirname(__DIR__, 2) . '/core/components/sendex/model/schema/sendex.mysql.schema.xml'
+        );
+
+        $this->assertStringContainsString('defaultEngine="InnoDB"', $schema);
+        $this->assertStringContainsString(
+            'alias="subscriber_id" name="subscriber_id"',
+            $schema
+        );
+        $this->assertStringNotContainsString(
+            'alias="subscriber_id" name="user_id"',
+            $schema
+        );
     }
 }

--- a/tests/Unit/PhinxConfigTest.php
+++ b/tests/Unit/PhinxConfigTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sxphinxconfig.class.php';
+
+class PhinxConfigTest extends TestCase
+{
+    public function testNormalizeUtf8WebCharsetToUtf8mb4WhenPreferred(): void
+    {
+        $this->assertSame('utf8mb4', sxPhinxConfig::normalizeMysqlCharset('UTF-8', true));
+        $this->assertSame('utf8', sxPhinxConfig::normalizeMysqlCharset('UTF-8', false));
+    }
+
+    public function testExtractDsnCharset(): void
+    {
+        $this->assertSame(
+            'utf8',
+            sxPhinxConfig::extractDsnCharset('mysql:host=localhost;dbname=x;charset=utf8')
+        );
+        $this->assertNull(sxPhinxConfig::extractDsnCharset('mysql:host=localhost;dbname=x'));
+    }
+
+    public function testDefaultCollation(): void
+    {
+        $this->assertSame('utf8_general_ci', sxPhinxConfig::defaultMysqlCollation('utf8'));
+        $this->assertSame('utf8mb4_unicode_ci', sxPhinxConfig::defaultMysqlCollation('utf8mb4'));
+    }
+
+    public function testMigrationTableUsesPrefix(): void
+    {
+        $this->assertSame('modx_sendex_migrations', sxPhinxConfig::migrationTableName('modx_'));
+        $this->assertSame('sendex_migrations', sxPhinxConfig::migrationTableName(''));
+    }
+
+    public function testBuildDbConfigPrefersDsnCharset(): void
+    {
+        $modx = new class {
+            public $opts = array(
+                'database_dsn' => 'mysql:host=db;dbname=sendex;charset=utf8',
+                'charset' => 'UTF-8',
+                'dbname' => 'sendex',
+                'username' => 'u',
+                'password' => 'p',
+                'host' => 'db',
+                'table_prefix' => 'modx_',
+            );
+
+            public function getOption($key, $options = null, $default = null)
+            {
+                return array_key_exists($key, $this->opts) ? $this->opts[$key] : $default;
+            }
+        };
+
+        $db = sxPhinxConfig::buildDbConfig($modx);
+        $this->assertSame('utf8', $db['charset']);
+        $this->assertSame('utf8_general_ci', $db['collation']);
+        $this->assertSame('modx_', $db['table_prefix']);
+        $this->assertSame('sendex', $db['name']);
+    }
+}

--- a/tests/Unit/QueueLinkTest.php
+++ b/tests/Unit/QueueLinkTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sxqueuelink.class.php';
+
+class QueueLinkTest extends TestCase
+{
+    public function testSubscriberIdFromSubscriberUsesPrimaryKey()
+    {
+        $modx = new FakeModX();
+        $subscriber = new sxSubscriber($modx);
+        $subscriber->fromArray(array(
+            'id'      => 42,
+            'user_id' => 7,
+            'email'   => 'a@example.com',
+        ));
+
+        $this->assertSame(42, sxQueueLink::subscriberIdFromSubscriber($subscriber));
+    }
+
+    public function testRemapKeepsValidSubscriberPrimaryKey()
+    {
+        $byId = function ($id, $newsletterId) {
+            if ($id === 42 && $newsletterId === 3) {
+                return $this->subscriber(42, 7, 'a@example.com');
+            }
+
+            return null;
+        };
+
+        $resolved = sxQueueLink::remapStoredSubscriberId(
+            42,
+            3,
+            'a@example.com',
+            $byId,
+            function () {
+                return null;
+            },
+            function () {
+                return null;
+            }
+        );
+
+        $this->assertSame(42, $resolved);
+    }
+
+    public function testRemapLegacyUserIdToSubscriberId()
+    {
+        $resolved = sxQueueLink::remapStoredSubscriberId(
+            7,
+            3,
+            'a@example.com',
+            function () {
+                return null;
+            },
+            function ($userId, $newsletterId) {
+                if ($userId === 7 && $newsletterId === 3) {
+                    return $this->subscriber(42, 7, 'a@example.com');
+                }
+
+                return null;
+            },
+            function () {
+                return null;
+            }
+        );
+
+        $this->assertSame(42, $resolved);
+    }
+
+    public function testRemapZeroUsesEmail()
+    {
+        $resolved = sxQueueLink::remapStoredSubscriberId(
+            0,
+            3,
+            'guest@example.com',
+            function () {
+                return null;
+            },
+            function () {
+                return null;
+            },
+            function ($email, $newsletterId) {
+                if ($email === 'guest@example.com' && $newsletterId === 3) {
+                    return $this->subscriber(9, 0, 'guest@example.com');
+                }
+
+                return null;
+            }
+        );
+
+        $this->assertSame(9, $resolved);
+    }
+
+    public function testRemapUnknownPositiveStoredLeftUnchanged()
+    {
+        $resolved = sxQueueLink::remapStoredSubscriberId(
+            99,
+            3,
+            'x@example.com',
+            function () {
+                return null;
+            },
+            function () {
+                return null;
+            },
+            function () {
+                return null;
+            }
+        );
+
+        $this->assertSame(99, $resolved);
+    }
+
+    /**
+     * @param int $id
+     * @param int $userId
+     * @param string $email
+     * @return sxSubscriber
+     */
+    private function subscriber($id, $userId, $email)
+    {
+        $modx = new FakeModX();
+        $subscriber = new sxSubscriber($modx);
+        $subscriber->fromArray(array(
+            'id'      => $id,
+            'user_id' => $userId,
+            'email'   => $email,
+        ));
+
+        return $subscriber;
+    }
+}


### PR DESCRIPTION
### Кратко

Phinx (как MiniShop3) плюс каноническая схема #67: InnoDB, индекс `subscriber_id`, смысл колонки как в #52.

## Что сделано
- Phinx: `composer.json`/`lock`, `phinx.php`, `sxPhinxConfig`, `resolve.migrations`
- миграции: `initial_schema`, `subscriber_unique_email`, `innodb_queue_subscriber_link`
- schema/map: `defaultEngine=InnoDB`, индекс queue `subscriber_id`
- `addQueues` пишет `sxSubscriber.id` через `sxQueueLink`; бэкфилл legacy `user_id` / guest по email
- тесты: `PhinxConfigTest`, `QueueLinkTest`, asserts в `NewsletterAddQueuesTest`
- changelog: breaking change по engine и смыслу `subscriber_id`

## Review
- Medium+: нет
- Soft FK на core/`0` defaults не добавляли (зафиксировано в changelog)

## Проверка
- `composer test` — exit 0 (90 tests; `QueueLinkTest`, schema contract)
- phpcs — exit 0
- waive: live Phinx migrate против MySQL (нет MODX DB в CI)

Fixes #67
Fixes #52
