### PR TITLE
fix(subscribers): Merge guest rows onto activated users

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Sendex runs email newsletters in MODX Revolution: subscribers, a send queue, and
 - Newsletters and subscribers in the manager
 - Add users one by one or from a MODX user group (active and unblocked accounts only)
 - Guest subscribe with email confirmation; authenticated users subscribe directly
+- Guest rows with the same email merge onto a new/activated `modUser` (no second subscriber row)
 - Queue letters; send one, send all, or flush via cron
 - Export subscriber emails
 - English and Russian lexicons
@@ -59,6 +60,16 @@ Root `composer.json` remains for PHPUnit/phpcs only.
 | `tplSubscribeGuest` | `tpl.Sendex.subscribe.guest` | Chunk for guests |
 | `tplUnsubscribe` | `tpl.Sendex.unsubscribe` | Unsubscribe chunk |
 | `tplActivate` | `tpl.Sendex.activate` | Confirmation email chunk |
+
+### Guest email vs existing User (#39)
+
+Policy: **merge**, not block.
+
+1. Anonymous confirm / `subscribe()` resolves `modUser` by profile email and stores `user_id` (see `#54`).
+2. Unique key `(newsletter_id, email)` prevents a guest+user duplicate row.
+3. If a guest subscribed first and the account is created later, the Sendex plugin merges on `OnUserActivate`, `OnBeforeUserActivate`, and `OnUserSave`: guest rows with that email get `user_id` set. Reinstall/upgrade the package so the plugin events are registered.
+
+Logged-in `isSubscribed($userId)` also matches a still-guest row by profile email, so the form shows unsubscribe without waiting for merge.
 
 ## Cron
 

--- a/_build/data/transport.plugins.php
+++ b/_build/data/transport.plugins.php
@@ -8,6 +8,9 @@ $tmp = array(
         'description' => '',
         'events'      => array(
             'OnManagerPageInit' => array(),
+            'OnUserActivate' => array(),
+            'OnBeforeUserActivate' => array(),
+            'OnUserSave' => array(),
         ),
     ),
 );

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -19,7 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [#67] / [#52] Schema and upgrade: Sendex tables use InnoDB; queue index renamed `user_id` → `subscriber_id`; `addQueues` stores `sxSubscriber.id` (not `user_id`); Phinx backfill remaps legacy queue rows (by user_id, guests by email).
-- [#54] `isSubscribed` matches by `user_id` OR `email` within a newsletter; unique key is `(newsletter_id, email)`; guest rows attach `user_id` when the same email confirms as a user (also covers main #39 cases; activate-merge handler still open).
+- [#54] `isSubscribed` matches by `user_id` OR `email` within a newsletter; unique key is `(newsletter_id, email)`; guest rows attach `user_id` when the same email confirms as a user.
+- [#39] Guest rows merge onto `modUser` on `OnUserActivate` / `OnBeforeUserActivate` / `OnUserSave` (`sxSubscriberMerge`); registration does not create a second subscriber row for the same email.
 - [#58] `confirmEmail` restores registry hash when `subscribe()` fails so the confirm link stays usable; remaining TTL kept via `_expires`; `checkEmail` shares `sxSubscribeRegistry::store`.
 - [#61] `sxSubscriber::save` keeps existing `code` (generate only when empty) so unsubscribe links stay valid.
 - [#53] Snippet: authenticated user without Profile no longer triggers TypeError on PHP 8; merge via `sxUserPlaceholders`.

--- a/core/components/sendex/elements/plugins/plugin.sendex.php
+++ b/core/components/sendex/elements/plugins/plugin.sendex.php
@@ -5,4 +5,24 @@ switch ($modx->event->name) {
         $cssFile = MODX_ASSETS_URL . 'components/sendex/css/mgr/main.css';
         $modx->regClientCSS($cssFile);
         break;
+
+    case 'OnUserActivate':
+    case 'OnBeforeUserActivate':
+    case 'OnUserSave':
+        $corePath = $modx->getOption(
+            'sendex_core_path',
+            null,
+            $modx->getOption('core_path') . 'components/sendex/'
+        );
+        require_once $corePath . 'model/sendex/sxsubscribermerge.class.php';
+
+        if (empty($user) && !empty($modx->event->params['user'])) {
+            $user = $modx->event->params['user'];
+        }
+
+        if (!empty($user)) {
+            $modx->addPackage('sendex', $corePath . 'model/');
+            sxSubscriberMerge::attachGuestsForUser($modx, $user);
+        }
+        break;
 }

--- a/core/components/sendex/model/sendex/sxsubscribermerge.class.php
+++ b/core/components/sendex/model/sendex/sxsubscribermerge.class.php
@@ -1,0 +1,126 @@
+<?php
+
+require_once dirname(__FILE__) . '/sxsubscribermatch.class.php';
+
+/**
+ * Attach guest subscriber rows to a modUser when email matches (#39).
+ */
+class sxSubscriberMerge
+{
+    /**
+     * Set user_id on guest rows (user_id = 0) with the same email across newsletters.
+     *
+     * Policy: merge, never create a second row for the same newsletter email.
+     *
+     * @param object $xpdo
+     * @param int $userId
+     * @param string $email
+     * @return int Number of rows updated
+     */
+    public static function attachGuestsByEmail($xpdo, $userId, $email)
+    {
+        $userId = (int) $userId;
+        $email = sxSubscriberMatch::normalizeEmail($email);
+        if ($userId <= 0 || $email === '') {
+            return 0;
+        }
+
+        $updated = 0;
+        foreach (self::findGuestRows($xpdo, $email) as $subscriber) {
+            if ((int) $subscriber->get('user_id') !== 0) {
+                continue;
+            }
+            if (strcasecmp((string) $subscriber->get('email'), $email) !== 0) {
+                continue;
+            }
+
+            $subscriber->set('user_id', $userId);
+            if ($subscriber->save()) {
+                $updated++;
+            }
+        }
+
+        return $updated;
+    }
+
+    /**
+     * Resolve profile email from a modUser-like object.
+     *
+     * @param object $xpdo
+     * @param object|null $user Object with get('id') and optional getOne('Profile')
+     * @return string
+     */
+    public static function emailFromUser($xpdo, $user)
+    {
+        if ($user === null) {
+            return '';
+        }
+
+        $profile = null;
+        if (method_exists($user, 'getOne')) {
+            $profile = $user->getOne('Profile');
+        }
+
+        if (!$profile && method_exists($user, 'get')) {
+            $profile = $xpdo->getObject('modUserProfile', array(
+                'internalKey' => (int) $user->get('id'),
+            ));
+        }
+
+        if (!$profile) {
+            return '';
+        }
+
+        return sxSubscriberMatch::normalizeEmail($profile->get('email'));
+    }
+
+    /**
+     * Merge guests for an activated / saved user.
+     *
+     * @param object $xpdo
+     * @param object|null $user
+     * @return int
+     */
+    public static function attachGuestsForUser($xpdo, $user)
+    {
+        if ($user === null || !method_exists($user, 'get')) {
+            return 0;
+        }
+
+        $userId = (int) $user->get('id');
+        $email = self::emailFromUser($xpdo, $user);
+
+        return self::attachGuestsByEmail($xpdo, $userId, $email);
+    }
+
+    /**
+     * @param object $xpdo
+     * @param string $email
+     * @return object[]
+     */
+    private static function findGuestRows($xpdo, $email)
+    {
+        if (!method_exists($xpdo, 'getCollection')) {
+            return array();
+        }
+
+        $q = $xpdo->newQuery('sxSubscriber');
+        $q->where(array(
+            'user_id' => 0,
+        ));
+
+        $rows = $xpdo->getCollection('sxSubscriber', $q);
+        if (!is_array($rows)) {
+            return array();
+        }
+
+        $matched = array();
+        foreach ($rows as $subscriber) {
+            if (strcasecmp((string) $subscriber->get('email'), $email) === 0) {
+                $matched[] = $subscriber;
+            }
+        }
+
+        return $matched;
+    }
+}

--- a/tests/Stubs/FakeModX.php
+++ b/tests/Stubs/FakeModX.php
@@ -237,6 +237,35 @@ class FakeModX extends modX
 
     /**
      * @param string $class
+     * @param FakeQuery|array|null $criteria
+     *
+     * @return array
+     */
+    public function getCollection($class, $criteria = null)
+    {
+        if ($class !== 'sxSubscriber') {
+            return array();
+        }
+
+        $where = array();
+        if ($criteria instanceof FakeQuery) {
+            $where = $criteria->where;
+        } elseif (is_array($criteria)) {
+            $where = $criteria;
+        }
+
+        $out = array();
+        foreach ($this->subscribers as $subscriber) {
+            if ($where === array() || sxSubscriberMatch::matchesWhere($where, $subscriber)) {
+                $out[] = $subscriber;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param string $class
      * @param array $criteria
      *
      * @return int

--- a/tests/Unit/SubscriberMergeTest.php
+++ b/tests/Unit/SubscriberMergeTest.php
@@ -1,0 +1,107 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sxsubscribermerge.class.php';
+
+class SubscriberMergeTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+    }
+
+    public function testAttachGuestsByEmailPromotesMatchingRows()
+    {
+        $guestA = $this->guest(1, 10, 'same@example.com');
+        $guestB = $this->guest(2, 11, 'SAME@example.com');
+        $other = $this->guest(3, 10, 'other@example.com');
+        $linked = new sxSubscriber($this->modx);
+        $linked->fromArray(array(
+            'id'            => 4,
+            'newsletter_id' => 12,
+            'user_id'       => 9,
+            'email'         => 'same@example.com',
+        ));
+
+        $this->modx->subscribers = array($guestA, $guestB, $other, $linked);
+
+        $updated = sxSubscriberMerge::attachGuestsByEmail($this->modx, 5, 'same@example.com');
+
+        $this->assertSame(2, $updated);
+        $this->assertSame(5, (int) $guestA->get('user_id'));
+        $this->assertSame(5, (int) $guestB->get('user_id'));
+        $this->assertSame(0, (int) $other->get('user_id'));
+        $this->assertSame(9, (int) $linked->get('user_id'));
+    }
+
+    public function testAttachGuestsByEmailIgnoresInvalidIdentity()
+    {
+        $this->modx->subscribers[] = $this->guest(1, 10, 'a@example.com');
+
+        $this->assertSame(0, sxSubscriberMerge::attachGuestsByEmail($this->modx, 0, 'a@example.com'));
+        $this->assertSame(0, sxSubscriberMerge::attachGuestsByEmail($this->modx, 5, ''));
+        $this->assertSame(0, (int) $this->modx->subscribers[0]->get('user_id'));
+    }
+
+    public function testAttachGuestsForUserReadsProfileEmail()
+    {
+        $this->modx->subscribers[] = $this->guest(1, 10, 'member@example.com');
+        $this->modx->profiles[8] = 'member@example.com';
+
+        $user = new modUser($this->modx);
+        $user->set('id', 8);
+
+        $this->assertSame(1, sxSubscriberMerge::attachGuestsForUser($this->modx, $user));
+        $this->assertSame(8, (int) $this->modx->subscribers[0]->get('user_id'));
+    }
+
+    public function testEmailFromUserReturnsEmptyWithoutProfile()
+    {
+        $user = new modUser($this->modx);
+        $user->set('id', 3);
+
+        $this->assertSame('', sxSubscriberMerge::emailFromUser($this->modx, $user));
+        $this->assertSame('', sxSubscriberMerge::emailFromUser($this->modx, null));
+    }
+
+    public function testPluginSourceRegistersActivateAndSaveEvents()
+    {
+        $plugin = file_get_contents(
+            dirname(__DIR__, 2) . '/core/components/sendex/elements/plugins/plugin.sendex.php'
+        );
+        $transport = file_get_contents(
+            dirname(__DIR__, 2) . '/_build/data/transport.plugins.php'
+        );
+
+        $this->assertStringContainsString("case 'OnUserActivate':", $plugin);
+        $this->assertStringContainsString("case 'OnBeforeUserActivate':", $plugin);
+        $this->assertStringContainsString("case 'OnUserSave':", $plugin);
+        $this->assertStringContainsString('sxSubscriberMerge::attachGuestsForUser', $plugin);
+        $this->assertStringContainsString("'OnUserActivate'", $transport);
+        $this->assertStringContainsString("'OnBeforeUserActivate'", $transport);
+        $this->assertStringContainsString("'OnUserSave'", $transport);
+    }
+
+    /**
+     * @param int $id
+     * @param int $newsletterId
+     * @param string $email
+     * @return sxSubscriber
+     */
+    private function guest($id, $newsletterId, $email)
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => $id,
+            'newsletter_id' => $newsletterId,
+            'user_id'       => 0,
+            'email'         => $email,
+        ));
+
+        return $subscriber;
+    }
+}


### PR DESCRIPTION
### Кратко

Добевает #39: guest→user **merge** при активации/сохранении User. Confirm/subscribe с резолвом email уже в #54.

## Что сделано
- `sxSubscriberMerge`: guest-строки с тем же email получают `user_id`
- plugin Sendex: `OnUserActivate`, `OnBeforeUserActivate`, `OnUserSave`
- transport: те же events
- README: политика merge (не block)
- тесты: `SubscriberMergeTest`
- миграция: не нужна (schema без изменений)

## Review
- Medium+: нет

## Проверка
- `composer test` — exit 0 (95; `SubscriberMergeTest`)
- phpcs — exit 0

Fixes #39