### PR TITLE
refactor(newsletter): Split sxNewsletter into focused helpers

### DIFF
--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHP 7.4–8.4: dynamic properties, null Profile in `addQueues`, PHPMailer `ErrorInfo`.
 
 ### Changed
+- [#62] Split `sxNewsletter` into `sxNewsletterSubscription`, `sxNewsletterQueueBuilder`, `sxSendexEvent`; model keeps a thin public API for processors/snippet.
 - **Breaking (DB):** existing `sendex_*` tables are converted to InnoDB on upgrade; queue `subscriber_id` meaning is `sxSubscriber.id` after backfill (join Queue→Subscriber for guests works). Soft FK to core `modUser` tables are not added.
 - `add_group` processor requires `edit_document` permission.
 - Newsletter create processor class renamed to `sxNewsletterCreateProcessor`.

--- a/core/components/sendex/model/sendex/sxnewsletter.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletter.class.php
@@ -1,382 +1,88 @@
 <?php
 
-require_once dirname(__FILE__) . '/sxsubscriberegistry.class.php';
-require_once dirname(__FILE__) . '/sxsubscribermatch.class.php';
-require_once dirname(__FILE__) . '/sxqueuelink.class.php';
+require_once dirname(__FILE__) . '/sxnewslettersubscription.class.php';
+require_once dirname(__FILE__) . '/sxnewsletterqueuebuilder.class.php';
+require_once dirname(__FILE__) . '/sxsendexevent.class.php';
 
+/**
+ * Newsletter persistence + thin API over subscription / queue helpers (#62).
+ */
 class sxNewsletter extends xPDOSimpleObject
 {
     /**
-     * Prepares emails and set them to queue
-     *
      * @return bool|mixed|string
      */
     public function addQueues()
     {
-        $template = null;
-        $params = $this->toArray();
-        /** @var modParser $parser */
-        $parser = $this->xpdo->getService(
-            'parser',
-            $this->xpdo->getOption('parser_class', null, 'modParser'),
-            $this->xpdo->getOption('parser_class_path', null, '')
-        );
+        $builder = new sxNewsletterQueueBuilder($this);
 
-        if (!$subscribers = $this->getMany('Subscribers')) {
-            return $this->xpdo->lexicon('sendex_newsletter_err_no_subscribers');
-        }
-
-        if ($tmp = $this->get('template')) {
-            /** @var modTemplate $template */
-            $template = $this->xpdo->getObject('modTemplate', $tmp);
-        }
-
-        if (!$template || !($template instanceof modTemplate)) {
-            return $this->xpdo->lexicon('sendex_newsletter_err_no_template');
-        }
-
-        /** @var sxSubscriber $subscriber */
-        foreach ($subscribers as $subscriber) {
-            $scriptProperties = array(
-                'newsletter' => $params,
-                'subscriber' => $subscriber->toArray(),
-            );
-
-            // Get email from user profile, if possible
-            /** @var modUser $user */
-            if ($subscriber->get('user_id') && $user = $this->xpdo->getObject('modUser', $subscriber->user_id)) {
-                /** @var modUserProfile|null $profile */
-                $profile = $user->getOne('Profile');
-
-                // Skip inactive users or users without a profile
-                if (!$profile || !$user->active || $profile->blocked) {
-                    continue;
-                }
-                // Add user fields
-                $scriptProperties['user'] = $user->toArray();
-                $scriptProperties['profile'] = $profile->toArray();
-            }
-
-            $email = $subscriber->email;
-            $subject = !empty($this->email_subject) ? $this->email_subject : 'No subject';
-            $from = !empty($this->email_from) ? $this->email_from : $this->xpdo->getOption('emailsender');
-            $from_name = !empty($this->email_from_name) ? $this->email_from_name : $this->xpdo->getOption('site_name');
-            $email_reply = !empty($this->email_reply) ? $this->email_reply : $from;
-
-            // Process email body
-            $template->_cacheable = false;
-            $template->_processed = false;
-            $template->_output = '';
-            $body = $template->process($scriptProperties);
-
-            if ($parser && $parser instanceof modParser) {
-                $maxIterations = (int) $this->xpdo->getOption('parser_max_iterations', null, 10);
-                $parser->processElementTags('', $body, true, true, '[[', ']]', array(), $maxIterations);
-            }
-
-            /** @var sxQueue $queue */
-            $queue = $this->xpdo->newObject('sxQueue');
-            $queue->fromArray(array(
-                'subscriber_id'   => sxQueueLink::subscriberIdFromSubscriber($subscriber),
-                'newsletter_id'   => $this->id,
-                'email_to'        => $email,
-                'email_subject'   => $subject,
-                'email_body'      => $body,
-                'email_from'      => $from,
-                'email_from_name' => $from_name,
-                'email_reply'     => $email_reply,
-            ));
-            $queue->save();
-        }
-
-        return true;
+        return $builder->addQueues();
     }
 
-
     /**
-     * Returns status of user for this newsletter
-     *
      * @param int $user_id
      * @param string $email
-     *
      * @return int
      */
     public function isSubscribed($user_id = 0, $email = '')
     {
-        $user_id = (int) $user_id;
-        $email = sxSubscriberMatch::normalizeEmail($email);
-
-        if ($email === '' && $user_id > 0) {
-            /** @var modUserProfile $profile */
-            $profile = $this->xpdo->getObject('modUserProfile', array('internalKey' => $user_id));
-            if ($profile) {
-                $email = sxSubscriberMatch::normalizeEmail($profile->get('email'));
-            }
-        }
-
-        $where = sxSubscriberMatch::whereClause($this->get('id'), $user_id, $email);
-        if ($where === null) {
-            return 0;
-        }
-
-        $q = $this->xpdo->newQuery('sxSubscriber');
-        $q->where($where);
-
-        /** @var sxSubscriber $subscriber */
-        $subscriber = $this->xpdo->getObject('sxSubscriber', $q);
-        if ($subscriber) {
-            return (int) $subscriber->id;
-        }
-
-        return 0;
+        return $this->subscription()->isSubscribed($user_id, $email);
     }
 
-
     /**
-     * Method for send subscription link
-     *
      * @param string $email
      * @param int $user_id
      * @param int $linkTTL
-     *
      * @return bool|string
      */
     public function checkEmail($email = '', $user_id = 0, $linkTTL = 1800)
     {
-        if (empty($email) && $profile = $this->xpdo->getObject('modUserProfile', array('internalKey' => $user_id))) {
-            $email = $profile->get('email');
-        }
-
-        if (empty($email) || !preg_match('/.+@.+\..+/i', $email)) {
-            return false;
-        } elseif ($this->isSubscribed($user_id, $email)) {
-            return true;
-        }
-
-        $hash = sha1(uniqid(sha1($email), true));
-
-        sxSubscribeRegistry::store(
-            $this->xpdo,
-            $hash,
-            array(
-                'user_id'       => $user_id,
-                'newsletter_id' => $this->id,
-                'email'         => $email,
-            ),
-            $linkTTL
-        );
-
-        return $hash;
+        return $this->subscription()->checkEmail($email, $user_id, $linkTTL);
     }
 
-
     /**
-     * Confirms email of user
-     *
-     * @param $hash
-     *
-     * @return bool|string true on success, false on failure, or plugin cancel message
+     * @param string $hash
+     * @return bool|string
      */
     public function confirmEmail($hash)
     {
-        if (empty($hash)) {
-            return false;
-        }
-
-        $entry = sxSubscribeRegistry::consume($this->xpdo, $hash);
-        if ($entry === null) {
-            return false;
-        }
-
-        $result = false;
-        if ($this->id != $entry['newsletter_id']) {
-            /** @var sxNewsletter $newsletter */
-            $newsletter = $this->xpdo->getObject('sxNewsletter', array(
-                'id'     => $entry['newsletter_id'],
-                'active' => 1,
-            ));
-            if ($newsletter) {
-                $result = $newsletter->subscribe($entry['user_id'], $entry['email']);
-            }
-        } else {
-            $result = $this->subscribe($entry['user_id'], $entry['email']);
-        }
-
-        if ($result !== true) {
-            sxSubscribeRegistry::restore($this->xpdo, $hash, $entry);
-        }
-
-        return $result;
+        return $this->subscription()->confirmEmail($hash);
     }
 
-
     /**
-     * Subscribes user to the newsletter
-     *
      * @param int $user_id
      * @param string $email
-     *
-     * @return true|false|string true on success, false on validation/save failure,
-     *                          or plugin cancel message from sxOnBeforeSubscribe
+     * @return true|false|string
      */
     public function subscribe($user_id = 0, $email = '')
     {
-        if (empty($email) && $profile = $this->xpdo->getObject('modUserProfile', array('internalKey' => $user_id))) {
-            $email = $profile->get('email');
-        }
-
-        $email = sxSubscriberMatch::normalizeEmail($email);
-        if ($email === '' || !preg_match('/.+@.+\..+/i', $email)) {
-            return false;
-        }
-
-        $user_id = sxSubscriberMatch::resolveUserId($this->xpdo, $user_id, $email);
-
-        if ($subscriberId = $this->isSubscribed($user_id, $email)) {
-            $this->attachUserToSubscriber($subscriberId, $user_id, $email);
-
-            return true;
-        }
-
-        $params = array(
-            'newsletter'    => $this,
-            'newsletter_id' => $this->id,
-            'user_id'       => $user_id,
-            'email'         => $email,
-            'subscriber'    => null,
-        );
-
-        $before = $this->invokeSendexEvent('sxOnBeforeSubscribe', $params);
-        if ($before !== true) {
-            return $before;
-        }
-
-        /** @var sxSubscriber $subscriber */
-        $subscriber = $this->xpdo->newObject('sxSubscriber');
-        $subscriber->fromArray(array(
-            'newsletter_id' => $this->id,
-            'user_id'       => $user_id,
-            'email'         => $email,
-        ), '', true, true);
-
-        if (!$subscriber->save()) {
-            return false;
-        }
-
-        $params['subscriber'] = $subscriber;
-        $this->invokeSendexEvent('sxOnSubscribe', $params);
-
-        return true;
+        return $this->subscription()->subscribe($user_id, $email);
     }
 
     /**
-     * Promote guest row / refresh email when identity already exists.
-     *
-     * @param int $subscriberId
-     * @param int $userId
-     * @param string $email
-     */
-    protected function attachUserToSubscriber($subscriberId, $userId, $email)
-    {
-        $userId = (int) $userId;
-        if ($userId <= 0 && $email === '') {
-            return;
-        }
-
-        /** @var sxSubscriber $subscriber */
-        $subscriber = $this->xpdo->getObject('sxSubscriber', (int) $subscriberId);
-        if (!$subscriber) {
-            return;
-        }
-
-        $changed = false;
-        if ($userId > 0 && (int) $subscriber->get('user_id') === 0) {
-            $subscriber->set('user_id', $userId);
-            $changed = true;
-        }
-        if ($email !== '' && strcasecmp((string) $subscriber->get('email'), $email) !== 0) {
-            if ($userId > 0 && (int) $subscriber->get('user_id') === $userId) {
-                $subscriber->set('email', $email);
-                $changed = true;
-            }
-        }
-
-        if ($changed) {
-            $subscriber->save();
-        }
-    }
-
-
-    /**
-     * Unsubscribes user from the newsletter
-     *
      * @param string $code
-     *
-     * @return true|false|string true on success, false on missing/mismatched code or remove failure,
-     *                           or plugin cancel message from sxOnBeforeUnsubscribe
+     * @return true|false|string
      */
     public function unSubscribe($code)
     {
-        /** @var sxSubscriber $subscriber */
-        if (!$subscriber = $this->xpdo->getObject('sxSubscriber', array('code' => $code))) {
-            return false;
-        }
-
-        if ((int) $subscriber->get('newsletter_id') !== (int) $this->get('id')) {
-            return false;
-        }
-
-        $params = array(
-            'newsletter'    => $this,
-            'newsletter_id' => $this->id,
-            'user_id'       => $subscriber->get('user_id'),
-            'email'         => $subscriber->get('email'),
-            'code'          => $code,
-            'subscriber'    => $subscriber,
-        );
-
-        $before = $this->invokeSendexEvent('sxOnBeforeUnsubscribe', $params);
-        if ($before !== true) {
-            return $before;
-        }
-
-        if (!$subscriber->remove()) {
-            return false;
-        }
-
-        $this->invokeSendexEvent('sxOnUnsubscribe', $params);
-
-        return true;
+        return $this->subscription()->unSubscribe($code);
     }
 
-
     /**
-     * Invoke a Sendex system event. Before-events cancel when a plugin outputs a non-empty string.
-     *
      * @param string $name
      * @param array $params
-     *
-     * @return true|string true, or first plugin error message if cancelled
+     * @return true|string
      */
     protected function invokeSendexEvent($name, array $params)
     {
-        if (!($this->xpdo instanceof modX) || !method_exists($this->xpdo, 'invokeEvent')) {
-            return true;
-        }
+        return sxSendexEvent::invoke($this->xpdo, $name, $params);
+    }
 
-        $response = $this->xpdo->invokeEvent($name, $params);
-        if (is_array($response)) {
-            $messages = array();
-            foreach ($response as $item) {
-                if (is_string($item) && trim($item) !== '') {
-                    $messages[] = trim($item);
-                }
-            }
-            if (!empty($messages)) {
-                return reset($messages);
-            }
-        }
-
-        return true;
+    /**
+     * @return sxNewsletterSubscription
+     */
+    protected function subscription()
+    {
+        return new sxNewsletterSubscription($this);
     }
 }

--- a/core/components/sendex/model/sendex/sxnewsletterqueuebuilder.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletterqueuebuilder.class.php
@@ -1,0 +1,106 @@
+<?php
+
+require_once dirname(__FILE__) . '/sxqueuelink.class.php';
+
+/**
+ * Build queue rows from newsletter subscribers.
+ */
+class sxNewsletterQueueBuilder
+{
+    /** @var sxNewsletter */
+    protected $newsletter;
+
+    /**
+     * @param sxNewsletter $newsletter
+     */
+    public function __construct(sxNewsletter $newsletter)
+    {
+        $this->newsletter = $newsletter;
+    }
+
+    /**
+     * @return bool|mixed|string
+     */
+    public function addQueues()
+    {
+        $newsletter = $this->newsletter;
+        $xpdo = $newsletter->xpdo;
+        $template = null;
+        $params = $newsletter->toArray();
+        /** @var modParser $parser */
+        $parser = $xpdo->getService(
+            'parser',
+            $xpdo->getOption('parser_class', null, 'modParser'),
+            $xpdo->getOption('parser_class_path', null, '')
+        );
+
+        if (!$subscribers = $newsletter->getMany('Subscribers')) {
+            return $xpdo->lexicon('sendex_newsletter_err_no_subscribers');
+        }
+
+        if ($tmp = $newsletter->get('template')) {
+            /** @var modTemplate $template */
+            $template = $xpdo->getObject('modTemplate', $tmp);
+        }
+
+        if (!$template || !($template instanceof modTemplate)) {
+            return $xpdo->lexicon('sendex_newsletter_err_no_template');
+        }
+
+        /** @var sxSubscriber $subscriber */
+        foreach ($subscribers as $subscriber) {
+            $scriptProperties = array(
+                'newsletter' => $params,
+                'subscriber' => $subscriber->toArray(),
+            );
+
+            /** @var modUser $user */
+            if ($subscriber->get('user_id') && $user = $xpdo->getObject('modUser', $subscriber->user_id)) {
+                /** @var modUserProfile|null $profile */
+                $profile = $user->getOne('Profile');
+
+                if (!$profile || !$user->active || $profile->blocked) {
+                    continue;
+                }
+                $scriptProperties['user'] = $user->toArray();
+                $scriptProperties['profile'] = $profile->toArray();
+            }
+
+            $email = $subscriber->email;
+            $subject = !empty($newsletter->email_subject) ? $newsletter->email_subject : 'No subject';
+            $from = !empty($newsletter->email_from)
+                ? $newsletter->email_from
+                : $xpdo->getOption('emailsender');
+            $fromName = !empty($newsletter->email_from_name)
+                ? $newsletter->email_from_name
+                : $xpdo->getOption('site_name');
+            $emailReply = !empty($newsletter->email_reply) ? $newsletter->email_reply : $from;
+
+            $template->_cacheable = false;
+            $template->_processed = false;
+            $template->_output = '';
+            $body = $template->process($scriptProperties);
+
+            if ($parser && $parser instanceof modParser) {
+                $maxIterations = (int) $xpdo->getOption('parser_max_iterations', null, 10);
+                $parser->processElementTags('', $body, true, true, '[[', ']]', array(), $maxIterations);
+            }
+
+            /** @var sxQueue $queue */
+            $queue = $xpdo->newObject('sxQueue');
+            $queue->fromArray(array(
+                'subscriber_id'   => sxQueueLink::subscriberIdFromSubscriber($subscriber),
+                'newsletter_id'   => $newsletter->id,
+                'email_to'        => $email,
+                'email_subject'   => $subject,
+                'email_body'      => $body,
+                'email_from'      => $from,
+                'email_from_name' => $fromName,
+                'email_reply'     => $emailReply,
+            ));
+            $queue->save();
+        }
+
+        return true;
+    }
+}

--- a/core/components/sendex/model/sendex/sxnewslettersubscription.class.php
+++ b/core/components/sendex/model/sendex/sxnewslettersubscription.class.php
@@ -1,0 +1,264 @@
+<?php
+
+require_once dirname(__FILE__) . '/sxsubscriberegistry.class.php';
+require_once dirname(__FILE__) . '/sxsubscribermatch.class.php';
+require_once dirname(__FILE__) . '/sxsendexevent.class.php';
+
+/**
+ * Subscribe / unsubscribe / confirm flows for one newsletter.
+ */
+class sxNewsletterSubscription
+{
+    /** @var sxNewsletter */
+    protected $newsletter;
+
+    /**
+     * @param sxNewsletter $newsletter
+     */
+    public function __construct(sxNewsletter $newsletter)
+    {
+        $this->newsletter = $newsletter;
+    }
+
+    /**
+     * @param int $userId
+     * @param string $email
+     * @return int
+     */
+    public function isSubscribed($userId = 0, $email = '')
+    {
+        $xpdo = $this->newsletter->xpdo;
+        $userId = (int) $userId;
+        $email = sxSubscriberMatch::normalizeEmail($email);
+
+        if ($email === '' && $userId > 0) {
+            /** @var modUserProfile $profile */
+            $profile = $xpdo->getObject('modUserProfile', array('internalKey' => $userId));
+            if ($profile) {
+                $email = sxSubscriberMatch::normalizeEmail($profile->get('email'));
+            }
+        }
+
+        $where = sxSubscriberMatch::whereClause($this->newsletter->get('id'), $userId, $email);
+        if ($where === null) {
+            return 0;
+        }
+
+        $q = $xpdo->newQuery('sxSubscriber');
+        $q->where($where);
+
+        /** @var sxSubscriber $subscriber */
+        $subscriber = $xpdo->getObject('sxSubscriber', $q);
+        if ($subscriber) {
+            return (int) $subscriber->id;
+        }
+
+        return 0;
+    }
+
+    /**
+     * @param string $email
+     * @param int $userId
+     * @param int $linkTTL
+     * @return bool|string
+     */
+    public function checkEmail($email = '', $userId = 0, $linkTTL = 1800)
+    {
+        $xpdo = $this->newsletter->xpdo;
+
+        if (empty($email) && $profile = $xpdo->getObject('modUserProfile', array('internalKey' => $userId))) {
+            $email = $profile->get('email');
+        }
+
+        if (empty($email) || !preg_match('/.+@.+\..+/i', $email)) {
+            return false;
+        } elseif ($this->isSubscribed($userId, $email)) {
+            return true;
+        }
+
+        $hash = sha1(uniqid(sha1($email), true));
+
+        sxSubscribeRegistry::store(
+            $xpdo,
+            $hash,
+            array(
+                'user_id'       => $userId,
+                'newsletter_id' => $this->newsletter->id,
+                'email'         => $email,
+            ),
+            $linkTTL
+        );
+
+        return $hash;
+    }
+
+    /**
+     * @param string $hash
+     * @return bool|string
+     */
+    public function confirmEmail($hash)
+    {
+        $xpdo = $this->newsletter->xpdo;
+
+        if (empty($hash)) {
+            return false;
+        }
+
+        $entry = sxSubscribeRegistry::consume($xpdo, $hash);
+        if ($entry === null) {
+            return false;
+        }
+
+        $result = false;
+        if ($this->newsletter->id != $entry['newsletter_id']) {
+            /** @var sxNewsletter $newsletter */
+            $newsletter = $xpdo->getObject('sxNewsletter', array(
+                'id'     => $entry['newsletter_id'],
+                'active' => 1,
+            ));
+            if ($newsletter) {
+                $result = $newsletter->subscribe($entry['user_id'], $entry['email']);
+            }
+        } else {
+            $result = $this->subscribe($entry['user_id'], $entry['email']);
+        }
+
+        if ($result !== true) {
+            sxSubscribeRegistry::restore($xpdo, $hash, $entry);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param int $userId
+     * @param string $email
+     * @return true|false|string
+     */
+    public function subscribe($userId = 0, $email = '')
+    {
+        $xpdo = $this->newsletter->xpdo;
+
+        if (empty($email) && $profile = $xpdo->getObject('modUserProfile', array('internalKey' => $userId))) {
+            $email = $profile->get('email');
+        }
+
+        $email = sxSubscriberMatch::normalizeEmail($email);
+        if ($email === '' || !preg_match('/.+@.+\..+/i', $email)) {
+            return false;
+        }
+
+        $userId = sxSubscriberMatch::resolveUserId($xpdo, $userId, $email);
+
+        if ($subscriberId = $this->isSubscribed($userId, $email)) {
+            $this->attachUserToSubscriber($subscriberId, $userId, $email);
+
+            return true;
+        }
+
+        $params = array(
+            'newsletter'    => $this->newsletter,
+            'newsletter_id' => $this->newsletter->id,
+            'user_id'       => $userId,
+            'email'         => $email,
+            'subscriber'    => null,
+        );
+
+        $before = sxSendexEvent::invoke($xpdo, 'sxOnBeforeSubscribe', $params);
+        if ($before !== true) {
+            return $before;
+        }
+
+        /** @var sxSubscriber $subscriber */
+        $subscriber = $xpdo->newObject('sxSubscriber');
+        $subscriber->fromArray(array(
+            'newsletter_id' => $this->newsletter->id,
+            'user_id'       => $userId,
+            'email'         => $email,
+        ), '', true, true);
+
+        if (!$subscriber->save()) {
+            return false;
+        }
+
+        $params['subscriber'] = $subscriber;
+        sxSendexEvent::invoke($xpdo, 'sxOnSubscribe', $params);
+
+        return true;
+    }
+
+    /**
+     * @param string $code
+     * @return true|false|string
+     */
+    public function unSubscribe($code)
+    {
+        $xpdo = $this->newsletter->xpdo;
+
+        /** @var sxSubscriber $subscriber */
+        if (!$subscriber = $xpdo->getObject('sxSubscriber', array('code' => $code))) {
+            return false;
+        }
+
+        if ((int) $subscriber->get('newsletter_id') !== (int) $this->newsletter->get('id')) {
+            return false;
+        }
+
+        $params = array(
+            'newsletter'    => $this->newsletter,
+            'newsletter_id' => $this->newsletter->id,
+            'user_id'       => $subscriber->get('user_id'),
+            'email'         => $subscriber->get('email'),
+            'code'          => $code,
+            'subscriber'    => $subscriber,
+        );
+
+        $before = sxSendexEvent::invoke($xpdo, 'sxOnBeforeUnsubscribe', $params);
+        if ($before !== true) {
+            return $before;
+        }
+
+        if (!$subscriber->remove()) {
+            return false;
+        }
+
+        sxSendexEvent::invoke($xpdo, 'sxOnUnsubscribe', $params);
+
+        return true;
+    }
+
+    /**
+     * @param int $subscriberId
+     * @param int $userId
+     * @param string $email
+     */
+    protected function attachUserToSubscriber($subscriberId, $userId, $email)
+    {
+        $userId = (int) $userId;
+        if ($userId <= 0 && $email === '') {
+            return;
+        }
+
+        /** @var sxSubscriber $subscriber */
+        $subscriber = $this->newsletter->xpdo->getObject('sxSubscriber', (int) $subscriberId);
+        if (!$subscriber) {
+            return;
+        }
+
+        $changed = false;
+        if ($userId > 0 && (int) $subscriber->get('user_id') === 0) {
+            $subscriber->set('user_id', $userId);
+            $changed = true;
+        }
+        if ($email !== '' && strcasecmp((string) $subscriber->get('email'), $email) !== 0) {
+            if ($userId > 0 && (int) $subscriber->get('user_id') === $userId) {
+                $subscriber->set('email', $email);
+                $changed = true;
+            }
+        }
+
+        if ($changed) {
+            $subscriber->save();
+        }
+    }
+}

--- a/core/components/sendex/model/sendex/sxsendexevent.class.php
+++ b/core/components/sendex/model/sendex/sxsendexevent.class.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Cancelable Sendex system events via modX::invokeEvent.
+ */
+class sxSendexEvent
+{
+    /**
+     * Before-events cancel when a plugin outputs a non-empty string.
+     *
+     * @param object $xpdo
+     * @param string $name
+     * @param array $params
+     * @return true|string true, or first plugin error message if cancelled
+     */
+    public static function invoke($xpdo, $name, array $params)
+    {
+        if (!($xpdo instanceof modX) || !method_exists($xpdo, 'invokeEvent')) {
+            return true;
+        }
+
+        $response = $xpdo->invokeEvent($name, $params);
+        if (is_array($response)) {
+            $messages = array();
+            foreach ($response as $item) {
+                if (is_string($item) && trim($item) !== '') {
+                    $messages[] = trim($item);
+                }
+            }
+            if (!empty($messages)) {
+                return reset($messages);
+            }
+        }
+
+        return true;
+    }
+}

--- a/tests/Unit/NewsletterSplitContractTest.php
+++ b/tests/Unit/NewsletterSplitContractTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Structural contract for #62 split of sxNewsletter.
+ */
+class NewsletterSplitContractTest extends TestCase
+{
+    public function testNewsletterFacadeStaysUnderTwoHundredLines()
+    {
+        $path = dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sxnewsletter.class.php';
+        $lines = count(file($path));
+
+        $this->assertLessThanOrEqual(200, $lines, 'sxNewsletter should stay a thin facade');
+    }
+
+    public function testExtractedFilesStayUnderThreeHundredLines()
+    {
+        $base = dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/';
+        $files = array(
+            'sxnewslettersubscription.class.php',
+            'sxnewsletterqueuebuilder.class.php',
+            'sxsendexevent.class.php',
+        );
+
+        foreach ($files as $file) {
+            $lines = count(file($base . $file));
+            $this->assertLessThanOrEqual(
+                300,
+                $lines,
+                $file . ' should stay under ~300 lines'
+            );
+        }
+    }
+
+    public function testFacadeDelegatesToExtractedClasses()
+    {
+        $facade = file_get_contents(
+            dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sxnewsletter.class.php'
+        );
+
+        $this->assertStringContainsString('sxNewsletterSubscription', $facade);
+        $this->assertStringContainsString('sxNewsletterQueueBuilder', $facade);
+        $this->assertStringContainsString('sxSendexEvent::invoke', $facade);
+        $this->assertStringContainsString('function subscribe(', $facade);
+        $this->assertStringContainsString('function addQueues(', $facade);
+    }
+}


### PR DESCRIPTION
### Кратко

`sxNewsletter` был god-class. Логика подписки и очереди вынесена; публичный API тот же.

## Что сделано
- `sxNewsletterSubscription` — subscribe / unSubscribe / isSubscribed / checkEmail / confirmEmail
- `sxNewsletterQueueBuilder` — addQueues
- `sxSendexEvent` — cancelable invoke
- `sxNewsletter` — thin facade (~88 строк)
- тесты: `NewsletterSplitContractTest` + полный suite
- миграция: не нужна

## Почему так

Code judo из #62. Mailer уже в `Sendex` / `sxQueue` (не в newsletter); единый helper — #66.

## Review
- Medium+: нет

## Проверка
- `composer test` — exit 0 (98; contract + subscribe/events)
- phpcs — exit 0
- размеры: facade 88, subscription 264, queue 106, event 37 (все ≤300)

Fixes #62