### PR TITLE
fix(unsubscribe): Resolve newsletter from subscriber code

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ Policy: **merge**, not block.
 
 Logged-in `isSubscribed($userId)` also matches a still-guest row by profile email, so the form shows unsubscribe without waiting for merge.
 
+### Unsubscribe from email (#56)
+
+The page must call `[[!Sendex? &id=`…`]]` (any newsletter id is fine). Query params:
+
+| Param | Required | Meaning |
+| --- | --- | --- |
+| `sx_action` | yes | `unsubscribe` |
+| `code` | yes | `sxSubscriber.code` |
+| `newsletter_id` | no | Same as newsletter id; avoids confusion with MODX resource `id`. Snippet resolves the owner newsletter from `code` if the snippet `&id` differs. |
+
+Default letter template links to `site_start` with `sx_action`, `newsletter_id`, and `code`.
+
 ## Cron
 
 Process the queue from the site root (or adjust the path):

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Phinx migrations: `core/components/sendex/phinx.php`, `migrations/`, install/upgrade resolver; metadata table `{prefix}sendex_migrations`.
 
 ### Fixed
+- [#56] Unsubscribe from email: snippet resolves newsletter by subscriber `code` when snippet `&id` differs; default letter link includes `newsletter_id` (not MODX resource `id`).
 - [#67] / [#52] Schema and upgrade: Sendex tables use InnoDB; queue index renamed `user_id` → `subscriber_id`; `addQueues` stores `sxSubscriber.id` (not `user_id`); Phinx backfill remaps legacy queue rows (by user_id, guests by email).
 - [#54] `isSubscribed` matches by `user_id` OR `email` within a newsletter; unique key is `(newsletter_id, email)`; guest rows attach `user_id` when the same email confirms as a user.
 - [#39] Guest rows merge onto `modUser` on `OnUserActivate` / `OnBeforeUserActivate` / `OnUserSave` (`sxSubscriberMerge`); registration does not create a second subscriber row for the same email.

--- a/core/components/sendex/elements/snippets/snippet.sendex.php
+++ b/core/components/sendex/elements/snippets/snippet.sendex.php
@@ -15,6 +15,7 @@ if (!($Sendex instanceof Sendex)) {
 }
 
 require_once $corePath . 'model/sendex/sxuserplaceholders.class.php';
+require_once $corePath . 'model/sendex/sxunsubscriberesolve.class.php';
 
 $tplSubscribeAuth = $modx->getOption('tplSubscribeAuth', $scriptProperties, 'tpl.Sendex.subscribe.auth');
 $tplSubscribeGuest = $modx->getOption('tplSubscribeGuest', $scriptProperties, 'tpl.Sendex.subscribe.guest');
@@ -109,7 +110,28 @@ if (!empty($_REQUEST['sx_action'])) {
             break;
         case 'unsubscribe':
             if (!empty($_REQUEST['code'])) {
-                $response = $newsletter->unSubscribe($_REQUEST['code']);
+                $code = $_REQUEST['code'];
+                $target = sxUnsubscribeResolve::forCode($modx, $code, $newsletter);
+                if ($target) {
+                    $newsletter = $target;
+                    $placeholders = array_merge(
+                        $newsletter->toArray(),
+                        array(
+                            'message' => '',
+                            'class'   => '',
+                            'error'   => 0,
+                        )
+                    );
+                    if ($isAuthenticated) {
+                        $profile = $modx->user->getOne('Profile');
+                        $placeholders = sxUserPlaceholders::mergeAuthenticated(
+                            $modx->user->toArray(),
+                            $profile ? $profile->toArray() : null,
+                            $placeholders
+                        );
+                    }
+                }
+                $response = $newsletter->unSubscribe($code);
                 if ($response === true) {
                     $placeholders['message'] = $modx->lexicon('sendex_subscribe_email_unsubscribed');
                     $params['sx_unsubscribed'] = 1;
@@ -120,7 +142,7 @@ if (!empty($_REQUEST['sx_action'])) {
                     $placeholders['error'] = 1;
                 }
             }
-            unset($params['code']);
+            unset($params['code'], $params['newsletter_id']);
             break;
     }
 

--- a/core/components/sendex/elements/templates/template.sendex.tpl
+++ b/core/components/sendex/elements/templates/template.sendex.tpl
@@ -52,9 +52,12 @@
 <hr>
 
 <h1>Link for unsubscribe</h1>
-Link must lead to page with Sendex call and contain right sx_action and user code:<br/>
-<pre>&#91;&#91;~id_of_resource?scheme=`full`&action=`sx_unsubscribe`&code=`&#91;&#91;+subscriber.code&#93;&#93;`&#93;&#93;</pre>
+Link must lead to a page that calls the Sendex snippet. Required query params:
+<code>sx_action=unsubscribe</code>, <code>code</code> (subscriber code). Optional:
+<code>newsletter_id</code> (same as <code>[[+newsletter.id]]</code>; the snippet also resolves the newsletter from <code>code</code> if the snippet <code>&id</code> differs).
+<br/>
+<pre>&#91;&#91;~id_of_resource?scheme=`full`&sx_action=`unsubscribe`&newsletter_id=`&#91;&#91;+newsletter.id&#93;&#93;`&code=`&#91;&#91;+subscriber.code&#93;&#93;`&#93;&#93;</pre>
 
 <br/><br/>
-For example:<br/>
-<a href="[[~[[++site_start]]?scheme=`full`&sx_action=`unsubscribe`&code=`[[+subscriber.code]]`]]">Unsubscribe from this newsletter</a>
+For example (works on site_start even when the snippet &id is another newsletter):<br/>
+<a href="[[~[[++site_start]]?scheme=`full`&sx_action=`unsubscribe`&newsletter_id=`[[+newsletter.id]]`&code=`[[+subscriber.code]]`]]">Unsubscribe from this newsletter</a>

--- a/core/components/sendex/model/sendex/sxunsubscriberesolve.class.php
+++ b/core/components/sendex/model/sendex/sxunsubscriberesolve.class.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Resolve the newsletter that owns an unsubscribe code (#56).
+ */
+class sxUnsubscribeResolve
+{
+    /**
+     * @param object $xpdo
+     * @param string $code
+     * @return int newsletter id or 0
+     */
+    public static function newsletterIdFromCode($xpdo, $code)
+    {
+        $code = is_string($code) ? trim($code) : '';
+        if ($code === '') {
+            return 0;
+        }
+
+        /** @var object|null $subscriber */
+        $subscriber = $xpdo->getObject('sxSubscriber', array('code' => $code));
+        if (!$subscriber) {
+            return 0;
+        }
+
+        return (int) $subscriber->get('newsletter_id');
+    }
+
+    /**
+     * Prefer the newsletter that owns $code; keep $fallback when it already matches.
+     *
+     * @param object $xpdo
+     * @param string $code
+     * @param object|null $fallbackNewsletter sxNewsletter
+     * @return object|null
+     */
+    public static function forCode($xpdo, $code, $fallbackNewsletter = null)
+    {
+        $newsletterId = self::newsletterIdFromCode($xpdo, $code);
+        if ($newsletterId <= 0) {
+            return $fallbackNewsletter;
+        }
+
+        if (
+            $fallbackNewsletter !== null
+            && (int) $fallbackNewsletter->get('id') === $newsletterId
+        ) {
+            return $fallbackNewsletter;
+        }
+
+        return $xpdo->getObject('sxNewsletter', $newsletterId);
+    }
+}

--- a/tests/Unit/UnsubscribeResolveTest.php
+++ b/tests/Unit/UnsubscribeResolveTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sxunsubscriberesolve.class.php';
+
+class UnsubscribeResolveTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+    }
+
+    public function testNewsletterIdFromCode()
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 7,
+            'user_id'       => 0,
+            'email'         => 'a@example.com',
+            'code'          => 'abc123',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $this->assertSame(7, sxUnsubscribeResolve::newsletterIdFromCode($this->modx, 'abc123'));
+        $this->assertSame(0, sxUnsubscribeResolve::newsletterIdFromCode($this->modx, 'missing'));
+        $this->assertSame(0, sxUnsubscribeResolve::newsletterIdFromCode($this->modx, ''));
+    }
+
+    public function testForCodeKeepsMatchingFallback()
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'code'          => 'same',
+            'email'         => 'a@example.com',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $newsletter = new TestableNewsletter($this->modx);
+        $newsletter->set('id', 10);
+
+        $resolved = sxUnsubscribeResolve::forCode($this->modx, 'same', $newsletter);
+        $this->assertSame($newsletter, $resolved);
+    }
+
+    public function testForCodeLoadsOwnerWhenSnippetIdDiffers()
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 22,
+            'code'          => 'cross',
+            'email'         => 'a@example.com',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $owner = new TestableNewsletter($this->modx);
+        $owner->set('id', 22);
+        $this->modx->newsletters[22] = $owner;
+
+        $snippetNewsletter = new TestableNewsletter($this->modx);
+        $snippetNewsletter->set('id', 1);
+
+        $resolved = sxUnsubscribeResolve::forCode($this->modx, 'cross', $snippetNewsletter);
+        $this->assertSame($owner, $resolved);
+        $this->assertSame(22, (int) $resolved->get('id'));
+    }
+
+    public function testTemplateIncludesNewsletterIdQueryParam()
+    {
+        $template = file_get_contents(
+            dirname(__DIR__, 2) . '/core/components/sendex/elements/templates/template.sendex.tpl'
+        );
+
+        $this->assertStringContainsString('sx_action=`unsubscribe`', $template);
+        $this->assertStringContainsString('newsletter_id=`[[+newsletter.id]]`', $template);
+        $this->assertStringContainsString('code=`[[+subscriber.code]]`', $template);
+    }
+
+    public function testSnippetResolvesByCodeBeforeUnsubscribe()
+    {
+        $snippet = file_get_contents(
+            dirname(__DIR__, 2) . '/core/components/sendex/elements/snippets/snippet.sendex.php'
+        );
+
+        $this->assertStringContainsString('sxUnsubscribeResolve::forCode', $snippet);
+        $this->assertStringContainsString("case 'unsubscribe':", $snippet);
+    }
+}


### PR DESCRIPTION
### Кратко

Ссылка отписки на `site_start` с чужим snippet `&id` больше не ломается: сниппет берёт рассылку по `code`.

## Что сделано
- `sxUnsubscribeResolve` — newsletter id / объект по `code`
- snippet: перед `unSubscribe` резолв владельца кода
- шаблон письма: `newsletter_id` + `code` + `sx_action` (не MODX resource `id`)
- README: контракт query-параметров
- тесты: `UnsubscribeResolveTest`
- миграция: не нужна

## Review
- Medium+: нет

## Проверка
- `composer test` — exit 0 (103; `UnsubscribeResolveTest`)
- phpcs — exit 0

Fixes #56