### PR TITLE
fix(queue): Reject addQueues success when zero rows created

### DIFF
--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Phinx migrations: `core/components/sendex/phinx.php`, `migrations/`, install/upgrade resolver; metadata table `{prefix}sendex_migrations`.
 
 ### Fixed
+- [#57] `addQueues` returns an error when 0 queue rows were created (all subscribers skipped); mgr `queue/add` reports the created count on success.
 - [#55] Queue send claims the row (remove-before-send) so parallel cron/mgr workers do not double-deliver; mail failure requeues and logs; cron logs non-true `send()` results.
 - [#56] Unsubscribe from email: snippet resolves newsletter by subscriber `code` when snippet `&id` differs; default letter link includes `newsletter_id` (not MODX resource `id`).
 - [#67] / [#52] Schema and upgrade: Sendex tables use InnoDB; queue index renamed `user_id` → `subscriber_id`; `addQueues` stores `sxSubscriber.id` (not `user_id`); Phinx backfill remaps legacy queue rows (by user_id, guests by email).

--- a/core/components/sendex/lexicon/en/default.inc.php
+++ b/core/components/sendex/lexicon/en/default.inc.php
@@ -29,6 +29,8 @@ $_lang['sendex_newsletter_err_remove'] = 'An error occurred while trying to remo
 $_lang['sendex_newsletter_err_save'] = 'An error occurred while trying to save the newsletter.';
 $_lang['sendex_newsletter_err_no_subscribers'] = 'This newsletter has no subscribers.';
 $_lang['sendex_newsletter_err_no_template'] = 'This newsletter has no template.';
+$_lang['sendex_newsletter_err_no_queues'] = 'No letters were added to the queue (0 rows).';
+$_lang['sendex_newsletter_queues_added'] = 'Added [[+count]] letter(s) to the queue.';
 $_lang['sendex_newsletter_err_template'] = 'You must select template.';
 
 $_lang['sendex_newsletters_remove'] = 'Remove newsletters';

--- a/core/components/sendex/lexicon/ru/default.inc.php
+++ b/core/components/sendex/lexicon/ru/default.inc.php
@@ -29,6 +29,8 @@ $_lang['sendex_newsletter_err_remove'] = 'Ошибка при удалении �
 $_lang['sendex_newsletter_err_save'] = 'Ошибка при сохранении подписки.';
 $_lang['sendex_newsletter_err_no_subscribers'] = 'У этой рассылки нет подписчиков.';
 $_lang['sendex_newsletter_err_no_template'] = 'У этой рассылки нет шаблона.';
+$_lang['sendex_newsletter_err_no_queues'] = 'В очередь не добавлено ни одного письма (0 строк).';
+$_lang['sendex_newsletter_queues_added'] = 'В очередь добавлено писем: [[+count]].';
 $_lang['sendex_newsletter_err_template'] = 'Вы должны выбрать шаблон.';
 
 $_lang['sendex_newsletters_remove'] = 'Удалить подписки';

--- a/core/components/sendex/model/sendex/sxnewsletter.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletter.class.php
@@ -10,7 +10,7 @@ require_once dirname(__FILE__) . '/sxsendexevent.class.php';
 class sxNewsletter extends xPDOSimpleObject
 {
     /**
-     * @return bool|mixed|string
+     * @return int|string
      */
     public function addQueues()
     {

--- a/core/components/sendex/model/sendex/sxnewsletterqueuebuilder.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletterqueuebuilder.class.php
@@ -19,7 +19,7 @@ class sxNewsletterQueueBuilder
     }
 
     /**
-     * @return bool|mixed|string
+     * @return int|string Number of queue rows created, or lexicon error key/message
      */
     public function addQueues()
     {
@@ -46,6 +46,9 @@ class sxNewsletterQueueBuilder
         if (!$template || !($template instanceof modTemplate)) {
             return $xpdo->lexicon('sendex_newsletter_err_no_template');
         }
+
+        $newsletterId = (int) $newsletter->id;
+        $before = (int) $xpdo->getCount('sxQueue', array('newsletter_id' => $newsletterId));
 
         /** @var sxSubscriber $subscriber */
         foreach ($subscribers as $subscriber) {
@@ -90,7 +93,7 @@ class sxNewsletterQueueBuilder
             $queue = $xpdo->newObject('sxQueue');
             $queue->fromArray(array(
                 'subscriber_id'   => sxQueueLink::subscriberIdFromSubscriber($subscriber),
-                'newsletter_id'   => $newsletter->id,
+                'newsletter_id'   => $newsletterId,
                 'email_to'        => $email,
                 'email_subject'   => $subject,
                 'email_body'      => $body,
@@ -101,6 +104,11 @@ class sxNewsletterQueueBuilder
             $queue->save();
         }
 
-        return true;
+        $created = (int) $xpdo->getCount('sxQueue', array('newsletter_id' => $newsletterId)) - $before;
+        if ($created <= 0) {
+            return $xpdo->lexicon('sendex_newsletter_err_no_queues');
+        }
+
+        return $created;
     }
 }

--- a/core/components/sendex/processors/mgr/queue/add.class.php
+++ b/core/components/sendex/processors/mgr/queue/add.class.php
@@ -21,11 +21,14 @@ class sxQueueAddProcessor extends modProcessor
 
         /** @var sxNewsletter $newsletter */
         $result = $newsletter->addQueues();
-        if ($result !== true) {
+        if (!is_int($result)) {
             return $this->failure($result);
-        } else {
-            return $this->success();
         }
+
+        return $this->success(
+            $this->modx->lexicon('sendex_newsletter_queues_added', array('count' => $result)),
+            array('count' => $result)
+        );
     }
 }
 

--- a/tests/Stubs/FakeModX.php
+++ b/tests/Stubs/FakeModX.php
@@ -90,12 +90,22 @@ class FakeModX extends modX
 
     /**
      * @param string $key
+     * @param array $params
      *
      * @return string
      */
-    public function lexicon($key)
+    public function lexicon($key, $params = array())
     {
-        return $key;
+        if (!is_array($params) || $params === array()) {
+            return $key;
+        }
+
+        $out = $key;
+        foreach ($params as $name => $value) {
+            $out .= ':' . $name . '=' . $value;
+        }
+
+        return $out;
     }
 
     /**
@@ -299,6 +309,24 @@ class FakeModX extends modX
      */
     public function getCount($class, $criteria = array())
     {
+        if ($class === 'sxQueue') {
+            $count = 0;
+            foreach ($this->queues as $queue) {
+                $match = true;
+                foreach ($criteria as $key => $value) {
+                    if ((string) $queue->get($key) !== (string) $value) {
+                        $match = false;
+                        break;
+                    }
+                }
+                if ($match) {
+                    $count++;
+                }
+            }
+
+            return $count;
+        }
+
         if ($class !== 'sxSubscriber') {
             return 0;
         }

--- a/tests/Unit/NewsletterAddQueuesTest.php
+++ b/tests/Unit/NewsletterAddQueuesTest.php
@@ -60,7 +60,7 @@ class NewsletterAddQueuesTest extends TestCase
         ));
         $this->modx->subscribers[] = $subscriber;
 
-        $this->assertTrue($this->newsletter->addQueues());
+        $this->assertSame(1, $this->newsletter->addQueues());
         $this->assertCount(1, $this->modx->queues);
         $this->assertSame('guest@example.com', $this->modx->queues[0]->get('email_to'));
         $this->assertSame('Hello', $this->modx->queues[0]->get('email_subject'));
@@ -83,7 +83,7 @@ class NewsletterAddQueuesTest extends TestCase
         $user->active = true;
         $this->modx->users[5] = $user;
 
-        $this->assertTrue($this->newsletter->addQueues());
+        $this->assertSame('sendex_newsletter_err_no_queues', $this->newsletter->addQueues());
         $this->assertCount(0, $this->modx->queues);
     }
 
@@ -108,7 +108,7 @@ class NewsletterAddQueuesTest extends TestCase
         $profile->set('email', 'user@example.com');
         $this->modx->userProfiles[5] = $profile;
 
-        $this->assertTrue($this->newsletter->addQueues());
+        $this->assertSame('sendex_newsletter_err_no_queues', $this->newsletter->addQueues());
         $this->assertCount(0, $this->modx->queues);
     }
 
@@ -133,7 +133,7 @@ class NewsletterAddQueuesTest extends TestCase
         $profile->set('email', 'user@example.com');
         $this->modx->userProfiles[5] = $profile;
 
-        $this->assertTrue($this->newsletter->addQueues());
+        $this->assertSame(1, $this->newsletter->addQueues());
         $this->assertCount(1, $this->modx->queues);
         $this->assertSame('Body for user@example.com', $this->modx->queues[0]->get('email_body'));
         // Must be sxSubscriber.id (1), not modUser.id (5)

--- a/tests/Unit/QueueAddProcessorTest.php
+++ b/tests/Unit/QueueAddProcessorTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class QueueAddProcessorTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+        require_once dirname(__DIR__, 2)
+            . '/core/components/sendex/processors/mgr/queue/add.class.php';
+    }
+
+    public function testFailureWhenNoQueuesCreated()
+    {
+        $newsletter = new TestableNewsletter($this->modx);
+        $newsletter->set('id', 10);
+        $newsletter->set('template', 1);
+        $this->modx->newsletters[10] = $newsletter;
+        $this->modx->templates[1] = new modTemplate();
+
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 5,
+            'email'         => 'user@example.com',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $user = new modUser($this->modx);
+        $user->set('id', 5);
+        $user->active = true;
+        $this->modx->users[5] = $user;
+
+        $processor = new sxQueueAddProcessor($this->modx, array('newsletter_id' => 10));
+        $response = $processor->process();
+
+        $this->assertFalse($response['success']);
+        $this->assertSame('sendex_newsletter_err_no_queues', $response['message']);
+    }
+
+    public function testSuccessReportsCreatedCount()
+    {
+        $newsletter = new TestableNewsletter($this->modx);
+        $newsletter->set('id', 10);
+        $newsletter->set('template', 1);
+        $newsletter->set('email_subject', 'Hello');
+        $newsletter->set('email_from', 'from@example.com');
+        $this->modx->newsletters[10] = $newsletter;
+        $this->modx->templates[1] = new modTemplate();
+
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 0,
+            'email'         => 'guest@example.com',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $processor = new sxQueueAddProcessor($this->modx, array('newsletter_id' => 10));
+        $response = $processor->process();
+
+        $this->assertTrue($response['success']);
+        $this->assertSame(1, $response['object']['count']);
+        $this->assertStringContainsString('count=1', $response['message']);
+    }
+}


### PR DESCRIPTION
### Кратко

Пустая постановка в очередь больше не даёт success «отправлено»: 0 строк → failure с явным сообщением.

## Что сделано
- `addQueues` считает новые `sxQueue` и при 0 возвращает `sendex_newsletter_err_no_queues`
- при успехе возвращает int count; processor пишет `sendex_newsletter_queues_added`
- lexicons en/ru
- тесты: `NewsletterAddQueuesTest`, `QueueAddProcessorTest`
- миграция: не нужна

## Review
- Medium+: нет

## Проверка
- `composer test` — exit 0 (113)
- phpcs — exit 0

Fixes #57