### PR TITLE
refactor(queue): Unify delivery in sxQueueSender flush/sendOne

### DIFF
--- a/core/components/sendex/cron/send.php
+++ b/core/components/sendex/cron/send.php
@@ -3,21 +3,11 @@
 require_once dirname(dirname(dirname(dirname(dirname(__FILE__))))) . '/config.core.php';
 require_once MODX_CORE_PATH . 'config/' . MODX_CONFIG_KEY . '.inc.php';
 require_once MODX_CONNECTORS_PATH . 'index.php';
+require_once MODX_CORE_PATH . 'components/sendex/model/sendex/sxqueuesender.class.php';
 
 $modx->addPackage('sendex', MODX_CORE_PATH . 'components/sendex/model/');
 
-$q = $modx->newQuery('sxQueue');
-$q->limit($modx->getOption('sendex_queue_limit', null, 100, true));
-
-$queue = $modx->getCollection('sxQueue', $q);
-/** @var sxQueue $email */
-foreach ($queue as $email) {
-    $result = $email->send();
-    if ($result !== true) {
-        $modx->log(
-            modX::LOG_LEVEL_ERROR,
-            '[Sendex] queue id ' . $email->get('id') . ': '
-                . (is_string($result) ? $result : 'send skipped or failed')
-        );
-    }
-}
+sxQueueSender::flush($modx, array(
+    'limit'     => $modx->getOption('sendex_queue_limit', null, 100, true),
+    'logErrors' => true,
+));

--- a/core/components/sendex/cron/send.php
+++ b/core/components/sendex/cron/send.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once dirname(dirname(dirname(dirname(dirname(__FILE__))))) . '/config.core.php';
+require_once dirname(__FILE__, 5) . '/config.core.php';
 require_once MODX_CORE_PATH . 'config/' . MODX_CONFIG_KEY . '.inc.php';
 require_once MODX_CONNECTORS_PATH . 'index.php';
 require_once MODX_CORE_PATH . 'components/sendex/model/sendex/sxqueuesender.class.php';

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHP 7.4–8.4: dynamic properties, null Profile in `addQueues`, PHPMailer `ErrorInfo`.
 
 ### Changed
+- [#65] Queue delivery unified in `sxQueueSender` (`sendOne` / `flush`); cron and mgr send processors delegate to it (claim + log from #55).
 - [#62] Split `sxNewsletter` into `sxNewsletterSubscription`, `sxNewsletterQueueBuilder`, `sxSendexEvent`; model keeps a thin public API for processors/snippet.
 - **Breaking (DB):** existing `sendex_*` tables are converted to InnoDB on upgrade; queue `subscriber_id` meaning is `sxSubscriber.id` after backfill (join Queue→Subscriber for guests works). Soft FK to core `modUser` tables are not added.
 - `add_group` processor requires `edit_document` permission.

--- a/core/components/sendex/model/sendex/sxqueue.class.php
+++ b/core/components/sendex/model/sendex/sxqueue.class.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once dirname(__FILE__) . '/sxqueuedeliver.class.php';
+require_once dirname(__FILE__) . '/sxqueuesender.class.php';
 
 class sxQueue extends xPDOSimpleObject
 {
@@ -38,30 +38,6 @@ class sxQueue extends xPDOSimpleObject
      */
     public function send()
     {
-        $queue = $this;
-
-        return sxQueueDeliver::send($this, function () use ($queue) {
-            /** @var modPHPMailer $mail */
-            $mail = $queue->xpdo->getService('mail', 'mail.modPHPMailer');
-            $mail->set(modMail::MAIL_BODY, $queue->email_body);
-            $mail->set(modMail::MAIL_FROM, $queue->email_from);
-            $mail->set(modMail::MAIL_FROM_NAME, $queue->email_from_name);
-            $mail->set(modMail::MAIL_SUBJECT, $queue->email_subject);
-            $mail->address('to', $queue->email_to);
-            $mail->address('reply-to', $queue->email_reply);
-            $mail->setHTML(true);
-            if (!$mail->send()) {
-                $queue->xpdo->log(
-                    xPDO::LOG_LEVEL_ERROR,
-                    'An error occurred while trying to send the email: '
-                        . $mail->mailer->ErrorInfo
-                );
-                $mail->reset();
-                return $mail->mailer->ErrorInfo;
-            }
-
-            $mail->reset();
-            return true;
-        });
+        return sxQueueSender::sendOne($this);
     }
 }

--- a/core/components/sendex/model/sendex/sxqueuesender.class.php
+++ b/core/components/sendex/model/sendex/sxqueuesender.class.php
@@ -1,0 +1,137 @@
+<?php
+
+require_once dirname(__FILE__) . '/sxqueuedeliver.class.php';
+
+/**
+ * Single entry point for queue delivery (#65): cron and mgr processors call flush/sendOne.
+ */
+class sxQueueSender
+{
+    /**
+     * Claim, send mail, requeue on failure (#55).
+     *
+     * @param object $queue sxQueue
+     * @return true|false|string
+     */
+    public static function sendOne($queue)
+    {
+        return sxQueueDeliver::send($queue, array(__CLASS__, 'deliverMail'));
+    }
+
+    /**
+     * Send a batch of queue rows.
+     *
+     * Options:
+     * - criteria (array): xPDO where, e.g. array('id:IN' => array(1, 2))
+     * - limit (int): max rows (cron)
+     * - stopOnError (bool): mgr processors stop on first mail error
+     * - logErrors (bool): cron-style error log for non-true results
+     * - sendFn (callable): test hook; defaults to sendOne
+     *
+     * @param object $xpdo modX / xPDO
+     * @param array $options
+     * @return array{sent:int,skipped:int,failed:int,firstError:string|null}
+     */
+    public static function flush($xpdo, array $options = array())
+    {
+        $stopOnError = !empty($options['stopOnError']);
+        $logErrors = !empty($options['logErrors']);
+        $sendFn = isset($options['sendFn']) && is_callable($options['sendFn'])
+            ? $options['sendFn']
+            : array(__CLASS__, 'sendOne');
+
+        $query = $xpdo->newQuery('sxQueue');
+        if (!empty($options['criteria']) && is_array($options['criteria'])) {
+            $query->where($options['criteria']);
+        }
+        if (isset($options['limit']) && (int) $options['limit'] > 0) {
+            $query->limit((int) $options['limit']);
+        }
+
+        $queues = $xpdo->getCollection('sxQueue', $query);
+        $stats = array(
+            'sent'       => 0,
+            'skipped'    => 0,
+            'failed'     => 0,
+            'firstError' => null,
+        );
+
+        foreach ($queues as $queue) {
+            $result = call_user_func($sendFn, $queue);
+            if ($result === true) {
+                $stats['sent']++;
+                continue;
+            }
+
+            if ($result === false) {
+                $stats['skipped']++;
+            } else {
+                $stats['failed']++;
+            }
+
+            $message = is_string($result) ? $result : 'send skipped or failed';
+            if ($stats['firstError'] === null) {
+                $stats['firstError'] = $message;
+            }
+
+            if ($logErrors && method_exists($xpdo, 'log')) {
+                $xpdo->log(
+                    self::logLevelError(),
+                    '[Sendex] queue id ' . $queue->get('id') . ': ' . $message
+                );
+            }
+
+            if ($stopOnError) {
+                break;
+            }
+        }
+
+        return $stats;
+    }
+
+    /**
+     * @param object $queue sxQueue
+     * @return true|string
+     */
+    public static function deliverMail($queue)
+    {
+        /** @var modPHPMailer $mail */
+        $mail = $queue->xpdo->getService('mail', 'mail.modPHPMailer');
+        $mail->set(modMail::MAIL_BODY, $queue->email_body);
+        $mail->set(modMail::MAIL_FROM, $queue->email_from);
+        $mail->set(modMail::MAIL_FROM_NAME, $queue->email_from_name);
+        $mail->set(modMail::MAIL_SUBJECT, $queue->email_subject);
+        $mail->address('to', $queue->email_to);
+        $mail->address('reply-to', $queue->email_reply);
+        $mail->setHTML(true);
+        if (!$mail->send()) {
+            $error = $mail->mailer->ErrorInfo;
+            $queue->xpdo->log(
+                xPDO::LOG_LEVEL_ERROR,
+                'An error occurred while trying to send the email: ' . $error
+            );
+            $mail->reset();
+
+            return $error;
+        }
+
+        $mail->reset();
+
+        return true;
+    }
+
+    /**
+     * @return int
+     */
+    protected static function logLevelError()
+    {
+        if (class_exists('modX', false) && defined('modX::LOG_LEVEL_ERROR')) {
+            return constant('modX::LOG_LEVEL_ERROR');
+        }
+        if (defined('xPDO::LOG_LEVEL_ERROR')) {
+            return constant('xPDO::LOG_LEVEL_ERROR');
+        }
+
+        return 3;
+    }
+}

--- a/core/components/sendex/processors/mgr/queue/send.class.php
+++ b/core/components/sendex/processors/mgr/queue/send.class.php
@@ -1,9 +1,11 @@
 <?php
 
-/**
- * Send an Queue
- */
+require_once dirname(dirname(dirname(dirname(__FILE__))))
+    . '/model/sendex/sxqueuesender.class.php';
 
+/**
+ * Send queue rows by id (mgr).
+ */
 class sxQueueSendProcessor extends modProcessor
 {
     public $classKey = 'sxQueue';
@@ -12,17 +14,18 @@ class sxQueueSendProcessor extends modProcessor
     /** {inheritDoc} */
     public function process()
     {
-        if (!$ids = explode(',', $this->getProperty('ids'))) {
+        $ids = explode(',', (string) $this->getProperty('ids'));
+        if (!$ids || $ids === array('')) {
             return $this->failure($this->modx->lexicon('sendex_queue_err_ns'));
         }
 
-        $queues = $this->modx->getIterator($this->classKey, array('id:IN' => $ids));
-        /** @var sxQueue $queue */
-        foreach ($queues as $queue) {
-            $result = $queue->send();
-            if ($result !== true) {
-                return $this->failure($result);
-            }
+        $stats = sxQueueSender::flush($this->modx, array(
+            'criteria'    => array('id:IN' => $ids),
+            'stopOnError' => true,
+        ));
+
+        if ($stats['firstError'] !== null) {
+            return $this->failure($stats['firstError']);
         }
 
         return $this->success();

--- a/core/components/sendex/processors/mgr/queue/send_all.class.php
+++ b/core/components/sendex/processors/mgr/queue/send_all.class.php
@@ -1,9 +1,11 @@
 <?php
 
-/**
- * Send an Queue
- */
+require_once dirname(dirname(dirname(dirname(__FILE__))))
+    . '/model/sendex/sxqueuesender.class.php';
 
+/**
+ * Send all queue rows (mgr).
+ */
 class sxQueueSendAllProcessor extends modProcessor
 {
     public $objectType = 'sxQueue';
@@ -13,13 +15,12 @@ class sxQueueSendAllProcessor extends modProcessor
     /** {inheritDoc} */
     public function process()
     {
-        $queues = $this->modx->getIterator($this->classKey);
-        /** @var sxQueue $queue */
-        foreach ($queues as $queue) {
-            $result = $queue->send();
-            if ($result !== true) {
-                return $this->failure($result);
-            }
+        $stats = sxQueueSender::flush($this->modx, array(
+            'stopOnError' => true,
+        ));
+
+        if ($stats['firstError'] !== null) {
+            return $this->failure($stats['firstError']);
         }
 
         return $this->success();

--- a/tests/Stubs/FakeMail.php
+++ b/tests/Stubs/FakeMail.php
@@ -1,0 +1,54 @@
+<?php
+
+class FakeMail
+{
+    /** @var bool */
+    public $sendResult = true;
+
+    /** @var string */
+    public $errorInfo = 'SMTP down';
+
+    /** @var stdClass */
+    public $mailer;
+
+    public function __construct()
+    {
+        $this->mailer = new stdClass();
+        $this->mailer->ErrorInfo = $this->errorInfo;
+    }
+
+    /**
+     * @param mixed $key
+     * @param mixed $value
+     */
+    public function set($key, $value)
+    {
+    }
+
+    /**
+     * @param string $type
+     * @param string $address
+     */
+    public function address($type, $address)
+    {
+    }
+
+    /**
+     * @param bool $html
+     */
+    public function setHTML($html)
+    {
+    }
+
+    /**
+     * @return bool
+     */
+    public function send()
+    {
+        return $this->sendResult;
+    }
+
+    public function reset()
+    {
+    }
+}

--- a/tests/Stubs/FakeModX.php
+++ b/tests/Stubs/FakeModX.php
@@ -117,6 +117,14 @@ class FakeModX extends modX
      */
     public function getService($name, $class = '', $path = '')
     {
+        if ($name === 'mail') {
+            if (!isset($this->services['mail'])) {
+                $this->services['mail'] = new FakeMail();
+            }
+
+            return $this->services['mail'];
+        }
+
         return isset($this->services[$name]) ? $this->services[$name] : null;
     }
 
@@ -280,6 +288,10 @@ class FakeModX extends modX
      */
     public function getCollection($class, $criteria = null)
     {
+        if ($class === 'sxQueue') {
+            return $this->queueCollection($criteria);
+        }
+
         if ($class !== 'sxSubscriber') {
             return array();
         }
@@ -296,6 +308,42 @@ class FakeModX extends modX
             if ($where === array() || sxSubscriberMatch::matchesWhere($where, $subscriber)) {
                 $out[] = $subscriber;
             }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param FakeQuery|array|null $criteria
+     *
+     * @return sxQueue[]
+     */
+    protected function queueCollection($criteria)
+    {
+        $where = array();
+        $limit = null;
+        if ($criteria instanceof FakeQuery) {
+            $where = $criteria->where;
+            $limit = $criteria->limit;
+        } elseif (is_array($criteria)) {
+            $where = $criteria;
+        }
+
+        $ids = array();
+        if (isset($where['id:IN']) && is_array($where['id:IN'])) {
+            $ids = array_map('intval', $where['id:IN']);
+        }
+
+        $out = array();
+        foreach ($this->queues as $queue) {
+            if ($ids && !in_array((int) $queue->get('id'), $ids, true)) {
+                continue;
+            }
+            $out[] = $queue;
+        }
+
+        if ($limit !== null && $limit > 0) {
+            $out = array_slice($out, 0, $limit);
         }
 
         return $out;

--- a/tests/Stubs/FakeQuery.php
+++ b/tests/Stubs/FakeQuery.php
@@ -8,6 +8,9 @@ class FakeQuery
     /** @var array */
     public $where = array();
 
+    /** @var int|null */
+    public $limit;
+
     /**
      * @param string $class
      * @param array|null $criteria
@@ -18,6 +21,18 @@ class FakeQuery
         if (is_array($criteria)) {
             $this->where = $criteria;
         }
+    }
+
+    /**
+     * @param int $limit
+     *
+     * @return self
+     */
+    public function limit($limit)
+    {
+        $this->limit = (int) $limit;
+
+        return $this;
     }
 
     /**

--- a/tests/Stubs/modMail.php
+++ b/tests/Stubs/modMail.php
@@ -1,0 +1,9 @@
+<?php
+
+class modMail
+{
+    const MAIL_BODY = 'body';
+    const MAIL_FROM = 'from';
+    const MAIL_FROM_NAME = 'from_name';
+    const MAIL_SUBJECT = 'subject';
+}

--- a/tests/Stubs/sxQueue.php
+++ b/tests/Stubs/sxQueue.php
@@ -66,4 +66,12 @@ class sxQueue extends xPDOSimpleObject
 
         return true;
     }
+
+    /**
+     * @return true|false|string
+     */
+    public function send()
+    {
+        return sxQueueSender::sendOne($this);
+    }
 }

--- a/tests/Stubs/xPDO.php
+++ b/tests/Stubs/xPDO.php
@@ -1,0 +1,6 @@
+<?php
+
+class xPDO
+{
+    const LOG_LEVEL_ERROR = 3;
+}

--- a/tests/Unit/QueueSendProcessorTest.php
+++ b/tests/Unit/QueueSendProcessorTest.php
@@ -1,0 +1,113 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class QueueSendProcessorTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+        require_once dirname(__DIR__, 2)
+            . '/core/components/sendex/processors/mgr/queue/send.class.php';
+        require_once dirname(__DIR__, 2)
+            . '/core/components/sendex/processors/mgr/queue/send_all.class.php';
+    }
+
+    public function testSendProcessorRequiresIds()
+    {
+        $processor = new sxQueueSendProcessor($this->modx, array('ids' => ''));
+        $response = $processor->process();
+
+        $this->assertFalse($response['success']);
+        $this->assertSame('sendex_queue_err_ns', $response['message']);
+    }
+
+    public function testSendProcessorFailsOnMailError()
+    {
+        $this->addQueue(7);
+        /** @var FakeMail $mail */
+        $mail = $this->modx->getService('mail');
+        $mail->sendResult = false;
+        $mail->mailer->ErrorInfo = 'SMTP down';
+
+        $processor = new sxQueueSendProcessor($this->modx, array('ids' => '7'));
+        $response = $processor->process();
+
+        $this->assertFalse($response['success']);
+        $this->assertSame('SMTP down', $response['message']);
+    }
+
+    public function testSendAllProcessorFailsOnFirstError()
+    {
+        $this->addQueue(1);
+        $this->addQueue(2);
+        /** @var FakeMail $mail */
+        $mail = $this->modx->getService('mail');
+        $mail->sendResult = false;
+        $mail->mailer->ErrorInfo = 'boom';
+
+        $processor = new sxQueueSendAllProcessor($this->modx);
+        $response = $processor->process();
+
+        $this->assertFalse($response['success']);
+        $this->assertSame('boom', $response['message']);
+        $this->assertTrue($this->hasQueueId(2), 'stopOnError must not send the second row');
+    }
+
+    public function testProcessorsDelegateToQueueSender()
+    {
+        $send = file_get_contents(
+            dirname(__DIR__, 2) . '/core/components/sendex/processors/mgr/queue/send.class.php'
+        );
+        $sendAll = file_get_contents(
+            dirname(__DIR__, 2) . '/core/components/sendex/processors/mgr/queue/send_all.class.php'
+        );
+        $cron = file_get_contents(
+            dirname(__DIR__, 2) . '/core/components/sendex/cron/send.php'
+        );
+
+        $this->assertStringContainsString('sxQueueSender::flush', $send);
+        $this->assertStringContainsString('sxQueueSender::flush', $sendAll);
+        $this->assertStringContainsString('sxQueueSender::flush', $cron);
+        $this->assertStringNotContainsString('$queue->send()', $send);
+        $this->assertStringNotContainsString('$queue->send()', $sendAll);
+    }
+
+    /**
+     * @param int $id
+     */
+    private function addQueue($id)
+    {
+        $queue = new sxQueue($this->modx);
+        $queue->fromArray(array(
+            'id'              => $id,
+            'newsletter_id'   => 1,
+            'subscriber_id'   => 1,
+            'email_to'        => 'user' . $id . '@example.com',
+            'email_subject'   => 'Hi',
+            'email_body'      => 'Body',
+            'email_from'      => 'from@example.com',
+            'email_from_name' => 'From',
+            'email_reply'     => 'from@example.com',
+        ));
+        $this->modx->queues[] = $queue;
+    }
+
+    /**
+     * @param int $id
+     * @return bool
+     */
+    private function hasQueueId($id)
+    {
+        foreach ($this->modx->queues as $queue) {
+            if ((int) $queue->get('id') === $id) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Unit/QueueSenderTest.php
+++ b/tests/Unit/QueueSenderTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sxqueuesender.class.php';
+
+class QueueSenderTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+    }
+
+    public function testFlushCronStyleContinuesAfterFailure()
+    {
+        $this->addQueue(1);
+        $this->addQueue(2);
+
+        $calls = 0;
+        $stats = sxQueueSender::flush($this->modx, array(
+            'sendFn' => function () use (&$calls) {
+                $calls++;
+                if ($calls === 1) {
+                    return 'SMTP down';
+                }
+
+                return true;
+            },
+        ));
+
+        $this->assertSame(1, $stats['sent']);
+        $this->assertSame(1, $stats['failed']);
+        $this->assertSame('SMTP down', $stats['firstError']);
+        $this->assertSame(2, $calls);
+    }
+
+    public function testFlushStopOnErrorBreaksEarly()
+    {
+        $this->addQueue(1);
+        $this->addQueue(2);
+
+        $calls = 0;
+        $stats = sxQueueSender::flush($this->modx, array(
+            'stopOnError' => true,
+            'sendFn'    => function () use (&$calls) {
+                $calls++;
+
+                return 'fail';
+            },
+        ));
+
+        $this->assertSame(1, $stats['failed']);
+        $this->assertSame('fail', $stats['firstError']);
+        $this->assertSame(1, $calls);
+    }
+
+    public function testFlushRespectsLimitAndCriteria()
+    {
+        $this->addQueue(1);
+        $this->addQueue(2);
+        $this->addQueue(3);
+
+        $seen = array();
+        sxQueueSender::flush($this->modx, array(
+            'criteria' => array('id:IN' => array(1, 3)),
+            'limit'    => 1,
+            'sendFn'   => function ($queue) use (&$seen) {
+                $seen[] = (int) $queue->get('id');
+
+                return true;
+            },
+        ));
+
+        $this->assertSame(array(1), $seen);
+    }
+
+    public function testFlushLogsNonTrueResultsWhenRequested()
+    {
+        $this->addQueue(5);
+
+        sxQueueSender::flush($this->modx, array(
+            'logErrors' => true,
+            'sendFn'    => function () {
+                return false;
+            },
+        ));
+
+        $this->assertCount(1, $this->modx->logs);
+        $this->assertStringContainsString('queue id 5', $this->modx->logs[0][1]);
+        $this->assertStringContainsString('send skipped or failed', $this->modx->logs[0][1]);
+    }
+
+    /**
+     * @param int $id
+     */
+    private function addQueue($id)
+    {
+        $queue = new sxQueue($this->modx);
+        $queue->fromArray(array(
+            'id'              => $id,
+            'newsletter_id'   => 1,
+            'subscriber_id'   => 1,
+            'email_to'        => 'user' . $id . '@example.com',
+            'email_subject'   => 'Hi',
+            'email_body'      => 'Body',
+            'email_from'      => 'from@example.com',
+            'email_from_name' => 'From',
+            'email_reply'     => 'from@example.com',
+        ));
+        $this->modx->queues[] = $queue;
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,12 +11,16 @@ require_once __DIR__ . '/Stubs/modTemplate.php';
 require_once __DIR__ . '/Stubs/modParser.php';
 require_once __DIR__ . '/Stubs/FakeRegister.php';
 require_once __DIR__ . '/Stubs/FakeRegistry.php';
+require_once __DIR__ . '/Stubs/modMail.php';
+require_once __DIR__ . '/Stubs/xPDO.php';
 require_once __DIR__ . '/Stubs/sxSubscriber.php';
 require_once __DIR__ . '/Stubs/sxQueue.php';
+require_once __DIR__ . '/Stubs/FakeMail.php';
 require_once __DIR__ . '/Stubs/FakeModX.php';
 require_once __DIR__ . '/Stubs/modProcessor.php';
 
 require_once dirname(__DIR__) . '/core/components/sendex/model/sendex/sxnewsletter.class.php';
+require_once dirname(__DIR__) . '/core/components/sendex/model/sendex/sxqueuesender.class.php';
 require_once __DIR__ . '/Support/TestableNewsletter.php';
 
 require_once dirname(__DIR__) . '/core/components/sendex/processors/mgr/newsletter/subscriber/create.class.php';


### PR DESCRIPTION
### Кратко

Один `sxQueueSender` для cron и mgr: claim, отправка, лог и requeue в одном месте.

## Что сделано
- `sxQueueSender::sendOne` / `flush` (limit, criteria, stopOnError, logErrors)
- `cron/send.php`, `queue/send`, `queue/send_all` вызывают только `flush`
- `sxQueue::send` делегирует в `sendOne`
- тесты: `QueueSenderTest`, `QueueSendProcessorTest`
- миграция: не нужна

## Review
- Medium+: нет

## Проверка
- `composer test` — exit 0 (123; новые: QueueSenderTest, QueueSendProcessorTest)
- phpcs — exit 0

Fixes #65