### PR TITLE
refactor(mgr): Unify processor ACL and ids parsing

### DIFF
--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHP 7.4–8.4: dynamic properties, null Profile in `addQueues`, PHPMailer `ErrorInfo`.
 
 ### Changed
-- [#65] Queue delivery unified in `sxQueueSender` (`sendOne` / `flush`); cron and mgr send processors delegate to it (claim + log from #55).
+- [#69] Mgr processors share `sxSendexProcessor` (`edit_document` + `requireIds` / `parseIds`); get-list processors declare `view_document`.
 - [#62] Split `sxNewsletter` into `sxNewsletterSubscription`, `sxNewsletterQueueBuilder`, `sxSendexEvent`; model keeps a thin public API for processors/snippet.
 - **Breaking (DB):** existing `sendex_*` tables are converted to InnoDB on upgrade; queue `subscriber_id` meaning is `sxSubscriber.id` after backfill (join Queue→Subscriber for guests works). Soft FK to core `modUser` tables are not added.
 - `add_group` processor requires `edit_document` permission.

--- a/core/components/sendex/model/sendex/sxprocessorinput.class.php
+++ b/core/components/sendex/model/sendex/sxprocessorinput.class.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Normalized mgr processor input (#69).
+ */
+class sxProcessorInput
+{
+    /**
+     * Parse comma-separated ids into unique positive integers.
+     *
+     * @param mixed $raw
+     * @return int[]
+     */
+    public static function parseIds($raw)
+    {
+        if ($raw === null || $raw === '') {
+            return array();
+        }
+
+        $ids = array();
+        foreach (explode(',', (string) $raw) as $part) {
+            $id = (int) trim($part);
+            if ($id > 0) {
+                $ids[] = $id;
+            }
+        }
+
+        return array_values(array_unique($ids));
+    }
+}

--- a/core/components/sendex/processors/mgr/newsletter/disable.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/disable.class.php
@@ -1,10 +1,11 @@
 <?php
 
+require_once dirname(__DIR__) . '/sendexprocessor.class.php';
+
 /**
  * Disable an Newsletter
  */
-
-class sxNewsletterDisableProcessor extends modProcessor
+class sxNewsletterDisableProcessor extends sxSendexProcessor
 {
     public $objectType = 'sxNewsletter';
     public $classKey = 'sxNewsletter';
@@ -14,8 +15,12 @@ class sxNewsletterDisableProcessor extends modProcessor
     /** {inheritDoc} */
     public function process()
     {
-        if (!$ids = explode(',', $this->getProperty('ids'))) {
-            return $this->failure($this->modx->lexicon('sendex_newsletters_err_ns'));
+        if ($failure = $this->failureIfNoPermission()) {
+            return $failure;
+        }
+        list($ids, $failure) = $this->requireIds('sendex_newsletters_err_ns');
+        if ($failure) {
+            return $failure;
         }
 
         $newsletters = $this->modx->getIterator($this->classKey, array('id:IN' => $ids, 'active' => true));

--- a/core/components/sendex/processors/mgr/newsletter/enable.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/enable.class.php
@@ -1,10 +1,11 @@
 <?php
 
+require_once dirname(__DIR__) . '/sendexprocessor.class.php';
+
 /**
  * Enable an Newsletter
  */
-
-class sxNewsletterEnableProcessor extends modProcessor
+class sxNewsletterEnableProcessor extends sxSendexProcessor
 {
     public $objectType = 'sxNewsletter';
     public $classKey = 'sxNewsletter';
@@ -14,8 +15,12 @@ class sxNewsletterEnableProcessor extends modProcessor
     /** {inheritDoc} */
     public function process()
     {
-        if (!$ids = explode(',', $this->getProperty('ids'))) {
-            return $this->failure($this->modx->lexicon('sendex_newsletters_err_ns'));
+        if ($failure = $this->failureIfNoPermission()) {
+            return $failure;
+        }
+        list($ids, $failure) = $this->requireIds('sendex_newsletters_err_ns');
+        if ($failure) {
+            return $failure;
         }
 
         $newsletters = $this->modx->getIterator($this->classKey, array('id:IN' => $ids, 'active' => false));

--- a/core/components/sendex/processors/mgr/newsletter/get.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/get.class.php
@@ -9,6 +9,7 @@ class sxNewsletterGetProcessor extends modObjectGetProcessor
     public $objectType = 'sxNewsletter';
     public $classKey = 'sxNewsletter';
     public $languageTopics = array('sendex:default');
+    public $permission = 'view_document';
 }
 
 return 'sxNewsletterGetProcessor';

--- a/core/components/sendex/processors/mgr/newsletter/getlist.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/getlist.class.php
@@ -10,6 +10,7 @@ class sxNewsletterGetListProcessor extends modObjectGetListProcessor
     public $classKey = 'sxNewsletter';
     public $defaultSortField = 'id';
     public $defaultSortDirection = 'DESC';
+    public $permission = 'view_document';
 
 
     /**

--- a/core/components/sendex/processors/mgr/newsletter/remove.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/remove.class.php
@@ -1,10 +1,11 @@
 <?php
 
+require_once dirname(__DIR__) . '/sendexprocessor.class.php';
+
 /**
  * Remove an Newsletters
  */
-
-class sxNewsletterRemoveProcessor extends modProcessor
+class sxNewsletterRemoveProcessor extends sxSendexProcessor
 {
     public $classKey = 'sxNewsletter';
 
@@ -12,8 +13,12 @@ class sxNewsletterRemoveProcessor extends modProcessor
     /** {inheritDoc} */
     public function process()
     {
-        if (!$ids = explode(',', $this->getProperty('ids'))) {
-            return $this->failure($this->modx->lexicon('sendex_newsletters_err_ns'));
+        if ($failure = $this->failureIfNoPermission()) {
+            return $failure;
+        }
+        list($ids, $failure) = $this->requireIds('sendex_newsletters_err_ns');
+        if ($failure) {
+            return $failure;
         }
 
         $newsletters = $this->modx->getIterator($this->classKey, array('id:IN' => $ids));

--- a/core/components/sendex/processors/mgr/newsletter/subscriber/create.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/subscriber/create.class.php
@@ -1,15 +1,15 @@
 <?php
 
-/**
- * Create an Subscriber
- */
+require_once dirname(__DIR__, 2) . '/sendexprocessor.class.php';
 
-class sxSubscriberCreateProcessor extends modProcessor
+/**
+ * Create a Subscriber
+ */
+class sxSubscriberCreateProcessor extends sxSendexProcessor
 {
     public $objectType = 'sxSubscriber';
     public $classKey = 'sxSubscriber';
     public $languageTopics = array('sendex');
-    public $permission = '';
 
 
     /**
@@ -17,6 +17,10 @@ class sxSubscriberCreateProcessor extends modProcessor
      */
     public function process()
     {
+        if ($failure = $this->failureIfNoPermission()) {
+            return $failure;
+        }
+
         $user_id = (int) $this->getProperty('user_id');
         $newsletter_id = (int) $this->getProperty('newsletter_id');
 

--- a/core/components/sendex/processors/mgr/newsletter/subscriber/getlist.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/subscriber/getlist.class.php
@@ -12,6 +12,7 @@ class sxSubscriberGetListProcessor extends modObjectGetListProcessor
     public $classKey = 'sxSubscriber';
     public $defaultSortField = 'id';
     public $defaultSortDirection = 'DESC';
+    public $permission = 'view_document';
 
 
     /**

--- a/core/components/sendex/processors/mgr/newsletter/subscriber/remove.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/subscriber/remove.class.php
@@ -1,10 +1,11 @@
 <?php
 
+require_once dirname(__DIR__, 2) . '/sendexprocessor.class.php';
+
 /**
  * Remove subscribers
  */
-
-class sxSubscriberRemoveProcessor extends modProcessor
+class sxSubscriberRemoveProcessor extends sxSendexProcessor
 {
     public $classKey = 'sxSubscriber';
 
@@ -12,9 +13,12 @@ class sxSubscriberRemoveProcessor extends modProcessor
     /** {inheritDoc} */
     public function process()
     {
-        $ids = array_filter(array_map('intval', explode(',', (string) $this->getProperty('ids'))));
-        if (empty($ids)) {
-            return $this->failure($this->modx->lexicon('sendex_subscribers_err_ns'));
+        if ($failure = $this->failureIfNoPermission()) {
+            return $failure;
+        }
+        list($ids, $failure) = $this->requireIds('sendex_subscribers_err_ns');
+        if ($failure) {
+            return $failure;
         }
 
         $errors = array();

--- a/core/components/sendex/processors/mgr/queue/add.class.php
+++ b/core/components/sendex/processors/mgr/queue/add.class.php
@@ -1,10 +1,11 @@
 <?php
 
+require_once dirname(__DIR__) . '/sendexprocessor.class.php';
+
 /**
  * Add a list of Queues
  */
-
-class sxQueueAddProcessor extends modProcessor
+class sxQueueAddProcessor extends sxSendexProcessor
 {
     public $objectType = 'sxQueue';
     public $classKey = 'sxQueue';
@@ -13,6 +14,10 @@ class sxQueueAddProcessor extends modProcessor
     /** {inheritDoc} */
     public function process()
     {
+        if ($failure = $this->failureIfNoPermission()) {
+            return $failure;
+        }
+
         if (!$id = $this->getProperty('newsletter_id')) {
             return $this->failure($this->modx->lexicon('sendex_newsletter_err_ns'));
         } elseif (!$newsletter = $this->modx->getObject('sxNewsletter', $id)) {

--- a/core/components/sendex/processors/mgr/queue/getlist.class.php
+++ b/core/components/sendex/processors/mgr/queue/getlist.class.php
@@ -12,6 +12,7 @@ class sxQueueGetListProcessor extends modObjectGetListProcessor
     public $classKey = 'sxQueue';
     public $defaultSortField = 'id';
     public $defaultSortDirection = 'DESC';
+    public $permission = 'view_document';
 
 
     /**

--- a/core/components/sendex/processors/mgr/queue/remove.class.php
+++ b/core/components/sendex/processors/mgr/queue/remove.class.php
@@ -1,10 +1,11 @@
 <?php
 
-/**
- * Remove an Newsletter
- */
+require_once dirname(__DIR__) . '/sendexprocessor.class.php';
 
-class sxQueueRemoveProcessor extends modProcessor
+/**
+ * Remove queue rows
+ */
+class sxQueueRemoveProcessor extends sxSendexProcessor
 {
     public $classKey = 'sxQueue';
 
@@ -12,8 +13,12 @@ class sxQueueRemoveProcessor extends modProcessor
     /** {inheritDoc} */
     public function process()
     {
-        if (!$ids = explode(',', $this->getProperty('ids'))) {
-            return $this->failure($this->modx->lexicon('sendex_queue_err_ns'));
+        if ($failure = $this->failureIfNoPermission()) {
+            return $failure;
+        }
+        list($ids, $failure) = $this->requireIds('sendex_queue_err_ns');
+        if ($failure) {
+            return $failure;
         }
 
         $queues = $this->modx->getIterator($this->classKey, array('id:IN' => $ids));

--- a/core/components/sendex/processors/mgr/queue/remove_all.class.php
+++ b/core/components/sendex/processors/mgr/queue/remove_all.class.php
@@ -1,10 +1,11 @@
 <?php
 
-/**
- * Remove an Queue
- */
+require_once dirname(__DIR__) . '/sendexprocessor.class.php';
 
-class sxQueueRemoveAllProcessor extends modProcessor
+/**
+ * Remove all queue rows
+ */
+class sxQueueRemoveAllProcessor extends sxSendexProcessor
 {
     public $objectType = 'sxQueue';
     public $classKey = 'sxQueue';
@@ -13,6 +14,10 @@ class sxQueueRemoveAllProcessor extends modProcessor
     /** {inheritDoc} */
     public function process()
     {
+        if ($failure = $this->failureIfNoPermission()) {
+            return $failure;
+        }
+
         $this->modx->removeCollection($this->classKey, array());
 
         return $this->success();

--- a/core/components/sendex/processors/mgr/queue/send.class.php
+++ b/core/components/sendex/processors/mgr/queue/send.class.php
@@ -1,12 +1,12 @@
 <?php
 
-require_once dirname(dirname(dirname(dirname(__FILE__))))
-    . '/model/sendex/sxqueuesender.class.php';
+require_once dirname(__DIR__) . '/sendexprocessor.class.php';
+require_once dirname(__FILE__, 4) . '/model/sendex/sxqueuesender.class.php';
 
 /**
  * Send queue rows by id (mgr).
  */
-class sxQueueSendProcessor extends modProcessor
+class sxQueueSendProcessor extends sxSendexProcessor
 {
     public $classKey = 'sxQueue';
 
@@ -14,9 +14,12 @@ class sxQueueSendProcessor extends modProcessor
     /** {inheritDoc} */
     public function process()
     {
-        $ids = explode(',', (string) $this->getProperty('ids'));
-        if (!$ids || $ids === array('')) {
-            return $this->failure($this->modx->lexicon('sendex_queue_err_ns'));
+        if ($failure = $this->failureIfNoPermission()) {
+            return $failure;
+        }
+        list($ids, $failure) = $this->requireIds('sendex_queue_err_ns');
+        if ($failure) {
+            return $failure;
         }
 
         $stats = sxQueueSender::flush($this->modx, array(

--- a/core/components/sendex/processors/mgr/queue/send_all.class.php
+++ b/core/components/sendex/processors/mgr/queue/send_all.class.php
@@ -1,12 +1,13 @@
 <?php
 
+require_once dirname(__DIR__) . '/sendexprocessor.class.php';
 require_once dirname(dirname(dirname(dirname(__FILE__))))
     . '/model/sendex/sxqueuesender.class.php';
 
 /**
  * Send all queue rows (mgr).
  */
-class sxQueueSendAllProcessor extends modProcessor
+class sxQueueSendAllProcessor extends sxSendexProcessor
 {
     public $objectType = 'sxQueue';
     public $classKey = 'sxQueue';
@@ -15,6 +16,10 @@ class sxQueueSendAllProcessor extends modProcessor
     /** {inheritDoc} */
     public function process()
     {
+        if ($failure = $this->failureIfNoPermission()) {
+            return $failure;
+        }
+
         $stats = sxQueueSender::flush($this->modx, array(
             'stopOnError' => true,
         ));

--- a/core/components/sendex/processors/mgr/sendexprocessor.class.php
+++ b/core/components/sendex/processors/mgr/sendexprocessor.class.php
@@ -1,0 +1,41 @@
+<?php
+
+require_once dirname(__FILE__, 3) . '/model/sendex/sxprocessorinput.class.php';
+
+/**
+ * Base mgr processor: permission gate + shared ids parsing (#69).
+ */
+abstract class sxSendexProcessor extends modProcessor
+{
+    /** @var string */
+    public $permission = 'edit_document';
+
+    /**
+     * @return array|null failure response when permission is missing
+     */
+    protected function failureIfNoPermission()
+    {
+        if ($this->permission === '' || $this->permission === null) {
+            return $this->failure($this->modx->lexicon('access_denied'));
+        }
+        if (!$this->modx->hasPermission($this->permission)) {
+            return $this->failure($this->modx->lexicon('access_denied'));
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string $lexiconKey
+     * @return array{0:int[],1:array|null}
+     */
+    protected function requireIds($lexiconKey)
+    {
+        $ids = sxProcessorInput::parseIds($this->getProperty('ids'));
+        if ($ids === array()) {
+            return array(array(), $this->failure($this->modx->lexicon($lexiconKey)));
+        }
+
+        return array($ids, null);
+    }
+}

--- a/tests/Stubs/FakeModX.php
+++ b/tests/Stubs/FakeModX.php
@@ -50,6 +50,13 @@ class FakeModX extends modX
     /** @var array<int,array{0:string,1:array}> */
     public $invoked = array();
 
+    /** @var array<string,bool> */
+    public $permissions = array(
+        'edit_document' => true,
+        'new_document'  => true,
+        'view_document' => true,
+    );
+
     /** @var array<int,array{0:mixed,1:string}> */
     public $logs = array();
 
@@ -96,6 +103,10 @@ class FakeModX extends modX
      */
     public function lexicon($key, $params = array())
     {
+        if ($key === 'access_denied') {
+            return 'access_denied';
+        }
+
         if (!is_array($params) || $params === array()) {
             return $key;
         }
@@ -106,6 +117,16 @@ class FakeModX extends modX
         }
 
         return $out;
+    }
+
+    /**
+     * @param string $permission
+     *
+     * @return bool
+     */
+    public function hasPermission($permission)
+    {
+        return !empty($this->permissions[$permission]);
     }
 
     /**

--- a/tests/Support/TestSendexIdsProcessor.php
+++ b/tests/Support/TestSendexIdsProcessor.php
@@ -1,0 +1,22 @@
+<?php
+
+require_once dirname(__DIR__, 2) . '/core/components/sendex/processors/mgr/sendexprocessor.class.php';
+
+class TestSendexIdsProcessor extends sxSendexProcessor
+{
+    /**
+     * @return array
+     */
+    public function process()
+    {
+        if ($failure = $this->failureIfNoPermission()) {
+            return $failure;
+        }
+        list($ids, $failure) = $this->requireIds('sendex_queue_err_ns');
+        if ($failure) {
+            return $failure;
+        }
+
+        return $this->success('', array('ids' => $ids));
+    }
+}

--- a/tests/Unit/ProcessorInputTest.php
+++ b/tests/Unit/ProcessorInputTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sxprocessorinput.class.php';
+
+class ProcessorInputTest extends TestCase
+{
+    public function testParseIdsReturnsUniquePositiveIntegers()
+    {
+        $this->assertSame(array(1, 2, 10), sxProcessorInput::parseIds('1, 2,10,2'));
+    }
+
+    public function testParseIdsRejectsEmptyAndZero()
+    {
+        $this->assertSame(array(), sxProcessorInput::parseIds(''));
+        $this->assertSame(array(), sxProcessorInput::parseIds(null));
+        $this->assertSame(array(), sxProcessorInput::parseIds('0'));
+        $this->assertSame(array(), sxProcessorInput::parseIds(', ,0'));
+    }
+}

--- a/tests/Unit/SendexProcessorAclTest.php
+++ b/tests/Unit/SendexProcessorAclTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../Support/TestSendexIdsProcessor.php';
+
+class SendexProcessorAclTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+    }
+
+    public function testRequireIdsUsesSameFailureForEmptyInput()
+    {
+        $processor = new TestSendexIdsProcessor($this->modx, array('ids' => ','));
+        $result = $processor->process();
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('sendex_queue_err_ns', $result['message']);
+    }
+
+    public function testFailureWhenPermissionMissing()
+    {
+        $this->modx->permissions['edit_document'] = false;
+        $processor = new TestSendexIdsProcessor($this->modx, array('ids' => '1'));
+        $result = $processor->process();
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('access_denied', $result['message']);
+    }
+
+    public function testMgrProcessorsExtendSendexProcessor()
+    {
+        $base = dirname(__DIR__, 2) . '/core/components/sendex/processors/mgr/';
+        $files = array(
+            'newsletter/remove.class.php',
+            'newsletter/enable.class.php',
+            'newsletter/disable.class.php',
+            'queue/remove.class.php',
+            'queue/remove_all.class.php',
+            'queue/add.class.php',
+            'queue/send_all.class.php',
+            'newsletter/subscriber/create.class.php',
+            'newsletter/subscriber/remove.class.php',
+        );
+
+        foreach ($files as $file) {
+            $source = file_get_contents($base . $file);
+            $this->assertStringContainsString('extends sxSendexProcessor', $source, $file);
+            $this->assertStringContainsString('failureIfNoPermission', $source, $file);
+        }
+    }
+
+    public function testGetListProcessorsDeclareViewPermission()
+    {
+        $base = dirname(__DIR__, 2) . '/core/components/sendex/processors/mgr/';
+        $files = array(
+            'newsletter/getlist.class.php',
+            'newsletter/get.class.php',
+            'newsletter/subscriber/getlist.class.php',
+            'queue/getlist.class.php',
+        );
+
+        foreach ($files as $file) {
+            $source = file_get_contents($base . $file);
+            $this->assertStringContainsString("'view_document'", $source, $file);
+        }
+    }
+}

--- a/tests/Unit/SendexProcessorAclTest.php
+++ b/tests/Unit/SendexProcessorAclTest.php
@@ -43,6 +43,7 @@ class SendexProcessorAclTest extends TestCase
             'queue/remove.class.php',
             'queue/remove_all.class.php',
             'queue/add.class.php',
+            'queue/send.class.php',
             'queue/send_all.class.php',
             'newsletter/subscriber/create.class.php',
             'newsletter/subscriber/remove.class.php',

--- a/tests/Unit/SubscriberCreateProcessorTest.php
+++ b/tests/Unit/SubscriberCreateProcessorTest.php
@@ -26,6 +26,18 @@ class SubscriberCreateProcessorTest extends TestCase
         $this->assertSame('sendex_subscriber_err_save', $result['message']);
     }
 
+    public function testRequiresPermission()
+    {
+        $this->modx->permissions['edit_document'] = false;
+        $this->processor->properties = array(
+            'user_id'       => 5,
+            'newsletter_id' => 10,
+        );
+        $result = $this->processor->process();
+        $this->assertFalse($result['success']);
+        $this->assertSame('access_denied', $result['message']);
+    }
+
     public function testFailsWithoutProfile()
     {
         $this->processor->properties = array(

--- a/tests/Unit/SubscriberRemoveProcessorTest.php
+++ b/tests/Unit/SubscriberRemoveProcessorTest.php
@@ -27,6 +27,23 @@ class SubscriberRemoveProcessorTest extends TestCase
         $this->assertSame('sendex_subscribers_err_ns', $result['message']);
     }
 
+    public function testRejectsCommaOnlyIds()
+    {
+        $this->processor->properties = array('ids' => '0,');
+        $result = $this->processor->process();
+        $this->assertFalse($result['success']);
+        $this->assertSame('sendex_subscribers_err_ns', $result['message']);
+    }
+
+    public function testRequiresPermission()
+    {
+        $this->modx->permissions['edit_document'] = false;
+        $this->processor->properties = array('ids' => '1');
+        $result = $this->processor->process();
+        $this->assertFalse($result['success']);
+        $this->assertSame('access_denied', $result['message']);
+    }
+
     public function testRemovesViaUnSubscribe()
     {
         $subscriber = new sxSubscriber($this->modx);


### PR DESCRIPTION
### Кратко

Mgr processors больше не расходятся по ACL и разбору `ids`.

## Что сделано
- `sxSendexProcessor`: `failureIfNoPermission`, `requireIds` + `sxProcessorInput::parseIds`
- мутации наследуют базу (`edit_document`); get-list — `view_document`
- subscriber create: убран пустой `$permission`
- тесты: `ProcessorInputTest`, `SendexProcessorAclTest` + расширены create/remove
- миграция: не нужна

## Review
- Medium+: нет

## Проверка
- `composer test` — exit 0 (132; новые: ProcessorInputTest, SendexProcessorAclTest)
- phpcs — exit 0

Fixes #69