### PR TITLE
fix(queue): Accept array or CSV ids in queue send processor

### DIFF
--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `add_group`: cast `group_id` and `newsletter_id` to int; require user Profile (`innerJoin`).
 - `confirmEmail` returns the `subscribe()` result when confirming a hash for another newsletter.
 - PHP 7.4–8.4: dynamic properties, null Profile in `addQueues`, PHPMailer `ErrorInfo`.
+- [#28] `sxProcessorInput::parseIds` accepts `ids` as array or CSV; queue send from snippet/code matches ExtJS `runProcessor` input.
 
 ### Changed
 - [#69] Mgr processors share `sxSendexProcessor` (`edit_document` + `requireIds` / `parseIds`); get-list processors declare `view_document`.

--- a/core/components/sendex/model/sendex/sxprocessorinput.class.php
+++ b/core/components/sendex/model/sendex/sxprocessorinput.class.php
@@ -17,9 +17,11 @@ class sxProcessorInput
             return array();
         }
 
+        $parts = is_array($raw) ? $raw : explode(',', (string) $raw);
+
         $ids = array();
-        foreach (explode(',', (string) $raw) as $part) {
-            $id = (int) trim($part);
+        foreach ($parts as $part) {
+            $id = (int) trim((string) $part);
             if ($id > 0) {
                 $ids[] = $id;
             }

--- a/tests/Unit/ProcessorInputTest.php
+++ b/tests/Unit/ProcessorInputTest.php
@@ -9,6 +9,8 @@ class ProcessorInputTest extends TestCase
     public function testParseIdsReturnsUniquePositiveIntegers()
     {
         $this->assertSame(array(1, 2, 10), sxProcessorInput::parseIds('1, 2,10,2'));
+        $this->assertSame(array(1, 2, 10), sxProcessorInput::parseIds(array(1, 2, 10, 2)));
+        $this->assertSame(array(1, 2, 10), sxProcessorInput::parseIds(array('1', ' 2', '10', '2')));
     }
 
     public function testParseIdsRejectsEmptyAndZero()
@@ -17,5 +19,7 @@ class ProcessorInputTest extends TestCase
         $this->assertSame(array(), sxProcessorInput::parseIds(null));
         $this->assertSame(array(), sxProcessorInput::parseIds('0'));
         $this->assertSame(array(), sxProcessorInput::parseIds(', ,0'));
+        $this->assertSame(array(), sxProcessorInput::parseIds(array()));
+        $this->assertSame(array(), sxProcessorInput::parseIds(array(0, '', '0')));
     }
 }

--- a/tests/Unit/QueueSendProcessorTest.php
+++ b/tests/Unit/QueueSendProcessorTest.php
@@ -23,6 +23,25 @@ class QueueSendProcessorTest extends TestCase
 
         $this->assertFalse($response['success']);
         $this->assertSame('sendex_queue_err_ns', $response['message']);
+
+        $processor = new sxQueueSendProcessor($this->modx, array('ids' => array()));
+        $response = $processor->process();
+
+        $this->assertFalse($response['success']);
+        $this->assertSame('sendex_queue_err_ns', $response['message']);
+    }
+
+    public function testSendProcessorAcceptsArrayIds()
+    {
+        $this->addQueue(1);
+        $this->addQueue(2);
+
+        $processor = new sxQueueSendProcessor($this->modx, array('ids' => array(1, 2)));
+        $response = $processor->process();
+
+        $this->assertTrue($response['success']);
+        $this->assertFalse($this->hasQueueId(1));
+        $this->assertFalse($this->hasQueueId(2));
     }
 
     public function testSendProcessorFailsOnMailError()


### PR DESCRIPTION
`sxProcessorInput::parseIds` принимает `ids` как массив или CSV-строку. Отправка очереди из сниппета через `runProcessor` работает так же, как из ExtJS.

## Что сделано
- `parseIds`: `is_array($raw)` → as-is, иначе `explode(',', …)`; фильтр нулей и дубликатов без изменений
- `sxQueueSendProcessor` уже вызывает `requireIds` (#69) — правок в processor не потребовалось
- тесты: `ProcessorInputTest` (array/CSV), `QueueSendProcessorTest` (пустой array → failure, array ids → send)
- миграция: не нужна (контракт входа, без изменений БД)

## Почему так
Один helper вместо веток в каждом send/remove processor — code judo поверх #69.

## Review
- Medium+: нет

## Проверка
- `composer test` — exit 0 (133 tests, +3 кейса)
- `vendor/bin/phpcs --standard=phpcs.xml` — exit 0

Fixes #28