### PR TITLE
refactor(mail): Centralize newsletter mailer setup

### DIFF
--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#28] `sxProcessorInput::parseIds` accepts `ids` as array or CSV; queue send from snippet/code matches ExtJS `runProcessor` input.
 
 ### Changed
-- [#66] `sxNewsletterMailer` centralizes From/Reply-To/HTML setup for activation mail and queue delivery.
+- [#66] `sxNewsletterMailer` centralizes From/Reply-To/HTML setup for activation mail and queue delivery; activation reply-to uses `email_reply` like queue build.
 - [#69] Mgr processors share `sxSendexProcessor` (`edit_document` + `requireIds` / `parseIds`); get-list processors declare `view_document`.
 - [#62] Split `sxNewsletter` into `sxNewsletterSubscription`, `sxNewsletterQueueBuilder`, `sxSendexEvent`; model keeps a thin public API for processors/snippet.
 - **Breaking (DB):** existing `sendex_*` tables are converted to InnoDB on upgrade; queue `subscriber_id` meaning is `sxSubscriber.id` after backfill (join Queue→Subscriber for guests works). Soft FK to core `modUser` tables are not added.

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#28] `sxProcessorInput::parseIds` accepts `ids` as array or CSV; queue send from snippet/code matches ExtJS `runProcessor` input.
 
 ### Changed
+- [#66] `sxNewsletterMailer` centralizes From/Reply-To/HTML setup for activation mail and queue delivery.
 - [#69] Mgr processors share `sxSendexProcessor` (`edit_document` + `requireIds` / `parseIds`); get-list processors declare `view_document`.
 - [#62] Split `sxNewsletter` into `sxNewsletterSubscription`, `sxNewsletterQueueBuilder`, `sxSendexEvent`; model keeps a thin public API for processors/snippet.
 - **Breaking (DB):** existing `sendex_*` tables are converted to InnoDB on upgrade; queue `subscriber_id` meaning is `sxSubscriber.id` after backfill (join Queue→Subscriber for guests works). Soft FK to core `modUser` tables are not added.

--- a/core/components/sendex/model/sendex/sendex.class.php
+++ b/core/components/sendex/model/sendex/sendex.class.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once dirname(__FILE__) . '/sxnewslettermailer.class.php';
+
 /**
  * The base class for Sendex.
  */
@@ -74,47 +76,10 @@ class Sendex
     {
         /** @var modPHPMailer $mail */
         $mail = $this->modx->getService('mail', 'mail.modPHPMailer');
-
-        $mail->set(modMail::MAIL_BODY, $this->modx->getOption('email_body', $options, ''));
-        $mail->set(
-            modMail::MAIL_FROM,
-            $this->modx->getOption(
-                'email_from',
-                $options,
-                $this->modx->getOption('emailsender'),
-                true
-            )
+        sxNewsletterMailer::configureMailer(
+            $mail,
+            sxNewsletterMailer::buildActivationMessage($this->modx, $email, $options)
         );
-        $mail->set(
-            modMail::MAIL_FROM_NAME,
-            $this->modx->getOption(
-                'email_from_name',
-                $options,
-                $this->modx->getOption('site_name'),
-                true
-            )
-        );
-        $mail->set(
-            modMail::MAIL_SUBJECT,
-            $this->modx->getOption(
-                'email_subject',
-                $options,
-                $this->modx->lexicon('sendex_subscribe_activate_subject'),
-                true
-            )
-        );
-
-        $mail->address('to', $email);
-        $mail->address(
-            'reply-to',
-            $this->modx->getOption(
-                'email_from',
-                $options,
-                $this->modx->getOption('emailsender'),
-                true
-            )
-        );
-        $mail->setHTML(true);
 
         $response = !$mail->send()
             ? $mail->mailer->ErrorInfo

--- a/core/components/sendex/model/sendex/sxnewslettermailer.class.php
+++ b/core/components/sendex/model/sendex/sxnewslettermailer.class.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * Shared newsletter mail headers + PHPMailer setup (#66).
+ */
+class sxNewsletterMailer
+{
+    /**
+     * Resolve From / Reply-To defaults from newsletter fields or site options.
+     *
+     * @param object|array $source sxNewsletter, options array, or queue-like row
+     * @param object $xpdo
+     * @return array{email_from:string,email_from_name:string,email_reply:string}
+     */
+    public static function resolveHeaders($source, $xpdo)
+    {
+        $from = trim((string) self::readField($source, 'email_from'));
+        if ($from === '') {
+            $from = (string) $xpdo->getOption('emailsender');
+        }
+
+        $fromName = trim((string) self::readField($source, 'email_from_name'));
+        if ($fromName === '') {
+            $fromName = (string) $xpdo->getOption('site_name');
+        }
+
+        $reply = trim((string) self::readField($source, 'email_reply'));
+        if ($reply === '') {
+            $reply = $from;
+        }
+
+        return array(
+            'email_from'      => $from,
+            'email_from_name' => $fromName,
+            'email_reply'     => $reply,
+        );
+    }
+
+    /**
+     * Build queue/send payload for one subscriber.
+     *
+     * @param object $newsletter sxNewsletter
+     * @param object $subscriber sxSubscriber
+     * @param string $subject
+     * @param string $body
+     * @param object $xpdo
+     * @return array
+     */
+    public static function buildMessage($newsletter, $subscriber, $subject, $body, $xpdo)
+    {
+        return array_merge(
+            self::resolveHeaders($newsletter, $xpdo),
+            array(
+                'email_to'      => $subscriber->get('email'),
+                'email_subject' => $subject,
+                'email_body'    => $body,
+            )
+        );
+    }
+
+    /**
+     * Activation mail after checkEmail (snippet → Sendex::sendEmail).
+     *
+     * @param object $xpdo
+     * @param string $to
+     * @param array $options newsletter placeholders + email_body
+     * @return array
+     */
+    public static function buildActivationMessage($xpdo, $to, array $options)
+    {
+        $headers = self::resolveHeaders($options, $xpdo);
+
+        return array(
+            'email_to'        => $to,
+            'email_body'      => $xpdo->getOption('email_body', $options, ''),
+            'email_subject'   => $xpdo->getOption(
+                'email_subject',
+                $options,
+                $xpdo->lexicon('sendex_subscribe_activate_subject'),
+                true
+            ),
+            'email_from'      => $headers['email_from'],
+            'email_from_name' => $headers['email_from_name'],
+            'email_reply'     => $xpdo->getOption(
+                'email_from',
+                $options,
+                $xpdo->getOption('emailsender'),
+                true
+            ),
+        );
+    }
+
+    /**
+     * @param object $queue sxQueue
+     * @return array
+     */
+    public static function messageFromQueue($queue)
+    {
+        return array(
+            'email_to'        => $queue->email_to,
+            'email_body'      => $queue->email_body,
+            'email_from'      => $queue->email_from,
+            'email_from_name' => $queue->email_from_name,
+            'email_subject'   => $queue->email_subject,
+            'email_reply'     => $queue->email_reply,
+        );
+    }
+
+    /**
+     * @param object $mail modPHPMailer
+     * @param array $message
+     */
+    public static function configureMailer($mail, array $message)
+    {
+        $mail->set(modMail::MAIL_BODY, $message['email_body']);
+        $mail->set(modMail::MAIL_FROM, $message['email_from']);
+        $mail->set(modMail::MAIL_FROM_NAME, $message['email_from_name']);
+        $mail->set(modMail::MAIL_SUBJECT, $message['email_subject']);
+        $mail->address('to', $message['email_to']);
+        $mail->address('reply-to', $message['email_reply']);
+        $mail->setHTML(true);
+    }
+
+    /**
+     * @param object|array $source
+     * @param string $key
+     * @return mixed
+     */
+    protected static function readField($source, $key)
+    {
+        if (is_array($source)) {
+            return isset($source[$key]) ? $source[$key] : '';
+        }
+
+        if (is_object($source) && method_exists($source, 'get')) {
+            return $source->get($key);
+        }
+
+        return '';
+    }
+}

--- a/core/components/sendex/model/sendex/sxnewslettermailer.class.php
+++ b/core/components/sendex/model/sendex/sxnewslettermailer.class.php
@@ -2,6 +2,11 @@
 
 /**
  * Shared newsletter mail headers + PHPMailer setup (#66).
+ *
+ * Post-#62 mail paths (issue originally named sxNewsletter::send/checkEmail):
+ * - activation: snippet → Sendex::sendEmail → buildActivationMessage
+ * - queue build: sxNewsletterQueueBuilder::addQueues → buildMessage
+ * - queue send: sxQueueSender::deliverMail → messageFromQueue
  */
 class sxNewsletterMailer
 {
@@ -81,12 +86,7 @@ class sxNewsletterMailer
             ),
             'email_from'      => $headers['email_from'],
             'email_from_name' => $headers['email_from_name'],
-            'email_reply'     => $xpdo->getOption(
-                'email_from',
-                $options,
-                $xpdo->getOption('emailsender'),
-                true
-            ),
+            'email_reply'     => $headers['email_reply'],
         );
     }
 

--- a/core/components/sendex/model/sendex/sxnewsletterqueuebuilder.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletterqueuebuilder.class.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once dirname(__FILE__) . '/sxqueuelink.class.php';
+require_once dirname(__FILE__) . '/sxnewslettermailer.class.php';
 
 /**
  * Build queue rows from newsletter subscribers.
@@ -71,13 +72,6 @@ class sxNewsletterQueueBuilder
 
             $email = $subscriber->email;
             $subject = !empty($newsletter->email_subject) ? $newsletter->email_subject : 'No subject';
-            $from = !empty($newsletter->email_from)
-                ? $newsletter->email_from
-                : $xpdo->getOption('emailsender');
-            $fromName = !empty($newsletter->email_from_name)
-                ? $newsletter->email_from_name
-                : $xpdo->getOption('site_name');
-            $emailReply = !empty($newsletter->email_reply) ? $newsletter->email_reply : $from;
 
             $template->_cacheable = false;
             $template->_processed = false;
@@ -89,17 +83,19 @@ class sxNewsletterQueueBuilder
                 $parser->processElementTags('', $body, true, true, '[[', ']]', array(), $maxIterations);
             }
 
+            $message = sxNewsletterMailer::buildMessage($newsletter, $subscriber, $subject, $body, $xpdo);
+
             /** @var sxQueue $queue */
             $queue = $xpdo->newObject('sxQueue');
             $queue->fromArray(array(
                 'subscriber_id'   => sxQueueLink::subscriberIdFromSubscriber($subscriber),
                 'newsletter_id'   => $newsletterId,
-                'email_to'        => $email,
-                'email_subject'   => $subject,
-                'email_body'      => $body,
-                'email_from'      => $from,
-                'email_from_name' => $fromName,
-                'email_reply'     => $emailReply,
+                'email_to'        => $message['email_to'],
+                'email_subject'   => $message['email_subject'],
+                'email_body'      => $message['email_body'],
+                'email_from'      => $message['email_from'],
+                'email_from_name' => $message['email_from_name'],
+                'email_reply'     => $message['email_reply'],
             ));
             $queue->save();
         }

--- a/core/components/sendex/model/sendex/sxqueuesender.class.php
+++ b/core/components/sendex/model/sendex/sxqueuesender.class.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once dirname(__FILE__) . '/sxqueuedeliver.class.php';
+require_once dirname(__FILE__) . '/sxnewslettermailer.class.php';
 
 /**
  * Single entry point for queue delivery (#65): cron and mgr processors call flush/sendOne.
@@ -97,13 +98,7 @@ class sxQueueSender
     {
         /** @var modPHPMailer $mail */
         $mail = $queue->xpdo->getService('mail', 'mail.modPHPMailer');
-        $mail->set(modMail::MAIL_BODY, $queue->email_body);
-        $mail->set(modMail::MAIL_FROM, $queue->email_from);
-        $mail->set(modMail::MAIL_FROM_NAME, $queue->email_from_name);
-        $mail->set(modMail::MAIL_SUBJECT, $queue->email_subject);
-        $mail->address('to', $queue->email_to);
-        $mail->address('reply-to', $queue->email_reply);
-        $mail->setHTML(true);
+        sxNewsletterMailer::configureMailer($mail, sxNewsletterMailer::messageFromQueue($queue));
         if (!$mail->send()) {
             $error = $mail->mailer->ErrorInfo;
             $queue->xpdo->log(

--- a/tests/Stubs/FakeMail.php
+++ b/tests/Stubs/FakeMail.php
@@ -11,6 +11,12 @@ class FakeMail
     /** @var stdClass */
     public $mailer;
 
+    /** @var array<string,mixed> */
+    public $sets = array();
+
+    /** @var array<string,string> */
+    public $addresses = array();
+
     public function __construct()
     {
         $this->mailer = new stdClass();
@@ -23,6 +29,7 @@ class FakeMail
      */
     public function set($key, $value)
     {
+        $this->sets[$key] = $value;
     }
 
     /**
@@ -31,6 +38,7 @@ class FakeMail
      */
     public function address($type, $address)
     {
+        $this->addresses[$type] = $address;
     }
 
     /**

--- a/tests/Unit/NewsletterMailerTest.php
+++ b/tests/Unit/NewsletterMailerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sxnewslettermailer.class.php';
+
+class NewsletterMailerTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+    }
+
+    public function testResolveHeadersUsesNewsletterFields()
+    {
+        $newsletter = new TestableNewsletter($this->modx);
+        $newsletter->set('email_from', 'from@example.com');
+        $newsletter->set('email_from_name', 'From');
+        $newsletter->set('email_reply', 'reply@example.com');
+
+        $headers = sxNewsletterMailer::resolveHeaders($newsletter, $this->modx);
+
+        $this->assertSame(array(
+            'email_from'      => 'from@example.com',
+            'email_from_name' => 'From',
+            'email_reply'     => 'reply@example.com',
+        ), $headers);
+    }
+
+    public function testResolveHeadersFallsBackToSiteOptions()
+    {
+        $headers = sxNewsletterMailer::resolveHeaders(array(), $this->modx);
+
+        $this->assertSame('noreply@example.com', $headers['email_from']);
+        $this->assertSame('Example', $headers['email_from_name']);
+        $this->assertSame('noreply@example.com', $headers['email_reply']);
+    }
+
+    public function testBuildMessageForSubscriber()
+    {
+        $newsletter = new TestableNewsletter($this->modx);
+        $newsletter->set('email_from', 'from@example.com');
+        $newsletter->set('email_from_name', 'From');
+        $newsletter->set('email_reply', 'reply@example.com');
+
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 0,
+            'email'         => 'guest@example.com',
+        ));
+
+        $message = sxNewsletterMailer::buildMessage(
+            $newsletter,
+            $subscriber,
+            'Hello',
+            '<p>Body</p>',
+            $this->modx
+        );
+
+        $this->assertSame('guest@example.com', $message['email_to']);
+        $this->assertSame('Hello', $message['email_subject']);
+        $this->assertSame('<p>Body</p>', $message['email_body']);
+        $this->assertSame('reply@example.com', $message['email_reply']);
+    }
+
+    public function testBuildActivationMessageKeepsLegacyReplyTo()
+    {
+        $message = sxNewsletterMailer::buildActivationMessage(
+            $this->modx,
+            'guest@example.com',
+            array(
+                'email_body'      => 'Activate',
+                'email_from'      => 'from@example.com',
+                'email_from_name' => 'From',
+                'email_reply'     => 'reply@example.com',
+                'email_subject'   => 'Confirm',
+            )
+        );
+
+        $this->assertSame('from@example.com', $message['email_reply']);
+        $this->assertSame('Confirm', $message['email_subject']);
+    }
+
+    public function testConfigureMailerSetsHeadersAndHtml()
+    {
+        $mail = new FakeMail();
+        sxNewsletterMailer::configureMailer($mail, array(
+            'email_to'        => 'to@example.com',
+            'email_body'      => 'Body',
+            'email_from'      => 'from@example.com',
+            'email_from_name' => 'From',
+            'email_subject'   => 'Subject',
+            'email_reply'     => 'reply@example.com',
+        ));
+
+        $this->assertSame('Body', $mail->sets[modMail::MAIL_BODY]);
+        $this->assertSame('from@example.com', $mail->sets[modMail::MAIL_FROM]);
+        $this->assertSame('From', $mail->sets[modMail::MAIL_FROM_NAME]);
+        $this->assertSame('Subject', $mail->sets[modMail::MAIL_SUBJECT]);
+        $this->assertSame('to@example.com', $mail->addresses['to']);
+        $this->assertSame('reply@example.com', $mail->addresses['reply-to']);
+    }
+
+    public function testMailPathsDelegateToNewsletterMailer()
+    {
+        $base = dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/';
+        $sendex = file_get_contents($base . 'sendex.class.php');
+        $sender = file_get_contents($base . 'sxqueuesender.class.php');
+        $builder = file_get_contents($base . 'sxnewsletterqueuebuilder.class.php');
+
+        $this->assertStringContainsString('sxNewsletterMailer::configureMailer', $sendex);
+        $this->assertStringContainsString('sxNewsletterMailer::configureMailer', $sender);
+        $this->assertStringContainsString('sxNewsletterMailer::buildMessage', $builder);
+    }
+}

--- a/tests/Unit/NewsletterMailerTest.php
+++ b/tests/Unit/NewsletterMailerTest.php
@@ -68,7 +68,7 @@ class NewsletterMailerTest extends TestCase
         $this->assertSame('reply@example.com', $message['email_reply']);
     }
 
-    public function testBuildActivationMessageKeepsLegacyReplyTo()
+    public function testBuildActivationMessageUsesEmailReply()
     {
         $message = sxNewsletterMailer::buildActivationMessage(
             $this->modx,
@@ -82,7 +82,7 @@ class NewsletterMailerTest extends TestCase
             )
         );
 
-        $this->assertSame('from@example.com', $message['email_reply']);
+        $this->assertSame('reply@example.com', $message['email_reply']);
         $this->assertSame('Confirm', $message['email_subject']);
     }
 

--- a/tests/Unit/NewsletterSplitContractTest.php
+++ b/tests/Unit/NewsletterSplitContractTest.php
@@ -21,6 +21,7 @@ class NewsletterSplitContractTest extends TestCase
         $files = array(
             'sxnewslettersubscription.class.php',
             'sxnewsletterqueuebuilder.class.php',
+            'sxnewslettermailer.class.php',
             'sxsendexevent.class.php',
         );
 


### PR DESCRIPTION
From/Reply-To/HTML настраивались в трёх местах. Теперь один helper рядом с классами из #62.

## Что сделано
- новый `sxNewsletterMailer`: `resolveHeaders`, `buildMessage`, `buildActivationMessage`, `configureMailer`, `messageFromQueue`
- `Sendex::sendEmail` (activation после checkEmail), `sxQueueSender::deliverMail`, `sxNewsletterQueueBuilder::addQueues` делегируют в helper
- тесты: `NewsletterMailerTest` (+6 кейсов), `FakeMail` записывает sets/addresses
- миграция: не нужна (рефакторинг без изменения БД)

## Почему так
Code judo: один builder + один configureMailer вместо копипасты headers в send/checkEmail-пути.

## Review
- Medium+: нет

## Проверка
- `composer test` — exit 0 (139 tests, +6 в NewsletterMailerTest)
- phpcs — exit 0

Fixes #66