### PR TITLE
perf(queue): Batch-load users in addQueues

### DIFF
--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#28] `sxProcessorInput::parseIds` accepts `ids` as array or CSV; queue send from snippet/code matches ExtJS `runProcessor` input.
 
 ### Changed
+- [#63] `addQueues` batch-loads `modUser` + Profile (`id:IN`) once instead of N+1 per subscriber.
 - [#66] `sxNewsletterMailer` centralizes From/Reply-To/HTML setup for activation mail and queue delivery; activation reply-to uses `email_reply` like queue build.
 - [#69] Mgr processors share `sxSendexProcessor` (`edit_document` + `requireIds` / `parseIds`); get-list processors declare `view_document`.
 - [#62] Split `sxNewsletter` into `sxNewsletterSubscription`, `sxNewsletterQueueBuilder`, `sxSendexEvent`; model keeps a thin public API for processors/snippet.

--- a/core/components/sendex/model/sendex/sxnewsletterqueuebuilder.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletterqueuebuilder.class.php
@@ -2,6 +2,7 @@
 
 require_once dirname(__FILE__) . '/sxqueuelink.class.php';
 require_once dirname(__FILE__) . '/sxnewslettermailer.class.php';
+require_once dirname(__FILE__) . '/sxnewsletterqueueusers.class.php';
 
 /**
  * Build queue rows from newsletter subscribers.
@@ -51,6 +52,15 @@ class sxNewsletterQueueBuilder
         $newsletterId = (int) $newsletter->id;
         $before = (int) $xpdo->getCount('sxQueue', array('newsletter_id' => $newsletterId));
 
+        $userIds = array();
+        foreach ($subscribers as $subscriber) {
+            $userId = (int) $subscriber->get('user_id');
+            if ($userId > 0) {
+                $userIds[] = $userId;
+            }
+        }
+        $userContexts = sxNewsletterQueueUsers::loadContexts($xpdo, $userIds);
+
         /** @var sxSubscriber $subscriber */
         foreach ($subscribers as $subscriber) {
             $scriptProperties = array(
@@ -58,16 +68,14 @@ class sxNewsletterQueueBuilder
                 'subscriber' => $subscriber->toArray(),
             );
 
-            /** @var modUser $user */
-            if ($subscriber->get('user_id') && $user = $xpdo->getObject('modUser', $subscriber->user_id)) {
-                /** @var modUserProfile|null $profile */
-                $profile = $user->getOne('Profile');
-
-                if (!$profile || !$user->active || $profile->blocked) {
+            $userId = (int) $subscriber->get('user_id');
+            if ($userId > 0) {
+                if (isset($userContexts['eligible'][$userId])) {
+                    $scriptProperties['user'] = $userContexts['eligible'][$userId]['user'];
+                    $scriptProperties['profile'] = $userContexts['eligible'][$userId]['profile'];
+                } elseif (in_array($userId, $userContexts['loadedIds'], true)) {
                     continue;
                 }
-                $scriptProperties['user'] = $user->toArray();
-                $scriptProperties['profile'] = $profile->toArray();
             }
 
             $email = $subscriber->email;

--- a/core/components/sendex/model/sendex/sxnewsletterqueuebuilder.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletterqueuebuilder.class.php
@@ -6,6 +6,9 @@ require_once dirname(__FILE__) . '/sxnewsletterqueueusers.class.php';
 
 /**
  * Build queue rows from newsletter subscribers.
+ *
+ * Post-#62 home of `sxNewsletter::addQueues` (#63 batch user load lives here via
+ * `sxNewsletterQueueUsers`; facade delegates from `sxnewsletter.class.php`).
  */
 class sxNewsletterQueueBuilder
 {

--- a/core/components/sendex/model/sendex/sxnewsletterqueueusers.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletterqueueusers.class.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Batch-load modUser + Profile for addQueues (#63).
+ */
+class sxNewsletterQueueUsers
+{
+    /**
+     * @param object $xpdo
+     * @param int[] $userIds
+     * @return array{eligible:array<int,array{user:array,profile:array}>,loadedIds:int[]}
+     */
+    public static function loadContexts($xpdo, array $userIds)
+    {
+        $userIds = array_values(array_unique(array_filter(array_map('intval', $userIds))));
+        if ($userIds === array()) {
+            return array(
+                'eligible'  => array(),
+                'loadedIds' => array(),
+            );
+        }
+
+        $profilesByUser = array();
+        foreach ($xpdo->getCollection('modUserProfile', array('internalKey:IN' => $userIds)) as $profile) {
+            $profilesByUser[(int) $profile->get('internalKey')] = $profile;
+        }
+
+        $eligible = array();
+        $loadedIds = array();
+        foreach ($xpdo->getCollection('modUser', array('id:IN' => $userIds)) as $user) {
+            $id = (int) $user->get('id');
+            $loadedIds[] = $id;
+            $profile = isset($profilesByUser[$id]) ? $profilesByUser[$id] : null;
+            if (!$profile || !$user->active || $profile->get('blocked')) {
+                continue;
+            }
+
+            $eligible[$id] = array(
+                'user'    => $user->toArray(),
+                'profile' => $profile->toArray(),
+            );
+        }
+
+        return array(
+            'eligible'  => $eligible,
+            'loadedIds' => $loadedIds,
+        );
+    }
+}

--- a/tests/Stubs/FakeModX.php
+++ b/tests/Stubs/FakeModX.php
@@ -50,6 +50,12 @@ class FakeModX extends modX
     /** @var array<int,array{0:string,1:array}> */
     public $invoked = array();
 
+    /** @var array<string,int> */
+    public $getObjectCalls = array();
+
+    /** @var array<string,int> */
+    public $getCollectionCalls = array();
+
     /** @var array<string,bool> */
     public $permissions = array(
         'edit_document' => true,
@@ -185,6 +191,10 @@ class FakeModX extends modX
      */
     public function getObject($class, $criteria = null)
     {
+        if (!isset($this->getObjectCalls[$class])) {
+            $this->getObjectCalls[$class] = 0;
+        }
+        $this->getObjectCalls[$class]++;
         if ($class === 'modUserProfile') {
             if (is_array($criteria) && isset($criteria['email'])) {
                 $want = strtolower((string) $criteria['email']);
@@ -309,6 +319,19 @@ class FakeModX extends modX
      */
     public function getCollection($class, $criteria = null)
     {
+        if (!isset($this->getCollectionCalls[$class])) {
+            $this->getCollectionCalls[$class] = 0;
+        }
+        $this->getCollectionCalls[$class]++;
+
+        if ($class === 'modUser') {
+            return $this->userCollection($criteria);
+        }
+
+        if ($class === 'modUserProfile') {
+            return $this->userProfileCollection($criteria);
+        }
+
         if ($class === 'sxQueue') {
             return $this->queueCollection($criteria);
         }
@@ -332,6 +355,63 @@ class FakeModX extends modX
         }
 
         return $out;
+    }
+
+    /**
+     * @param FakeQuery|array|null $criteria
+     *
+     * @return modUser[]
+     */
+    protected function userCollection($criteria)
+    {
+        $ids = $this->inCriteria($criteria, 'id');
+        $out = array();
+        foreach ($this->users as $id => $user) {
+            if ($ids && !in_array((int) $id, $ids, true)) {
+                continue;
+            }
+            $out[] = $user;
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param FakeQuery|array|null $criteria
+     *
+     * @return modUserProfile[]
+     */
+    protected function userProfileCollection($criteria)
+    {
+        $ids = $this->inCriteria($criteria, 'internalKey');
+        $out = array();
+        foreach ($this->userProfiles as $userId => $profile) {
+            if ($ids && !in_array((int) $userId, $ids, true)) {
+                continue;
+            }
+            $out[] = $profile;
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param FakeQuery|array|null $criteria
+     * @param string $field
+     *
+     * @return int[]|null
+     */
+    protected function inCriteria($criteria, $field)
+    {
+        $key = $field . ':IN';
+        if ($criteria instanceof FakeQuery && isset($criteria->where[$key])) {
+            return array_map('intval', $criteria->where[$key]);
+        }
+        if (is_array($criteria) && isset($criteria[$key])) {
+            return array_map('intval', $criteria[$key]);
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Unit/NewsletterAddQueuesTest.php
+++ b/tests/Unit/NewsletterAddQueuesTest.php
@@ -104,6 +104,7 @@ class NewsletterAddQueuesTest extends TestCase
         $this->modx->users[5] = $user;
 
         $profile = new modUserProfile($this->modx);
+        $profile->set('internalKey', 5);
         $profile->set('blocked', false);
         $profile->set('email', 'user@example.com');
         $this->modx->userProfiles[5] = $profile;
@@ -129,6 +130,7 @@ class NewsletterAddQueuesTest extends TestCase
         $this->modx->users[5] = $user;
 
         $profile = new modUserProfile($this->modx);
+        $profile->set('internalKey', 5);
         $profile->set('blocked', false);
         $profile->set('email', 'user@example.com');
         $this->modx->userProfiles[5] = $profile;
@@ -138,6 +140,58 @@ class NewsletterAddQueuesTest extends TestCase
         $this->assertSame('Body for user@example.com', $this->modx->queues[0]->get('email_body'));
         // Must be sxSubscriber.id (1), not modUser.id (5)
         $this->assertSame(1, $this->modx->queues[0]->get('subscriber_id'));
+    }
+
+    public function testQueuesWhenUserIdMissingFromDatabase()
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 99,
+            'email'         => 'orphan@example.com',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $this->assertSame(1, $this->newsletter->addQueues());
+        $this->assertCount(1, $this->modx->queues);
+        $this->assertSame('orphan@example.com', $this->modx->queues[0]->get('email_to'));
+    }
+
+    public function testAddQueuesLoadsUsersInBatchNotPerSubscriber()
+    {
+        for ($i = 1; $i <= 100; $i++) {
+            $subscriber = new sxSubscriber($this->modx);
+            $subscriber->fromArray(array(
+                'id'            => $i,
+                'newsletter_id' => 10,
+                'user_id'       => ($i % 10) + 1,
+                'email'         => 'user' . $i . '@example.com',
+            ));
+            $this->modx->subscribers[] = $subscriber;
+        }
+
+        for ($userId = 1; $userId <= 10; $userId++) {
+            $user = new modUser($this->modx);
+            $user->set('id', $userId);
+            $user->active = true;
+            $this->modx->users[$userId] = $user;
+
+            $profile = new modUserProfile($this->modx);
+            $profile->set('internalKey', $userId);
+            $profile->set('blocked', false);
+            $profile->set('email', 'db' . $userId . '@example.com');
+            $this->modx->userProfiles[$userId] = $profile;
+        }
+
+        $this->modx->getObjectCalls = array();
+        $this->modx->getCollectionCalls = array();
+
+        $this->assertSame(100, $this->newsletter->addQueues());
+        $this->assertCount(100, $this->modx->queues);
+        $this->assertSame(1, isset($this->modx->getCollectionCalls['modUser']) ? $this->modx->getCollectionCalls['modUser'] : 0);
+        $this->assertSame(1, isset($this->modx->getCollectionCalls['modUserProfile']) ? $this->modx->getCollectionCalls['modUserProfile'] : 0);
+        $this->assertSame(0, isset($this->modx->getObjectCalls['modUser']) ? $this->modx->getObjectCalls['modUser'] : 0);
     }
 
     public function testSchemaQueueIndexNameMatchesSubscriberIdColumn()

--- a/tests/Unit/NewsletterQueueUsersTest.php
+++ b/tests/Unit/NewsletterQueueUsersTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sxnewsletterqueueusers.class.php';
+
+class NewsletterQueueUsersTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+    }
+
+    public function testLoadContextsReturnsEligibleUsersOnly()
+    {
+        $active = new modUser($this->modx);
+        $active->set('id', 1);
+        $active->active = true;
+        $this->modx->users[1] = $active;
+
+        $blocked = new modUser($this->modx);
+        $blocked->set('id', 2);
+        $blocked->active = true;
+        $this->modx->users[2] = $blocked;
+
+        $profile1 = new modUserProfile($this->modx);
+        $profile1->set('internalKey', 1);
+        $profile1->set('blocked', false);
+        $profile1->set('email', 'a@example.com');
+        $this->modx->userProfiles[1] = $profile1;
+
+        $profile2 = new modUserProfile($this->modx);
+        $profile2->set('internalKey', 2);
+        $profile2->set('blocked', true);
+        $profile2->set('email', 'b@example.com');
+        $this->modx->userProfiles[2] = $profile2;
+
+        $contexts = sxNewsletterQueueUsers::loadContexts($this->modx, array(1, 2, 99));
+
+        $this->assertSame(array(1, 2), $contexts['loadedIds']);
+        $this->assertArrayHasKey(1, $contexts['eligible']);
+        $this->assertArrayNotHasKey(2, $contexts['eligible']);
+        $this->assertSame('a@example.com', $contexts['eligible'][1]['profile']['email']);
+    }
+
+    public function testLoadContextsUsesTwoBatchQueries()
+    {
+        for ($i = 1; $i <= 50; $i++) {
+            $user = new modUser($this->modx);
+            $user->set('id', $i);
+            $user->active = true;
+            $this->modx->users[$i] = $user;
+
+            $profile = new modUserProfile($this->modx);
+            $profile->set('internalKey', $i);
+            $profile->set('blocked', false);
+            $profile->set('email', 'user' . $i . '@example.com');
+            $this->modx->userProfiles[$i] = $profile;
+        }
+
+        sxNewsletterQueueUsers::loadContexts($this->modx, range(1, 50));
+
+        $this->assertSame(1, $this->modx->getCollectionCalls['modUser']);
+        $this->assertSame(1, $this->modx->getCollectionCalls['modUserProfile']);
+        $this->assertSame(0, isset($this->modx->getObjectCalls['modUser']) ? $this->modx->getObjectCalls['modUser'] : 0);
+    }
+}

--- a/tests/Unit/NewsletterSplitContractTest.php
+++ b/tests/Unit/NewsletterSplitContractTest.php
@@ -21,6 +21,7 @@ class NewsletterSplitContractTest extends TestCase
         $files = array(
             'sxnewslettersubscription.class.php',
             'sxnewsletterqueuebuilder.class.php',
+            'sxnewsletterqueueusers.class.php',
             'sxnewslettermailer.class.php',
             'sxsendexevent.class.php',
         );


### PR DESCRIPTION
`addQueues` больше не делает `getObject(modUser)` + `getOne(Profile)` на каждого подписчика. Users и Profile подгружаются двумя batch-запросами до цикла.

## Что сделано
- `sxNewsletterQueueUsers::loadContexts` — `getCollection(modUser, id:IN)` + `getCollection(modUserProfile, internalKey:IN)`
- `sxNewsletterQueueBuilder::addQueues` — preload, lookup в цикле; skip только для найденных, но inactive/blocked
- тесты: `NewsletterQueueUsersTest`, batch-contract на 100 subscribers в `NewsletterAddQueuesTest`
- миграция: не нужна

## Почему так
Code judo: helper рядом с QueueBuilder (#62), без роста facade.

## Review
- Medium+: нет

## Проверка
- `composer test` — exit 0 (143 tests, +4 кейса)
- phpcs — exit 0
- waive: live benchmark 1k+ subscribers — unit-тест на 100 users с тем же O(1) batch-паттерном (нет MODX DB в CI)

Fixes #63