### PR TITLE
perf(queue): Render email body at send time for compact rows

### DIFF
--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#28] `sxProcessorInput::parseIds` accepts `ids` as array or CSV; queue send from snippet/code matches ExtJS `runProcessor` input.
 
 ### Changed
+- [#64] New queue rows store empty `email_body` (compact mode); body is rendered at send from newsletter template; legacy rows with stored HTML still send as-is.
 - [#63] `addQueues` batch-loads `modUser` + Profile (`id:IN`) once instead of N+1 per subscriber.
 - [#66] `sxNewsletterMailer` centralizes From/Reply-To/HTML setup for activation mail and queue delivery; activation reply-to uses `email_reply` like queue build.
 - [#69] Mgr processors share `sxSendexProcessor` (`edit_document` + `requireIds` / `parseIds`); get-list processors declare `view_document`.

--- a/core/components/sendex/model/sendex/sxnewslettermailer.class.php
+++ b/core/components/sendex/model/sendex/sxnewslettermailer.class.php
@@ -1,12 +1,14 @@
 <?php
 
+require_once dirname(__FILE__) . '/sxqueuebodyrenderer.class.php';
+
 /**
  * Shared newsletter mail headers + PHPMailer setup (#66).
  *
  * Post-#62 mail paths (issue originally named sxNewsletter::send/checkEmail):
  * - activation: snippet → Sendex::sendEmail → buildActivationMessage
- * - queue build: sxNewsletterQueueBuilder::addQueues → buildMessage
- * - queue send: sxQueueSender::deliverMail → messageFromQueue
+ * - queue build: sxNewsletterQueueBuilder::addQueues → compact row (headers only)
+ * - queue send: sxQueueSender::deliverMail → messageFromQueue (+ sxQueueBodyRenderer when body empty)
  */
 class sxNewsletterMailer
 {
@@ -92,17 +94,26 @@ class sxNewsletterMailer
 
     /**
      * @param object $queue sxQueue
-     * @return array
+     * @return array|false
      */
     public static function messageFromQueue($queue)
     {
+        $body = (string) self::readField($queue, 'email_body');
+        if (!sxQueueBodyRenderer::usesStoredBody($queue)) {
+            $rendered = sxQueueBodyRenderer::renderForQueue($queue->xpdo, $queue);
+            if ($rendered === false) {
+                return false;
+            }
+            $body = $rendered;
+        }
+
         return array(
-            'email_to'        => $queue->email_to,
-            'email_body'      => $queue->email_body,
-            'email_from'      => $queue->email_from,
-            'email_from_name' => $queue->email_from_name,
-            'email_subject'   => $queue->email_subject,
-            'email_reply'     => $queue->email_reply,
+            'email_to'        => self::readField($queue, 'email_to'),
+            'email_body'      => $body,
+            'email_from'      => self::readField($queue, 'email_from'),
+            'email_from_name' => self::readField($queue, 'email_from_name'),
+            'email_subject'   => self::readField($queue, 'email_subject'),
+            'email_reply'     => self::readField($queue, 'email_reply'),
         );
     }
 

--- a/core/components/sendex/model/sendex/sxnewsletterqueuebuilder.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletterqueuebuilder.class.php
@@ -7,7 +7,11 @@ require_once dirname(__FILE__) . '/sxnewsletterqueueusers.class.php';
 /**
  * Build queue rows from newsletter subscribers.
  *
- * Post-#62 home of `sxNewsletter::addQueues` (#63 batch user load; #64 compact body at send).
+ * Post-#62 home of `sxNewsletter::addQueues` (issue #64 also named this path).
+ * Send path: `sxQueue::send()` → `sxQueueSender` → compact body via `sxQueueBodyRenderer`.
+ *
+ * Compact mode (#64): new rows store empty `email_body` (no extra DB column); headers
+ * and recipient are snapshotted; HTML is rendered at send time.
  */
 class sxNewsletterQueueBuilder
 {

--- a/core/components/sendex/model/sendex/sxnewsletterqueuebuilder.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletterqueuebuilder.class.php
@@ -7,8 +7,7 @@ require_once dirname(__FILE__) . '/sxnewsletterqueueusers.class.php';
 /**
  * Build queue rows from newsletter subscribers.
  *
- * Post-#62 home of `sxNewsletter::addQueues` (#63 batch user load lives here via
- * `sxNewsletterQueueUsers`; facade delegates from `sxnewsletter.class.php`).
+ * Post-#62 home of `sxNewsletter::addQueues` (#63 batch user load; #64 compact body at send).
  */
 class sxNewsletterQueueBuilder
 {
@@ -31,13 +30,6 @@ class sxNewsletterQueueBuilder
         $newsletter = $this->newsletter;
         $xpdo = $newsletter->xpdo;
         $template = null;
-        $params = $newsletter->toArray();
-        /** @var modParser $parser */
-        $parser = $xpdo->getService(
-            'parser',
-            $xpdo->getOption('parser_class', null, 'modParser'),
-            $xpdo->getOption('parser_class_path', null, '')
-        );
 
         if (!$subscribers = $newsletter->getMany('Subscribers')) {
             return $xpdo->lexicon('sendex_newsletter_err_no_subscribers');
@@ -54,6 +46,8 @@ class sxNewsletterQueueBuilder
 
         $newsletterId = (int) $newsletter->id;
         $before = (int) $xpdo->getCount('sxQueue', array('newsletter_id' => $newsletterId));
+        $subject = !empty($newsletter->email_subject) ? $newsletter->email_subject : 'No subject';
+        $headers = sxNewsletterMailer::resolveHeaders($newsletter, $xpdo);
 
         $userIds = array();
         foreach ($subscribers as $subscriber) {
@@ -66,47 +60,26 @@ class sxNewsletterQueueBuilder
 
         /** @var sxSubscriber $subscriber */
         foreach ($subscribers as $subscriber) {
-            $scriptProperties = array(
-                'newsletter' => $params,
-                'subscriber' => $subscriber->toArray(),
-            );
-
             $userId = (int) $subscriber->get('user_id');
-            if ($userId > 0) {
-                if (isset($userContexts['eligible'][$userId])) {
-                    $scriptProperties['user'] = $userContexts['eligible'][$userId]['user'];
-                    $scriptProperties['profile'] = $userContexts['eligible'][$userId]['profile'];
-                } elseif (in_array($userId, $userContexts['loadedIds'], true)) {
-                    continue;
-                }
+            if (
+                $userId > 0
+                && in_array($userId, $userContexts['loadedIds'], true)
+                && !isset($userContexts['eligible'][$userId])
+            ) {
+                continue;
             }
-
-            $email = $subscriber->email;
-            $subject = !empty($newsletter->email_subject) ? $newsletter->email_subject : 'No subject';
-
-            $template->_cacheable = false;
-            $template->_processed = false;
-            $template->_output = '';
-            $body = $template->process($scriptProperties);
-
-            if ($parser && $parser instanceof modParser) {
-                $maxIterations = (int) $xpdo->getOption('parser_max_iterations', null, 10);
-                $parser->processElementTags('', $body, true, true, '[[', ']]', array(), $maxIterations);
-            }
-
-            $message = sxNewsletterMailer::buildMessage($newsletter, $subscriber, $subject, $body, $xpdo);
 
             /** @var sxQueue $queue */
             $queue = $xpdo->newObject('sxQueue');
             $queue->fromArray(array(
                 'subscriber_id'   => sxQueueLink::subscriberIdFromSubscriber($subscriber),
                 'newsletter_id'   => $newsletterId,
-                'email_to'        => $message['email_to'],
-                'email_subject'   => $message['email_subject'],
-                'email_body'      => $message['email_body'],
-                'email_from'      => $message['email_from'],
-                'email_from_name' => $message['email_from_name'],
-                'email_reply'     => $message['email_reply'],
+                'email_to'        => $subscriber->get('email'),
+                'email_subject'   => $subject,
+                'email_body'      => '',
+                'email_from'      => $headers['email_from'],
+                'email_from_name' => $headers['email_from_name'],
+                'email_reply'     => $headers['email_reply'],
             ));
             $queue->save();
         }

--- a/core/components/sendex/model/sendex/sxqueue.class.php
+++ b/core/components/sendex/model/sendex/sxqueue.class.php
@@ -32,9 +32,9 @@ class sxQueue extends xPDOSimpleObject
 
 
     /**
-     * Sends an email to subscriber
+     * Send queue email (delegates to sxQueueSender; compact body rendered at send #64).
      *
-     * @return bool|string
+     * @return true|false|string
      */
     public function send()
     {

--- a/core/components/sendex/model/sendex/sxqueuebodyrenderer.class.php
+++ b/core/components/sendex/model/sendex/sxqueuebodyrenderer.class.php
@@ -3,13 +3,19 @@
 require_once dirname(__FILE__) . '/sxnewsletterqueueusers.class.php';
 
 /**
- * Render queue email body at send time when row has no stored HTML (#64).
+ * Render queue email body at send time for compact rows (#64).
  *
- * Legacy rows with non-empty `email_body` are sent as-is via sxNewsletterMailer.
+ * Call chain from issue #64: `sxQueue::send()` → `sxQueueSender::deliverMail`
+ * → `sxNewsletterMailer::messageFromQueue` → this class when body is empty.
+ *
+ * Compact mode: empty `email_body` (no separate column). Legacy rows with non-empty
+ * `email_body` skip rendering and are sent as-is via sxNewsletterMailer.
  */
 class sxQueueBodyRenderer
 {
     /**
+     * True when queue row stores pre-rendered HTML (legacy). False = compact (#64).
+     *
      * @param object $queue sxQueue-like
      * @return bool
      */

--- a/core/components/sendex/model/sendex/sxqueuebodyrenderer.class.php
+++ b/core/components/sendex/model/sendex/sxqueuebodyrenderer.class.php
@@ -1,0 +1,139 @@
+<?php
+
+require_once dirname(__FILE__) . '/sxnewsletterqueueusers.class.php';
+
+/**
+ * Render queue email body at send time when row has no stored HTML (#64).
+ *
+ * Legacy rows with non-empty `email_body` are sent as-is via sxNewsletterMailer.
+ */
+class sxQueueBodyRenderer
+{
+    /**
+     * @param object $queue sxQueue-like
+     * @return bool
+     */
+    public static function usesStoredBody($queue)
+    {
+        return trim((string) self::field($queue, 'email_body')) !== '';
+    }
+
+    /**
+     * @param object $xpdo
+     * @param object $queue sxQueue-like
+     * @return string|false
+     */
+    public static function renderForQueue($xpdo, $queue)
+    {
+        $newsletterId = (int) self::field($queue, 'newsletter_id');
+        /** @var sxNewsletter|null $newsletter */
+        $newsletter = $xpdo->getObject('sxNewsletter', $newsletterId);
+        if (!$newsletter) {
+            return false;
+        }
+
+        $subscriber = self::resolveSubscriber($xpdo, $queue, $newsletterId);
+        if (!$subscriber) {
+            return false;
+        }
+
+        return self::render($xpdo, $newsletter, $subscriber);
+    }
+
+    /**
+     * @param object $xpdo
+     * @param object $newsletter sxNewsletter
+     * @param object $subscriber sxSubscriber
+     * @return string|false
+     */
+    public static function render($xpdo, $newsletter, $subscriber)
+    {
+        $templateId = (int) $newsletter->get('template');
+        /** @var modTemplate|null $template */
+        $template = $templateId > 0 ? $xpdo->getObject('modTemplate', $templateId) : null;
+        if (!$template || !($template instanceof modTemplate)) {
+            return false;
+        }
+
+        $scriptProperties = array(
+            'newsletter' => $newsletter->toArray(),
+            'subscriber' => $subscriber->toArray(),
+        );
+
+        $userId = (int) $subscriber->get('user_id');
+        if ($userId > 0) {
+            $contexts = sxNewsletterQueueUsers::loadContexts($xpdo, array($userId));
+            if (isset($contexts['eligible'][$userId])) {
+                $scriptProperties['user'] = $contexts['eligible'][$userId]['user'];
+                $scriptProperties['profile'] = $contexts['eligible'][$userId]['profile'];
+            } elseif (in_array($userId, $contexts['loadedIds'], true)) {
+                return false;
+            }
+        }
+
+        $template->_cacheable = false;
+        $template->_processed = false;
+        $template->_output = '';
+        $body = $template->process($scriptProperties);
+
+        /** @var modParser|null $parser */
+        $parser = $xpdo->getService(
+            'parser',
+            $xpdo->getOption('parser_class', null, 'modParser'),
+            $xpdo->getOption('parser_class_path', null, '')
+        );
+        if ($parser && $parser instanceof modParser) {
+            $maxIterations = (int) $xpdo->getOption('parser_max_iterations', null, 10);
+            $parser->processElementTags('', $body, true, true, '[[', ']]', array(), $maxIterations);
+        }
+
+        return $body;
+    }
+
+    /**
+     * @param object $xpdo
+     * @param object $queue sxQueue-like
+     * @param int $newsletterId
+     * @return sxSubscriber|null
+     */
+    protected static function resolveSubscriber($xpdo, $queue, $newsletterId)
+    {
+        $subscriberId = (int) self::field($queue, 'subscriber_id');
+        if ($subscriberId > 0) {
+            /** @var sxSubscriber|null $subscriber */
+            $subscriber = $xpdo->getObject('sxSubscriber', $subscriberId);
+            if ($subscriber) {
+                return $subscriber;
+            }
+        }
+
+        $email = trim((string) self::field($queue, 'email_to'));
+        if ($email === '') {
+            return null;
+        }
+
+        /** @var sxSubscriber $guest */
+        $guest = $xpdo->newObject('sxSubscriber');
+        $guest->fromArray(array(
+            'newsletter_id' => $newsletterId,
+            'user_id'       => 0,
+            'email'         => $email,
+        ), '', true, true);
+
+        return $guest;
+    }
+
+    /**
+     * @param object $source
+     * @param string $key
+     * @return mixed
+     */
+    protected static function field($source, $key)
+    {
+        if (is_object($source) && method_exists($source, 'get')) {
+            return $source->get($key);
+        }
+
+        return '';
+    }
+}

--- a/core/components/sendex/model/sendex/sxqueuesender.class.php
+++ b/core/components/sendex/model/sendex/sxqueuesender.class.php
@@ -96,9 +96,14 @@ class sxQueueSender
      */
     public static function deliverMail($queue)
     {
+        $message = sxNewsletterMailer::messageFromQueue($queue);
+        if ($message === false) {
+            return $queue->xpdo->lexicon('sendex_newsletter_err_no_template');
+        }
+
         /** @var modPHPMailer $mail */
         $mail = $queue->xpdo->getService('mail', 'mail.modPHPMailer');
-        sxNewsletterMailer::configureMailer($mail, sxNewsletterMailer::messageFromQueue($queue));
+        sxNewsletterMailer::configureMailer($mail, $message);
         if (!$mail->send()) {
             $error = $mail->mailer->ErrorInfo;
             $queue->xpdo->log(

--- a/tests/Unit/NewsletterAddQueuesTest.php
+++ b/tests/Unit/NewsletterAddQueuesTest.php
@@ -65,6 +65,7 @@ class NewsletterAddQueuesTest extends TestCase
         $this->assertSame('guest@example.com', $this->modx->queues[0]->get('email_to'));
         $this->assertSame('Hello', $this->modx->queues[0]->get('email_subject'));
         $this->assertSame(1, $this->modx->queues[0]->get('subscriber_id'));
+        $this->assertSame('', $this->modx->queues[0]->get('email_body'));
     }
 
     public function testSkipsUserWithoutProfile()
@@ -137,7 +138,7 @@ class NewsletterAddQueuesTest extends TestCase
 
         $this->assertSame(1, $this->newsletter->addQueues());
         $this->assertCount(1, $this->modx->queues);
-        $this->assertSame('Body for user@example.com', $this->modx->queues[0]->get('email_body'));
+        $this->assertSame('', $this->modx->queues[0]->get('email_body'));
         // Must be sxSubscriber.id (1), not modUser.id (5)
         $this->assertSame(1, $this->modx->queues[0]->get('subscriber_id'));
     }
@@ -192,6 +193,15 @@ class NewsletterAddQueuesTest extends TestCase
         $this->assertSame(1, isset($this->modx->getCollectionCalls['modUser']) ? $this->modx->getCollectionCalls['modUser'] : 0);
         $this->assertSame(1, isset($this->modx->getCollectionCalls['modUserProfile']) ? $this->modx->getCollectionCalls['modUserProfile'] : 0);
         $this->assertSame(0, isset($this->modx->getObjectCalls['modUser']) ? $this->modx->getObjectCalls['modUser'] : 0);
+    }
+
+    public function testAddQueuesStoresCompactBody()
+    {
+        $builder = file_get_contents(
+            dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sxnewsletterqueuebuilder.class.php'
+        );
+
+        $this->assertStringContainsString("'email_body'      => ''", $builder);
     }
 
     public function testSchemaQueueIndexNameMatchesSubscriberIdColumn()

--- a/tests/Unit/NewsletterMailerTest.php
+++ b/tests/Unit/NewsletterMailerTest.php
@@ -115,6 +115,8 @@ class NewsletterMailerTest extends TestCase
 
         $this->assertStringContainsString('sxNewsletterMailer::configureMailer', $sendex);
         $this->assertStringContainsString('sxNewsletterMailer::configureMailer', $sender);
-        $this->assertStringContainsString('sxNewsletterMailer::buildMessage', $builder);
+        $mailer = file_get_contents($base . 'sxnewslettermailer.class.php');
+        $this->assertStringContainsString('sxNewsletterMailer::resolveHeaders', $builder);
+        $this->assertStringContainsString('sxQueueBodyRenderer::renderForQueue', $mailer);
     }
 }

--- a/tests/Unit/NewsletterSplitContractTest.php
+++ b/tests/Unit/NewsletterSplitContractTest.php
@@ -22,6 +22,7 @@ class NewsletterSplitContractTest extends TestCase
             'sxnewslettersubscription.class.php',
             'sxnewsletterqueuebuilder.class.php',
             'sxnewsletterqueueusers.class.php',
+            'sxqueuebodyrenderer.class.php',
             'sxnewslettermailer.class.php',
             'sxsendexevent.class.php',
         );

--- a/tests/Unit/QueueBodyRendererTest.php
+++ b/tests/Unit/QueueBodyRendererTest.php
@@ -1,0 +1,116 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sxqueuebodyrenderer.class.php';
+require_once dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sxqueuesender.class.php';
+
+class QueueBodyRendererTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+    }
+
+    public function testUsesStoredBodyWhenNonEmpty()
+    {
+        $queue = new sxQueue($this->modx);
+        $queue->set('email_body', '<p>legacy</p>');
+
+        $this->assertTrue(sxQueueBodyRenderer::usesStoredBody($queue));
+    }
+
+    public function testCompactRowHasEmptyBody()
+    {
+        $queue = new sxQueue($this->modx);
+        $queue->set('email_body', '');
+
+        $this->assertFalse(sxQueueBodyRenderer::usesStoredBody($queue));
+    }
+
+    public function testRenderForQueuePersonalizesSubscriber()
+    {
+        $newsletter = new TestableNewsletter($this->modx);
+        $newsletter->set('id', 1);
+        $newsletter->set('template', 1);
+        $this->modx->newsletters[1] = $newsletter;
+        $this->modx->templates[1] = new modTemplate();
+
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 5,
+            'newsletter_id' => 1,
+            'user_id'       => 0,
+            'email'         => 'guest@example.com',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $queue = new sxQueue($this->modx);
+        $queue->fromArray(array(
+            'newsletter_id' => 1,
+            'subscriber_id' => 5,
+            'email_to'      => 'guest@example.com',
+            'email_body'    => '',
+        ));
+
+        $this->assertSame('Body for guest@example.com', sxQueueBodyRenderer::renderForQueue($this->modx, $queue));
+    }
+
+    public function testDeliverMailUsesStoredBodyForLegacyRows()
+    {
+        $queue = new sxQueue($this->modx);
+        $queue->fromArray(array(
+            'id'            => 1,
+            'email_to'      => 'legacy@example.com',
+            'email_subject' => 'Hi',
+            'email_body'    => 'Stored HTML',
+            'email_from'    => 'from@example.com',
+            'email_from_name' => 'From',
+            'email_reply'   => 'from@example.com',
+        ));
+
+        /** @var FakeMail $mail */
+        $mail = $this->modx->getService('mail');
+        $this->assertTrue(sxQueueSender::deliverMail($queue));
+        $this->assertSame('Stored HTML', $mail->sets[modMail::MAIL_BODY]);
+    }
+
+    public function testDeliverMailRendersCompactBodyAtSendTime()
+    {
+        $newsletter = new TestableNewsletter($this->modx);
+        $newsletter->set('id', 1);
+        $newsletter->set('template', 1);
+        $this->modx->newsletters[1] = $newsletter;
+        $this->modx->templates[1] = new modTemplate();
+
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 2,
+            'newsletter_id' => 1,
+            'user_id'       => 0,
+            'email'         => 'send@example.com',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $queue = new sxQueue($this->modx);
+        $queue->fromArray(array(
+            'id'              => 2,
+            'newsletter_id'   => 1,
+            'subscriber_id'   => 2,
+            'email_to'        => 'send@example.com',
+            'email_subject'   => 'Hi',
+            'email_body'      => '',
+            'email_from'      => 'from@example.com',
+            'email_from_name' => 'From',
+            'email_reply'     => 'from@example.com',
+        ));
+
+        /** @var FakeMail $mail */
+        $mail = $this->modx->getService('mail');
+        $this->assertTrue(sxQueueSender::deliverMail($queue));
+        $this->assertSame('Body for send@example.com', $mail->sets[modMail::MAIL_BODY]);
+    }
+}


### PR DESCRIPTION
Новые строки очереди не хранят HTML: `email_body` пустой, персонализация — при send из шаблона newsletter. Старые строки с телом отправляются как раньше.

## Что сделано
- `sxQueueBodyRenderer` — рендер template + parser при send для compact-строк
- `addQueues` — только headers/to/subject; без template process в цикле
- `messageFromQueue` — legacy body as-is, иначе render; ошибка → lexicon `sendex_newsletter_err_no_template`
- тесты: `QueueBodyRendererTest`, обновлены `NewsletterAddQueuesTest`, `NewsletterMailerTest`
- миграция: не нужна (compact = пустой `email_body`, схема без изменений)

## Review
- Findings: нет (Low по stale issue paths и compact convention закрыты в PR)

## Проверка
- `composer test` — exit 0 (149 tests, +6)
- phpcs — exit 0

Fixes #64