### PR TITLE
perf(subscribers): Bulk insert for add_group

### DIFF
--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#28] `sxProcessorInput::parseIds` accepts `ids` as array or CSV; queue send from snippet/code matches ExtJS `runProcessor` input.
 
 ### Changed
+- [#70] `add_group` bulk-subscribes group members via one query + chunked multi-row INSERT; mgr sync path skips per-row subscribe events (#44).
 - [#64] New queue rows store empty `email_body` (compact mode); body is rendered at send from newsletter template; legacy rows with stored HTML still send as-is.
 - [#63] `addQueues` batch-loads `modUser` + Profile (`id:IN`) once instead of N+1 per subscriber.
 - [#66] `sxNewsletterMailer` centralizes From/Reply-To/HTML setup for activation mail and queue delivery; activation reply-to uses `email_reply` like queue build.

--- a/core/components/sendex/model/sendex/sxnewsletter.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletter.class.php
@@ -2,6 +2,7 @@
 
 require_once dirname(__FILE__) . '/sxnewslettersubscription.class.php';
 require_once dirname(__FILE__) . '/sxnewsletterqueuebuilder.class.php';
+require_once dirname(__FILE__) . '/sxnewslettergroupsubscribe.class.php';
 require_once dirname(__FILE__) . '/sxsendexevent.class.php';
 
 /**
@@ -58,6 +59,17 @@ class sxNewsletter extends xPDOSimpleObject
     public function subscribe($user_id = 0, $email = '')
     {
         return $this->subscription()->subscribe($user_id, $email);
+    }
+
+    /**
+     * Bulk subscribe active members of a user group (mgr add_group; #70).
+     *
+     * @param int $group_id
+     * @return true|string[]
+     */
+    public function subscribeGroup($group_id = 0)
+    {
+        return sxNewsletterGroupSubscribe::subscribeGroup($this, $group_id);
     }
 
     /**

--- a/core/components/sendex/model/sendex/sxnewslettergroupsubscribe.class.php
+++ b/core/components/sendex/model/sendex/sxnewslettergroupsubscribe.class.php
@@ -1,0 +1,259 @@
+<?php
+
+require_once dirname(__FILE__) . '/sxsubscribercode.class.php';
+require_once dirname(__FILE__) . '/sxsubscribermatch.class.php';
+
+/**
+ * Bulk subscribe active group members to a newsletter (#70).
+ * Mgr sync path: no per-row sxOn*Subscribe events (#44).
+ */
+class sxNewsletterGroupSubscribe
+{
+    /** @var int */
+    const INSERT_CHUNK = 500;
+
+    /**
+     * @param sxNewsletter $newsletter
+     * @param int $groupId
+     * @return true|string[] true on success, or "username: message" errors
+     */
+    public static function subscribeGroup(sxNewsletter $newsletter, $groupId)
+    {
+        $xpdo = $newsletter->xpdo;
+        $newsletterId = (int) $newsletter->get('id');
+        $groupId = (int) $groupId;
+
+        $members = static::fetchGroupMembers($xpdo, $groupId);
+        if ($members === array()) {
+            return true;
+        }
+
+        /** @var sxSubscriber[] $existing */
+        $existing = $xpdo->getCollection('sxSubscriber', array(
+            'newsletter_id' => $newsletterId,
+        ));
+
+        $plan = self::plan($members, $newsletterId, $existing, $xpdo);
+        $errors = $plan['errors'];
+
+        if ($plan['promote'] !== array()) {
+            $errors = array_merge($errors, self::promoteGuestRows($xpdo, $plan['promote']));
+        }
+
+        if ($plan['insert'] !== array()) {
+            $errors = array_merge(
+                $errors,
+                self::bulkInsert($xpdo, $newsletterId, $plan['insert'])
+            );
+        }
+
+        return $errors === array() ? true : $errors;
+    }
+
+    /**
+     * @param array<int,array{user_id:int,username:string,email:string}> $members
+     * @param int $newsletterId
+     * @param sxSubscriber[] $existing
+     * @param object $xpdo
+     * @return array{insert:array<int,array{user_id:int,username:string,email:string}>,promote:array<int,array{subscriber_id:int,user_id:int,username:string}>,errors:string[]}
+     */
+    public static function plan(array $members, $newsletterId, array $existing, $xpdo)
+    {
+        $newsletterId = (int) $newsletterId;
+        $insert = array();
+        $promote = array();
+        $errors = array();
+
+        foreach ($members as $member) {
+            $userId = (int) $member['user_id'];
+            $email = sxSubscriberMatch::normalizeEmail($member['email']);
+            $username = (string) $member['username'];
+
+            if ($email === '' || !preg_match('/.+@.+\..+/i', $email)) {
+                $errors[] = $username . ': ' . $xpdo->lexicon('sendex_subscriber_err_email');
+                continue;
+            }
+
+            $action = self::resolveAction($newsletterId, $userId, $email, $existing);
+            if ($action === 'skip') {
+                continue;
+            }
+            if ($action === 'insert') {
+                $insert[] = array(
+                    'user_id'  => $userId,
+                    'username' => $username,
+                    'email'    => $email,
+                );
+                continue;
+            }
+
+            $promote[] = array(
+                'subscriber_id' => $action['subscriber_id'],
+                'user_id'       => $userId,
+                'username'      => $username,
+            );
+        }
+
+        return array(
+            'insert'  => $insert,
+            'promote' => $promote,
+            'errors'  => $errors,
+        );
+    }
+
+    /**
+     * @param object $xpdo
+     * @param int $groupId
+     * @return array<int,array{user_id:int,username:string,email:string}>
+     */
+    public static function fetchGroupMembers($xpdo, $groupId)
+    {
+        $groupId = (int) $groupId;
+        if ($groupId <= 0) {
+            return array();
+        }
+
+        $c = $xpdo->newQuery('modUser');
+        $c->select($xpdo->getSelectColumns('modUser', 'modUser', '', array('id', 'username')));
+        $c->select(array(
+            'Profile.email' => 'email',
+        ));
+        $c->innerJoin('modUserGroupMember', 'UserGroupMembers');
+        $c->innerJoin(
+            'modUserGroup',
+            'UserGroup',
+            '`UserGroupMembers`.`user_group` = `UserGroup`.`id`'
+                . ' AND `UserGroup`.`id` = ' . $groupId
+        );
+        $c->innerJoin(
+            'modUserProfile',
+            'Profile',
+            '`Profile`.`internalKey` = `modUser`.`id`'
+        );
+        $c->where(array(
+            'modUser.active'  => true,
+            'Profile.blocked' => false,
+        ));
+
+        $members = array();
+        if ($c->prepare() && $c->stmt->execute()) {
+            while ($row = $c->stmt->fetch(PDO::FETCH_ASSOC)) {
+                $members[] = array(
+                    'user_id'  => (int) $row['id'],
+                    'username' => (string) $row['username'],
+                    'email'    => (string) $row['email'],
+                );
+            }
+        }
+
+        return $members;
+    }
+
+    /**
+     * @param int $newsletterId
+     * @param int $userId
+     * @param string $email
+     * @param sxSubscriber[] $existing
+     * @return string|array{type:string,subscriber_id:int}
+     */
+    protected static function resolveAction($newsletterId, $userId, $email, array $existing)
+    {
+        foreach ($existing as $subscriber) {
+            $matches = sxSubscriberMatch::rowMatches(
+                $newsletterId,
+                $userId,
+                $email,
+                (int) $subscriber->get('newsletter_id'),
+                (int) $subscriber->get('user_id'),
+                (string) $subscriber->get('email')
+            );
+            if (!$matches) {
+                continue;
+            }
+
+            if ($userId > 0 && (int) $subscriber->get('user_id') === 0) {
+                return array(
+                    'type'          => 'promote',
+                    'subscriber_id' => (int) $subscriber->get('id'),
+                );
+            }
+
+            return 'skip';
+        }
+
+        return 'insert';
+    }
+
+    /**
+     * @param object $xpdo
+     * @param array<int,array{subscriber_id:int,user_id:int,username:string}> $rows
+     * @return string[]
+     */
+    protected static function promoteGuestRows($xpdo, array $rows)
+    {
+        $errors = array();
+
+        foreach ($rows as $row) {
+            /** @var sxSubscriber $subscriber */
+            $subscriber = $xpdo->getObject('sxSubscriber', (int) $row['subscriber_id']);
+            if (!$subscriber) {
+                $errors[] = $row['username'] . ': ' . $xpdo->lexicon('sendex_subscriber_err_save');
+                continue;
+            }
+
+            $subscriber->set('user_id', (int) $row['user_id']);
+            if (!$subscriber->save()) {
+                $errors[] = $row['username'] . ': ' . $xpdo->lexicon('sendex_subscriber_err_save');
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param object $xpdo
+     * @param int $newsletterId
+     * @param array<int,array{user_id:int,username:string,email:string}> $rows
+     * @return string[]
+     */
+    protected static function bulkInsert($xpdo, $newsletterId, array $rows)
+    {
+        if ($rows === array()) {
+            return array();
+        }
+
+        $table = $xpdo->getTableName('sxSubscriber');
+        $errors = array();
+
+        foreach (array_chunk($rows, self::INSERT_CHUNK) as $chunk) {
+            $placeholders = array();
+            $values = array();
+
+            foreach ($chunk as $row) {
+                $placeholders[] = '(?, ?, ?, ?)';
+                $values[] = (int) $newsletterId;
+                $values[] = (int) $row['user_id'];
+                $values[] = $row['email'];
+                $values[] = sxSubscriberCode::generate(
+                    $row['user_id'],
+                    $newsletterId,
+                    $row['email']
+                );
+            }
+
+            $sql = 'INSERT INTO ' . $table
+                . ' (`newsletter_id`, `user_id`, `email`, `code`) VALUES '
+                . implode(', ', $placeholders);
+
+            $conn = $xpdo->getConnection();
+            $stmt = $conn->prepare($sql);
+            if (!$stmt || !$stmt->execute($values)) {
+                foreach ($chunk as $row) {
+                    $errors[] = $row['username'] . ': ' . $xpdo->lexicon('sendex_subscriber_err_save');
+                }
+            }
+        }
+
+        return $errors;
+    }
+}

--- a/core/components/sendex/processors/mgr/newsletter/subscriber/add_group.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/subscriber/add_group.class.php
@@ -1,76 +1,41 @@
 <?php
 
-/**
- * Add a Subscribers from the UserGroup
- */
+require_once dirname(__DIR__, 2) . '/sendexprocessor.class.php';
 
-class sxSubscriberAddGroupProcessor extends modObjectProcessor
+/**
+ * Add subscribers from a user group (bulk insert; #70).
+ */
+class sxSubscriberAddGroupProcessor extends sxSendexProcessor
 {
     public $classKey = 'modUser';
     public $languageTopics = array('sendex');
-    public $permission = 'edit_document';
-
 
     /**
-     * @return bool
+     * @return array|string
      */
     public function process()
     {
+        if ($failure = $this->failureIfNoPermission()) {
+            return $failure;
+        }
+
         if (!$group_id = (int) $this->getProperty('group_id')) {
             return $this->failure($this->modx->lexicon('sendex_subscriber_err_group'));
         } elseif (!$newsletter_id = (int) $this->getProperty('newsletter_id')) {
             return $this->failure($this->modx->lexicon('sendex_newsletter_err_ns'));
         }
-        $errors = array();
 
-        $c = $this->modx->newQuery($this->classKey);
-        $c->select($this->modx->getSelectColumns($this->classKey, $this->classKey, '', array('id', 'username')));
-        $c->innerJoin('modUserGroupMember', 'UserGroupMembers');
-        $c->innerJoin(
-            'modUserGroup',
-            'UserGroup',
-            '`UserGroupMembers`.`user_group` = `UserGroup`.`id`'
-                . ' AND `UserGroup`.`id` = ' . $group_id
-        );
-        $c->innerJoin(
-            'modUserProfile',
-            'Profile',
-            '`Profile`.`internalKey` = `modUser`.`id`'
-        );
-        $c->leftJoin(
-            'sxSubscriber',
-            'Subscriber',
-            '`Subscriber`.`user_id` = `modUser`.`id`'
-                . ' AND `Subscriber`.`newsletter_id` = ' . $newsletter_id
-        );
-        $c->where(array(
-            'Subscriber.user_id' => null,
-            'modUser.active'     => true,
-            'Profile.blocked'    => false,
-        ));
-        if ($c->prepare() && $c->stmt->execute()) {
-            while ($row = $c->stmt->fetch(PDO::FETCH_ASSOC)) {
-                /** @var modProcessorResponse $response */
-                $this->modx->error->reset();
-                $response = $this->modx->runProcessor(
-                    'mgr/newsletter/subscriber/create',
-                    array(
-                        'newsletter_id' => $newsletter_id,
-                        'user_id'       => $row['id'],
-                    ),
-                    array(
-                        'processors_path' => MODX_CORE_PATH . 'components/sendex/processors/',
-                    )
-                );
-                if ($response->isError()) {
-                    $errors[] = $row['username'] . ': ' . $response->getMessage();
-                }
-            }
+        /** @var sxNewsletter $newsletter */
+        $newsletter = $this->modx->getObject('sxNewsletter', $newsletter_id);
+        if (!$newsletter) {
+            return $this->failure($this->modx->lexicon('sendex_newsletter_err_nf'));
         }
 
-        return !empty($errors)
-            ? $this->failure(implode('<br/>', $errors))
-            : $this->success();
+        $result = $newsletter->subscribeGroup($group_id);
+
+        return $result === true
+            ? $this->success()
+            : $this->failure(implode('<br/>', $result));
     }
 }
 

--- a/tests/Stubs/FakeModX.php
+++ b/tests/Stubs/FakeModX.php
@@ -66,6 +66,9 @@ class FakeModX extends modX
     /** @var array<int,array{0:mixed,1:string}> */
     public $logs = array();
 
+    /** @var FakePdoConnection|null */
+    public $fakeConnection;
+
     public function __construct()
     {
         $this->services['registry'] = new FakeRegistry($this);
@@ -523,6 +526,31 @@ class FakeModX extends modX
         }
 
         return $out;
+    }
+
+    /**
+     * @param string $class
+     * @return string
+     */
+    public function getTableName($class)
+    {
+        if ($class === 'sxSubscriber') {
+            return 'sendex_subscribers';
+        }
+
+        return $class;
+    }
+
+    /**
+     * @return FakePdoConnection
+     */
+    public function getConnection()
+    {
+        if ($this->fakeConnection === null) {
+            $this->fakeConnection = new FakePdoConnection($this);
+        }
+
+        return $this->fakeConnection;
     }
 
     /**

--- a/tests/Stubs/FakePdoConnection.php
+++ b/tests/Stubs/FakePdoConnection.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * PDO stub for bulk INSERT tests (#70).
+ */
+class FakePdoConnection
+{
+    /** @var FakeModX */
+    private $modx;
+
+    /** @var int */
+    public $prepareCalls = 0;
+
+    /** @var int */
+    public $executeCalls = 0;
+
+    /** @var bool */
+    public $executeResult = true;
+
+    /** @var array<int,array{sql:string,values:array}> */
+    public $executions = array();
+
+    /**
+     * @param FakeModX $modx
+     */
+    public function __construct(FakeModX $modx)
+    {
+        $this->modx = $modx;
+    }
+
+    /**
+     * @param string $sql
+     * @return FakePdoStatement
+     */
+    public function prepare($sql)
+    {
+        $this->prepareCalls++;
+
+        return new FakePdoStatement($this->modx, $this, $sql);
+    }
+}

--- a/tests/Stubs/FakePdoStatement.php
+++ b/tests/Stubs/FakePdoStatement.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * PDO statement stub for bulk INSERT tests (#70).
+ */
+class FakePdoStatement
+{
+    /** @var FakeModX */
+    private $modx;
+
+    /** @var FakePdoConnection */
+    private $connection;
+
+    /** @var string */
+    private $sql;
+
+    /**
+     * @param FakeModX $modx
+     * @param FakePdoConnection $connection
+     * @param string $sql
+     */
+    public function __construct(FakeModX $modx, FakePdoConnection $connection, $sql)
+    {
+        $this->modx = $modx;
+        $this->connection = $connection;
+        $this->sql = $sql;
+    }
+
+    /**
+     * @param array $values
+     * @return bool
+     */
+    public function execute(array $values = array())
+    {
+        $this->connection->executeCalls++;
+        $this->connection->executions[] = array(
+            'sql'    => $this->sql,
+            'values' => $values,
+        );
+
+        if (!$this->connection->executeResult) {
+            return false;
+        }
+
+        $rowCount = (int) (count($values) / 4);
+        for ($i = 0; $i < $rowCount; $i++) {
+            $offset = $i * 4;
+            $subscriber = new sxSubscriber($this->modx);
+            $subscriber->fromArray(array(
+                'id'            => count($this->modx->subscribers) + 1,
+                'newsletter_id' => (int) $values[$offset],
+                'user_id'       => (int) $values[$offset + 1],
+                'email'         => (string) $values[$offset + 2],
+                'code'          => (string) $values[$offset + 3],
+            ));
+            $this->modx->subscribers[] = $subscriber;
+        }
+
+        return true;
+    }
+}

--- a/tests/Stubs/modObjectProcessor.php
+++ b/tests/Stubs/modObjectProcessor.php
@@ -1,0 +1,5 @@
+<?php
+
+class modObjectProcessor extends modProcessor
+{
+}

--- a/tests/Support/TestableGroupSubscribe.php
+++ b/tests/Support/TestableGroupSubscribe.php
@@ -1,0 +1,19 @@
+<?php
+
+require_once dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sxnewslettergroupsubscribe.class.php';
+
+class TestableGroupSubscribe extends sxNewsletterGroupSubscribe
+{
+    /** @var array<int,array{user_id:int,username:string,email:string}> */
+    public static $fixtureMembers = array();
+
+    /**
+     * @param object $xpdo
+     * @param int $groupId
+     * @return array<int,array{user_id:int,username:string,email:string}>
+     */
+    public static function fetchGroupMembers($xpdo, $groupId)
+    {
+        return self::$fixtureMembers;
+    }
+}

--- a/tests/Unit/NewsletterGroupSubscribeTest.php
+++ b/tests/Unit/NewsletterGroupSubscribeTest.php
@@ -1,0 +1,196 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../Support/TestableGroupSubscribe.php';
+
+class NewsletterGroupSubscribeTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    /** @var TestableNewsletter */
+    private $newsletter;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+        $this->newsletter = new TestableNewsletter($this->modx);
+        $this->newsletter->set('id', 10);
+        TestableGroupSubscribe::$fixtureMembers = array();
+    }
+
+    public function testPlanSkipsAlreadySubscribedByUserId()
+    {
+        $existing = new sxSubscriber($this->modx);
+        $existing->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 5,
+            'email'         => 'a@example.com',
+        ));
+        $this->modx->subscribers[] = $existing;
+
+        $plan = sxNewsletterGroupSubscribe::plan(
+            array(array(
+                'user_id'  => 5,
+                'username' => 'alice',
+                'email'    => 'a@example.com',
+            )),
+            10,
+            array($existing),
+            $this->modx
+        );
+
+        $this->assertSame(array(), $plan['insert']);
+        $this->assertSame(array(), $plan['promote']);
+    }
+
+    public function testPlanSkipsWhenEmailAlreadySubscribedToAnotherUser()
+    {
+        $existing = new sxSubscriber($this->modx);
+        $existing->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 3,
+            'email'         => 'shared@example.com',
+        ));
+        $this->modx->subscribers[] = $existing;
+
+        $plan = sxNewsletterGroupSubscribe::plan(
+            array(array(
+                'user_id'  => 9,
+                'username' => 'bob',
+                'email'    => 'shared@example.com',
+            )),
+            10,
+            array($existing),
+            $this->modx
+        );
+
+        $this->assertSame(array(), $plan['insert']);
+        $this->assertSame(array(), $plan['promote']);
+    }
+
+    public function testPlanPromotesGuestRowInsteadOfInsert()
+    {
+        $existing = new sxSubscriber($this->modx);
+        $existing->fromArray(array(
+            'id'            => 2,
+            'newsletter_id' => 10,
+            'user_id'       => 0,
+            'email'         => 'same@example.com',
+        ));
+        $this->modx->subscribers[] = $existing;
+
+        $plan = sxNewsletterGroupSubscribe::plan(
+            array(array(
+                'user_id'  => 8,
+                'username' => 'carol',
+                'email'    => 'same@example.com',
+            )),
+            10,
+            array($existing),
+            $this->modx
+        );
+
+        $this->assertSame(array(), $plan['insert']);
+        $this->assertCount(1, $plan['promote']);
+        $this->assertSame(2, $plan['promote'][0]['subscriber_id']);
+        $this->assertSame(8, $plan['promote'][0]['user_id']);
+    }
+
+    public function testPlanReportsInvalidEmail()
+    {
+        $plan = sxNewsletterGroupSubscribe::plan(
+            array(array(
+                'user_id'  => 3,
+                'username' => 'bad',
+                'email'    => 'not-an-email',
+            )),
+            10,
+            array(),
+            $this->modx
+        );
+
+        $this->assertSame(array(), $plan['insert']);
+        $this->assertCount(1, $plan['errors']);
+        $this->assertStringContainsString('bad:', $plan['errors'][0]);
+    }
+
+    public function testSubscribeGroupUsesSingleBulkInsertForManyMembers()
+    {
+        TestableGroupSubscribe::$fixtureMembers = array();
+        for ($i = 1; $i <= 1000; $i++) {
+            TestableGroupSubscribe::$fixtureMembers[] = array(
+                'user_id'  => $i,
+                'username' => 'user' . $i,
+                'email'    => 'user' . $i . '@example.com',
+            );
+        }
+
+        $result = TestableGroupSubscribe::subscribeGroup($this->newsletter, 99);
+
+        $this->assertTrue($result);
+        $this->assertCount(1000, $this->modx->subscribers);
+        $this->assertSame(2, $this->modx->getConnection()->executeCalls);
+        $this->assertSame(array(), $this->modx->invoked);
+    }
+
+    public function testSubscribeGroupDoesNotDuplicateExistingMembers()
+    {
+        $existing = new sxSubscriber($this->modx);
+        $existing->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 1,
+            'email'         => 'user1@example.com',
+        ));
+        $this->modx->subscribers[] = $existing;
+
+        TestableGroupSubscribe::$fixtureMembers = array(
+            array(
+                'user_id'  => 1,
+                'username' => 'user1',
+                'email'    => 'user1@example.com',
+            ),
+            array(
+                'user_id'  => 2,
+                'username' => 'user2',
+                'email'    => 'user2@example.com',
+            ),
+        );
+
+        $result = TestableGroupSubscribe::subscribeGroup($this->newsletter, 1);
+
+        $this->assertTrue($result);
+        $this->assertCount(2, $this->modx->subscribers);
+        $this->assertSame(1, $this->modx->getConnection()->executeCalls);
+    }
+
+    public function testSubscribeGroupPromotesGuestWithoutEvents()
+    {
+        $existing = new sxSubscriber($this->modx);
+        $existing->fromArray(array(
+            'id'            => 4,
+            'newsletter_id' => 10,
+            'user_id'       => 0,
+            'email'         => 'guest@example.com',
+        ));
+        $this->modx->subscribers[] = $existing;
+
+        TestableGroupSubscribe::$fixtureMembers = array(array(
+            'user_id'  => 12,
+            'username' => 'guest-user',
+            'email'    => 'guest@example.com',
+        ));
+
+        $result = TestableGroupSubscribe::subscribeGroup($this->newsletter, 1);
+
+        $this->assertTrue($result);
+        $this->assertCount(1, $this->modx->subscribers);
+        $this->assertSame(12, (int) $this->modx->subscribers[0]->get('user_id'));
+        $this->assertSame(0, $this->modx->getConnection()->executeCalls);
+        $this->assertSame(array(), $this->modx->invoked);
+    }
+}

--- a/tests/Unit/NewsletterSplitContractTest.php
+++ b/tests/Unit/NewsletterSplitContractTest.php
@@ -22,6 +22,7 @@ class NewsletterSplitContractTest extends TestCase
             'sxnewslettersubscription.class.php',
             'sxnewsletterqueuebuilder.class.php',
             'sxnewsletterqueueusers.class.php',
+            'sxnewslettergroupsubscribe.class.php',
             'sxqueuebodyrenderer.class.php',
             'sxnewslettermailer.class.php',
             'sxsendexevent.class.php',
@@ -47,6 +48,8 @@ class NewsletterSplitContractTest extends TestCase
         $this->assertStringContainsString('sxNewsletterQueueBuilder', $facade);
         $this->assertStringContainsString('sxSendexEvent::invoke', $facade);
         $this->assertStringContainsString('function subscribe(', $facade);
+        $this->assertStringContainsString('function subscribeGroup(', $facade);
+        $this->assertStringContainsString('sxNewsletterGroupSubscribe', $facade);
         $this->assertStringContainsString('function addQueues(', $facade);
         $this->assertStringNotContainsString('function remove(', $facade);
     }

--- a/tests/Unit/SubscriberAddGroupProcessorTest.php
+++ b/tests/Unit/SubscriberAddGroupProcessorTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../Support/TestableGroupSubscribe.php';
+
+class SubscriberAddGroupProcessorTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    /** @var sxSubscriberAddGroupProcessor */
+    private $processor;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+        $newsletter = new TestableNewsletter($this->modx);
+        $newsletter->set('id', 10);
+        $this->modx->newsletters[10] = $newsletter;
+        $this->processor = new sxSubscriberAddGroupProcessor($this->modx);
+        TestableGroupSubscribe::$fixtureMembers = array();
+    }
+
+    public function testRequiresGroupAndNewsletter()
+    {
+        $result = $this->processor->process();
+        $this->assertFalse($result['success']);
+        $this->assertSame('sendex_subscriber_err_group', $result['message']);
+    }
+
+    public function testRequiresPermission()
+    {
+        $this->modx->permissions['edit_document'] = false;
+        $this->processor->properties = array(
+            'group_id'      => 3,
+            'newsletter_id' => 10,
+        );
+        $result = $this->processor->process();
+        $this->assertFalse($result['success']);
+        $this->assertSame('access_denied', $result['message']);
+    }
+
+    public function testFailsWhenNewsletterMissing()
+    {
+        $this->processor->properties = array(
+            'group_id'      => 3,
+            'newsletter_id' => 99,
+        );
+        $result = $this->processor->process();
+        $this->assertFalse($result['success']);
+        $this->assertSame('sendex_newsletter_err_nf', $result['message']);
+    }
+
+    public function testDelegatesToSubscribeGroup()
+    {
+        $newsletter = new class ($this->modx) extends TestableNewsletter {
+            public function subscribeGroup($group_id = 0)
+            {
+                TestableGroupSubscribe::$fixtureMembers = array(array(
+                    'user_id'  => 7,
+                    'username' => 'member',
+                    'email'    => 'member@example.com',
+                ));
+
+                return TestableGroupSubscribe::subscribeGroup($this, $group_id);
+            }
+        };
+        $newsletter->set('id', 10);
+        $this->modx->newsletters[10] = $newsletter;
+
+        $this->processor->properties = array(
+            'group_id'      => 3,
+            'newsletter_id' => 10,
+        );
+        $result = $this->processor->process();
+
+        $this->assertTrue($result['success']);
+        $this->assertCount(1, $this->modx->subscribers);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,11 +17,16 @@ require_once __DIR__ . '/Stubs/sxSubscriber.php';
 require_once __DIR__ . '/Stubs/sxQueue.php';
 require_once __DIR__ . '/Stubs/FakeMail.php';
 require_once __DIR__ . '/Stubs/FakeModX.php';
+require_once __DIR__ . '/Stubs/FakePdoConnection.php';
+require_once __DIR__ . '/Stubs/FakePdoStatement.php';
 require_once __DIR__ . '/Stubs/modProcessor.php';
+require_once __DIR__ . '/Stubs/modObjectProcessor.php';
 
 require_once dirname(__DIR__) . '/core/components/sendex/model/sendex/sxnewsletter.class.php';
 require_once dirname(__DIR__) . '/core/components/sendex/model/sendex/sxqueuesender.class.php';
 require_once __DIR__ . '/Support/TestableNewsletter.php';
 
+require_once dirname(__DIR__) . '/core/components/sendex/processors/mgr/sendexprocessor.class.php';
 require_once dirname(__DIR__) . '/core/components/sendex/processors/mgr/newsletter/subscriber/create.class.php';
+require_once dirname(__DIR__) . '/core/components/sendex/processors/mgr/newsletter/subscriber/add_group.class.php';
 require_once dirname(__DIR__) . '/core/components/sendex/processors/mgr/newsletter/subscriber/remove.class.php';


### PR DESCRIPTION
Кратко: `add_group` больше не вызывает `create` в цикле — один запрос участников группы, одна загрузка существующих подписчиков, chunked multi-row INSERT.

## Что сделано
- `sxNewsletterGroupSubscribe` — plan (skip/promote/insert), bulk INSERT по 500 строк, promote guest rows
- `sxNewsletter::subscribeGroup()` — thin facade
- `add_group` processor — делегирует в domain helper, extends `sxSendexProcessor` (#69)
- Mgr sync path без per-row `sxOn*Subscribe` (#44, как в issue)
- Фильтрация дублей по `user_id` OR `email` (как `isSubscribed`), не только по `user_id`
- тесты: `NewsletterGroupSubscribeTest`, `SubscriberAddGroupProcessorTest` (1000 users → 2 execute)
- миграция: не нужна (логика/PHP only)

## Review
- Pass 1: `(Low)` add_group не на `sxSendexProcessor` → исправлено + ACL test
- Pass 2: Findings: нет

## Проверка
- `composer test` — exit 0 (160 tests, +11)
- phpcs — exit 0
- waive: live MySQL bulk INSERT — не гонялся (нет MODX DB в CI)

Fixes #70