### PR TITLE
perf(subscribe): Reuse single subscriber lookup on confirm

### DIFF
--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#28] `sxProcessorInput::parseIds` accepts `ids` as array or CSV; queue send from snippet/code matches ExtJS `runProcessor` input.
 
 ### Changed
+- [#71] Confirm/subscribe reuses one `sxSubscriber` lookup (`findSubscriber`) instead of SELECT in `isSubscribed` plus a second SELECT in `attachUserToSubscriber`.
 - [#70] `add_group` bulk-subscribes group members via one query + chunked multi-row INSERT; mgr sync path skips per-row subscribe events (#44).
 - [#64] New queue rows store empty `email_body` (compact mode); body is rendered at send from newsletter template; legacy rows with stored HTML still send as-is.
 - [#63] `addQueues` batch-loads `modUser` + Profile (`id:IN`) once instead of N+1 per subscriber.

--- a/core/components/sendex/model/sendex/sxnewslettersubscription.class.php
+++ b/core/components/sendex/model/sendex/sxnewslettersubscription.class.php
@@ -27,6 +27,18 @@ class sxNewsletterSubscription
      */
     public function isSubscribed($userId = 0, $email = '')
     {
+        $subscriber = $this->findSubscriber($userId, $email);
+
+        return $subscriber ? (int) $subscriber->id : 0;
+    }
+
+    /**
+     * @param int $userId
+     * @param string $email
+     * @return sxSubscriber|null
+     */
+    protected function findSubscriber($userId = 0, $email = '')
+    {
         $xpdo = $this->newsletter->xpdo;
         $userId = (int) $userId;
         $email = sxSubscriberMatch::normalizeEmail($email);
@@ -41,19 +53,16 @@ class sxNewsletterSubscription
 
         $where = sxSubscriberMatch::whereClause($this->newsletter->get('id'), $userId, $email);
         if ($where === null) {
-            return 0;
+            return null;
         }
 
         $q = $xpdo->newQuery('sxSubscriber');
         $q->where($where);
 
-        /** @var sxSubscriber $subscriber */
+        /** @var sxSubscriber|false $subscriber */
         $subscriber = $xpdo->getObject('sxSubscriber', $q);
-        if ($subscriber) {
-            return (int) $subscriber->id;
-        }
 
-        return 0;
+        return $subscriber ?: null;
     }
 
     /**
@@ -150,8 +159,8 @@ class sxNewsletterSubscription
 
         $userId = sxSubscriberMatch::resolveUserId($xpdo, $userId, $email);
 
-        if ($subscriberId = $this->isSubscribed($userId, $email)) {
-            $this->attachUserToSubscriber($subscriberId, $userId, $email);
+        if ($subscriber = $this->findSubscriber($userId, $email)) {
+            $this->attachUserToSubscriber($subscriber, $userId, $email);
 
             return true;
         }
@@ -228,19 +237,17 @@ class sxNewsletterSubscription
     }
 
     /**
-     * @param int $subscriberId
+     * @param sxSubscriber $subscriber
      * @param int $userId
      * @param string $email
      */
-    protected function attachUserToSubscriber($subscriberId, $userId, $email)
+    protected function attachUserToSubscriber($subscriber, $userId, $email)
     {
         $userId = (int) $userId;
         if ($userId <= 0 && $email === '') {
             return;
         }
 
-        /** @var sxSubscriber $subscriber */
-        $subscriber = $this->newsletter->xpdo->getObject('sxSubscriber', (int) $subscriberId);
         if (!$subscriber) {
             return;
         }

--- a/tests/Unit/NewsletterConfirmEmailTest.php
+++ b/tests/Unit/NewsletterConfirmEmailTest.php
@@ -152,4 +152,30 @@ class NewsletterConfirmEmailTest extends TestCase
         $this->assertTrue($this->newsletter->confirmEmail('hash-dup'));
         $this->assertArrayNotHasKey('hash-dup', $this->modx->registryEntries);
     }
+
+    public function testAlreadySubscribedConfirmUsesSingleSubscriberLookup()
+    {
+        $existing = new sxSubscriber($this->modx);
+        $existing->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 4,
+            'email'         => 'ok@example.com',
+        ));
+        $this->modx->subscribers[] = $existing;
+
+        $this->modx->registryEntries['hash-one-select'] = array(
+            'user_id'       => 4,
+            'newsletter_id' => 10,
+            'email'         => 'ok@example.com',
+        );
+
+        $before = isset($this->modx->getObjectCalls['sxSubscriber'])
+            ? $this->modx->getObjectCalls['sxSubscriber']
+            : 0;
+
+        $this->assertTrue($this->newsletter->confirmEmail('hash-one-select'));
+
+        $this->assertSame(1, $this->modx->getObjectCalls['sxSubscriber'] - $before);
+    }
 }

--- a/tests/Unit/NewsletterSubscribeTest.php
+++ b/tests/Unit/NewsletterSubscribeTest.php
@@ -48,6 +48,26 @@ class NewsletterSubscribeTest extends TestCase
         $this->assertCount(1, $this->modx->subscribers);
     }
 
+    public function testAlreadySubscribedUsesSingleSubscriberLookup()
+    {
+        $existing = new sxSubscriber($this->modx);
+        $existing->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 5,
+            'email'         => 'user@example.com',
+        ));
+        $this->modx->subscribers[] = $existing;
+
+        $before = isset($this->modx->getObjectCalls['sxSubscriber'])
+            ? $this->modx->getObjectCalls['sxSubscriber']
+            : 0;
+
+        $this->assertTrue($this->newsletter->subscribe(5, 'user@example.com'));
+
+        $this->assertSame(1, $this->modx->getObjectCalls['sxSubscriber'] - $before);
+    }
+
     public function testFiresBeforeAndAfterEventsOnSuccess()
     {
         $this->assertTrue($this->newsletter->subscribe(7, 'new@example.com'));


### PR DESCRIPTION
Кратко: confirm и idempotent subscribe больше не делают два SELECT по `sxSubscriber` — один `findSubscriber`, объект передаётся в `attachUserToSubscriber`.

## Что сделано
- `findSubscriber()` — единый lookup (profile + where OR)
- `isSubscribed()` делегирует в `findSubscriber`
- `subscribe()` / confirm path: attach без повторного `getObject`
- тесты: query-count в `NewsletterConfirmEmailTest`, `NewsletterSubscribeTest`
- миграция: не нужна (PHP only)

## Review
- Pass 1 / Pass 2: Findings: нет

## Проверка
- `composer test` — exit 0 (162 tests, +2)
- phpcs — exit 0

Fixes #71