### PR TITLE
perf(mgr): Cheap COUNT for newsletter getlist

### DIFF
--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#28] `sxProcessorInput::parseIds` accepts `ids` as array or CSV; queue send from snippet/code matches ExtJS `runProcessor` input.
 
 ### Changed
+- [#73] Newsletter mgr `getlist`: COUNT runs on filters only; JOIN/COUNT(`Subscribers`)/GROUP BY moved to `prepareQueryAfterCount` via `sxNewsletterListQuery`.
 - [#71] Confirm/subscribe reuses one `sxSubscriber` lookup (`findSubscriber`) instead of SELECT in `isSubscribed` plus a second SELECT in `attachUserToSubscriber`.
 - [#70] `add_group` bulk-subscribes group members via one query + chunked multi-row INSERT; mgr sync path skips per-row subscribe events (#44).
 - [#64] New queue rows store empty `email_body` (compact mode); body is rendered at send from newsletter template; legacy rows with stored HTML still send as-is.

--- a/core/components/sendex/model/sendex/sxnewsletterlistquery.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletterlistquery.class.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Newsletter mgr grid query: cheap COUNT in prepareQueryBeforeCount, aggregates after (#73).
+ */
+class sxNewsletterListQuery
+{
+    /**
+     * Filters only — safe for getCount (no JOIN/GROUP BY).
+     *
+     * @param object $query xPDOQuery / test stub
+     * @param array{query?:mixed,combo?:mixed} $properties
+     * @return object
+     */
+    public static function applyFilters($query, array $properties)
+    {
+        $search = isset($properties['query']) ? (string) $properties['query'] : '';
+        if ($search !== '') {
+            $query->where(array(
+                'name:LIKE'           => '%' . $search . '%',
+                'OR:description:LIKE' => '%' . $search . '%',
+            ));
+        }
+
+        if (!empty($properties['combo'])) {
+            $query->where(array('active' => 1));
+        }
+
+        return $query;
+    }
+
+    /**
+     * List SELECT/JOIN/GROUP BY — run from prepareQueryAfterCount only.
+     *
+     * @param object $modx
+     * @param object $query
+     * @param string $classKey
+     * @return object
+     */
+    public static function applyListSelects($modx, $query, $classKey = 'sxNewsletter')
+    {
+        $query->leftJoin('modTemplate', 'Template');
+        $query->leftJoin('sxSubscriber', 'Subscribers');
+        $query->select($modx->getSelectColumns($classKey, $classKey));
+        $query->select($modx->getSelectColumns('modTemplate', 'Template', '', array('templatename')));
+        $query->select('COUNT(`Subscribers`.`id`) as `subscribers`');
+        $query->groupby($classKey . '.id');
+
+        return $query;
+    }
+}

--- a/core/components/sendex/processors/mgr/newsletter/getlist.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/getlist.class.php
@@ -1,9 +1,10 @@
 <?php
 
+require_once dirname(__FILE__, 4) . '/model/sendex/sxnewsletterlistquery.class.php';
+
 /**
  * Get a list of Newsletters
  */
-
 class sxNewsletterGetListProcessor extends modObjectGetListProcessor
 {
     public $objectType = 'sxNewsletter';
@@ -12,7 +13,6 @@ class sxNewsletterGetListProcessor extends modObjectGetListProcessor
     public $defaultSortDirection = 'DESC';
     public $permission = 'view_document';
 
-
     /**
      * @param xPDOQuery $c
      *
@@ -20,25 +20,21 @@ class sxNewsletterGetListProcessor extends modObjectGetListProcessor
      */
     public function prepareQueryBeforeCount(xPDOQuery $c)
     {
-        $c->leftJoin('modTemplate', 'Template');
-        $c->leftJoin('sxSubscriber', 'Subscribers');
-        $c->select($this->modx->getSelectColumns($this->classKey, $this->classKey));
-        $c->select($this->modx->getSelectColumns('modTemplate', 'Template', '', array('templatename')));
-        $c->select('COUNT(`Subscribers`.`id`) as `subscribers`');
-        $c->groupby($this->classKey . '.id');
-
-        if ($query = $this->getProperty('query')) {
-            $c->where(array(
-                'name:LIKE'           => "%$query%",
-                'OR:description:LIKE' => "%$query%",
-            ));
-        }
-        if ($this->getProperty('combo')) {
-            $c->where(array('active' => 1));
-        }
-        return $c;
+        return sxNewsletterListQuery::applyFilters($c, array(
+            'query' => $this->getProperty('query'),
+            'combo' => $this->getProperty('combo'),
+        ));
     }
 
+    /**
+     * @param xPDOQuery $c
+     *
+     * @return xPDOQuery
+     */
+    public function prepareQueryAfterCount(xPDOQuery $c)
+    {
+        return sxNewsletterListQuery::applyListSelects($this->modx, $c, $this->classKey);
+    }
 
     /**
      * @param xPDOObject $object

--- a/tests/Stubs/FakeModX.php
+++ b/tests/Stubs/FakeModX.php
@@ -530,6 +530,27 @@ class FakeModX extends modX
 
     /**
      * @param string $class
+     * @param string $alias
+     * @param string $prefix
+     * @param array $fields
+     * @return string
+     */
+    public function getSelectColumns($class, $alias, $prefix = '', array $fields = array())
+    {
+        if ($fields !== array()) {
+            $out = array();
+            foreach ($fields as $field) {
+                $out[] = $alias . '.' . $field;
+            }
+
+            return implode(', ', $out);
+        }
+
+        return $alias . '.*';
+    }
+
+    /**
+     * @param string $class
      * @return string
      */
     public function getTableName($class)

--- a/tests/Stubs/FakeQuery.php
+++ b/tests/Stubs/FakeQuery.php
@@ -11,6 +11,15 @@ class FakeQuery
     /** @var int|null */
     public $limit;
 
+    /** @var array<int,array{0:string,1:string,2?:string}> */
+    public $joins = array();
+
+    /** @var array<int,string|array> */
+    public $selects = array();
+
+    /** @var string|null */
+    public $groupby;
+
     /**
      * @param string $class
      * @param array|null $criteria
@@ -49,6 +58,44 @@ class FakeQuery
             }
             $this->where[$key] = $value;
         }
+
+        return $this;
+    }
+
+    /**
+     * @param string $class
+     * @param string $alias
+     * @param string $on
+     *
+     * @return self
+     */
+    public function leftJoin($class, $alias, $on = '')
+    {
+        $this->joins[] = array($class, $alias, $on);
+
+        return $this;
+    }
+
+    /**
+     * @param mixed $columns
+     *
+     * @return self
+     */
+    public function select($columns)
+    {
+        $this->selects[] = $columns;
+
+        return $this;
+    }
+
+    /**
+     * @param string $expression
+     *
+     * @return self
+     */
+    public function groupby($expression)
+    {
+        $this->groupby = $expression;
 
         return $this;
     }

--- a/tests/Unit/NewsletterGetListQueryTest.php
+++ b/tests/Unit/NewsletterGetListQueryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sxnewsletterlistquery.class.php';
+
+class NewsletterGetListQueryTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+    }
+
+    public function testApplyFiltersDoesNotJoinOrGroup()
+    {
+        $query = new FakeQuery('sxNewsletter');
+
+        sxNewsletterListQuery::applyFilters($query, array(
+            'query' => 'weekly',
+            'combo' => 1,
+        ));
+
+        $this->assertSame(array(), $query->joins);
+        $this->assertNull($query->groupby);
+        $this->assertArrayHasKey('name:LIKE', $query->where);
+        $this->assertSame(1, $query->where['active']);
+    }
+
+    public function testApplyListSelectsAddsJoinsAndGroupBy()
+    {
+        $query = new FakeQuery('sxNewsletter');
+
+        sxNewsletterListQuery::applyListSelects($this->modx, $query, 'sxNewsletter');
+
+        $this->assertCount(2, $query->joins);
+        $this->assertSame('modTemplate', $query->joins[0][0]);
+        $this->assertSame('sxSubscriber', $query->joins[1][0]);
+        $this->assertSame('sxNewsletter.id', $query->groupby);
+        $this->assertGreaterThanOrEqual(3, count($query->selects));
+    }
+
+    public function testGetListProcessorUsesAfterCountForAggregates()
+    {
+        $source = file_get_contents(
+            dirname(__DIR__, 2) . '/core/components/sendex/processors/mgr/newsletter/getlist.class.php'
+        );
+
+        $this->assertStringContainsString('prepareQueryAfterCount', $source);
+        $this->assertStringContainsString('sxNewsletterListQuery::applyListSelects', $source);
+        $this->assertStringContainsString('sxNewsletterListQuery::applyFilters', $source);
+        $this->assertStringNotContainsString('groupby', $this->beforeCountBody($source));
+    }
+
+    /**
+     * @param string $source
+     * @return string
+     */
+    private function beforeCountBody($source)
+    {
+        if (!preg_match('/function prepareQueryBeforeCount\\([^)]*\\)\\s*\\{(.*?)\\n\\s*\\}/s', $source, $matches)) {
+            return $source;
+        }
+
+        return $matches[1];
+    }
+}

--- a/tests/Unit/NewsletterSplitContractTest.php
+++ b/tests/Unit/NewsletterSplitContractTest.php
@@ -23,6 +23,7 @@ class NewsletterSplitContractTest extends TestCase
             'sxnewsletterqueuebuilder.class.php',
             'sxnewsletterqueueusers.class.php',
             'sxnewslettergroupsubscribe.class.php',
+            'sxnewsletterlistquery.class.php',
             'sxqueuebodyrenderer.class.php',
             'sxnewslettermailer.class.php',
             'sxsendexevent.class.php',


### PR DESCRIPTION
Кратко: total в mgr grid считается по `sxNewsletter` без JOIN/GROUP BY; агрегат подписчиков только в list-query.

## Что сделано
- `sxNewsletterListQuery`: `applyFilters` (COUNT) + `applyListSelects` (JOIN + COUNT subscribers + GROUP BY)
- `newsletter/getlist`: `prepareQueryBeforeCount` / `prepareQueryAfterCount`
- тесты: `NewsletterGetListQueryTest` (+ contract: groupby не в beforeCount)
- queue/subscriber getlist без изменений (нет GROUP BY)
- миграция: не нужна

## Review
- Pass 1 / Pass 2: Findings: нет

## Проверка
- `composer test` — exit 0 (165 tests, +3)
- phpcs — exit 0

Fixes #73