### PR TITLE
refactor(mgr): Share grid selection mixin for batch actions

### DIFF
--- a/assets/components/sendex/js/mgr/misc/utils.js
+++ b/assets/components/sendex/js/mgr/misc/utils.js
@@ -97,3 +97,84 @@ Sendex.utils.requestcomplete = function() {
     Ext.Ajax.un('beforerequest', Sendex.utils.beforerequest);
     Ext.Ajax.un('requestcomplete', Sendex.utils.requestcomplete);
 };
+
+/**
+ * Selected row ids from checkbox selection, or menu.record for a single row action (#60 / #68).
+ *
+ * @param {Ext.grid.GridPanel} grid
+ * @param {Object} [options]
+ * @return {Array|null} null when nothing selected
+ */
+Sendex.utils.getSelectedIds = function(grid, options) {
+    options = options || {};
+    var idField = options.idField || 'id';
+    var ids = [];
+    var selected = grid.getSelectionModel().getSelections();
+    var i;
+    var record;
+
+    for (i = 0; i < selected.length; i++) {
+        record = selected[i];
+        if (record && record.data && typeof record.data[idField] !== 'undefined' && record.data[idField] !== '') {
+            ids.push(record.data[idField]);
+        }
+    }
+
+    if (ids.length === 0 && grid.menu && grid.menu.record && typeof grid.menu.record[idField] !== 'undefined') {
+        ids.push(grid.menu.record[idField]);
+    }
+
+    return ids.length > 0 ? ids : null;
+};
+
+/**
+ * @param {Ext.grid.GridPanel} grid
+ * @param {String} [emptyLex]
+ * @return {Array|null}
+ */
+Sendex.utils.requireSelectedIds = function(grid, emptyLex) {
+    var ids = Sendex.utils.getSelectedIds(grid);
+    if (!ids) {
+        MODx.msg.alert(_('warning'), _(emptyLex || 'sendex_selection_err_ns'));
+        return null;
+    }
+    return ids;
+};
+
+Sendex.grid.SelectionMixin = {
+    getSelectedIds: function() {
+        return Sendex.utils.getSelectedIds(this);
+    },
+
+    requireSelectedIds: function(emptyLex) {
+        return Sendex.utils.requireSelectedIds(this, emptyLex);
+    },
+
+    confirmWithSelection: function(config) {
+        config = config || {};
+        var ids = this.requireSelectedIds(config.emptyLex);
+        if (!ids) {
+            return;
+        }
+        Sendex.utils.onAjax(this.getEl());
+        config.params = Ext.apply({}, config.params || {});
+        config.params.ids = ids.join(',');
+        MODx.msg.confirm(Ext.apply({
+            url: config.url || this.config.url || Sendex.config.connector_url
+        }, config));
+    },
+
+    ajaxWithSelection: function(config) {
+        config = config || {};
+        var ids = this.requireSelectedIds(config.emptyLex);
+        if (!ids) {
+            return;
+        }
+        Sendex.utils.onAjax(this.getEl());
+        config.params = Ext.apply({}, config.params || {});
+        config.params.ids = ids.join(',');
+        MODx.Ajax.request(Ext.apply({
+            url: config.url || this.config.url || Sendex.config.connector_url
+        }, config));
+    }
+};

--- a/assets/components/sendex/js/mgr/widgets/newsletters.grid.js
+++ b/assets/components/sendex/js/mgr/widgets/newsletters.grid.js
@@ -54,7 +54,7 @@ Sendex.grid.Newsletters = function(config) {
     });
     Sendex.grid.Newsletters.superclass.constructor.call(this,config);
 };
-Ext.extend(Sendex.grid.Newsletters,MODx.grid.Grid,{
+Ext.extend(Sendex.grid.Newsletters,MODx.grid.Grid,Ext.apply({
     windows: {}
 
     ,getMenu: function(grid, rowIndex) {
@@ -150,70 +150,43 @@ Ext.extend(Sendex.grid.Newsletters,MODx.grid.Grid,{
     }
 
     ,removeNewsletter: function(grid, e) {
-        var ids = this._getSelectedIds();
-        if (!ids) {return;}
-        Sendex.utils.onAjax(this.getEl());
-
-        MODx.msg.confirm({
-            title: _('sendex_newsletters_remove')
-            ,text: _('sendex_newsletters_remove_confirm')
-            ,url: this.config.url
-            ,params: {
+        this.confirmWithSelection({
+            emptyLex: 'sendex_newsletters_err_ns',
+            title: _('sendex_newsletters_remove'),
+            text: _('sendex_newsletters_remove_confirm'),
+            params: {
                 action: 'mgr/newsletter/remove'
-                ,ids: ids.join(',')
-            }
-            ,listeners: {
-                success: {fn:function(r) { this.refresh(); },scope:this}
+            },
+            listeners: {
+                success: {fn:function() { this.refresh(); },scope:this}
             }
         });
     }
 
     ,disableNewsletter: function(grid, e) {
-        var ids = this._getSelectedIds();
-        if (!ids) {return;}
-        Sendex.utils.onAjax(this.getEl());
-
-        MODx.Ajax.request({
-            url: this.config.url
-            ,params: {
+        this.ajaxWithSelection({
+            emptyLex: 'sendex_newsletters_err_ns',
+            params: {
                 action: 'mgr/newsletter/disable'
-                ,ids: ids.join(',')
-            }
-            ,listeners: {
-                success: {fn:function(r) { this.refresh(); },scope:this}
+            },
+            listeners: {
+                success: {fn:function() { this.refresh(); },scope:this}
             }
         });
     }
 
     ,enableNewsletter: function(grid, e) {
-        var ids = this._getSelectedIds();
-        if (!ids) {return;}
-        Sendex.utils.onAjax(this.getEl());
-
-        MODx.Ajax.request({
-            url: this.config.url
-            ,params: {
+        this.ajaxWithSelection({
+            emptyLex: 'sendex_newsletters_err_ns',
+            params: {
                 action: 'mgr/newsletter/enable'
-                ,ids: ids.join(',')
-            }
-            ,listeners: {
-                success: {fn:function(r) { this.refresh(); },scope:this}
+            },
+            listeners: {
+                success: {fn:function() { this.refresh(); },scope:this}
             }
         });
     }
-
-    ,_getSelectedIds: function() {
-        var ids = [];
-        var selected = this.getSelectionModel().getSelections();
-
-        for (var i in selected) {
-            if (!selected.hasOwnProperty(i)) {continue;}
-            ids.push(selected[i]['id']);
-        }
-
-        return ids;
-    }
-});
+}, Sendex.grid.SelectionMixin);
 Ext.reg('sendex-grid-newsletters',Sendex.grid.Newsletters);
 
 
@@ -401,7 +374,7 @@ Sendex.grid.NewsletterSubscribers = function(config) {
     });
     Sendex.grid.NewsletterSubscribers.superclass.constructor.call(this,config);
 };
-Ext.extend(Sendex.grid.NewsletterSubscribers,MODx.grid.Grid, {
+Ext.extend(Sendex.grid.NewsletterSubscribers,MODx.grid.Grid, Ext.apply({
 
     getMenu: function(grid, rowIndex) {
         var row = grid.getStore().getAt(rowIndex);
@@ -463,34 +436,17 @@ Ext.extend(Sendex.grid.NewsletterSubscribers,MODx.grid.Grid, {
     }
 
     ,removeSubscriber:function(btn,e) {
-        var ids = this._getSelectedIds();
-        if (!ids) {return;}
-        Sendex.utils.onAjax(this.getEl());
-
-        MODx.msg.confirm({
-            title: _('sendex_subscribers_remove')
-            ,text: _('sendex_subscribers_remove_confirm')
-            ,url: Sendex.config.connector_url
-            ,params: {
+        this.confirmWithSelection({
+            emptyLex: 'sendex_subscribers_err_ns',
+            title: _('sendex_subscribers_remove'),
+            text: _('sendex_subscribers_remove_confirm'),
+            params: {
                 action: 'mgr/newsletter/subscriber/remove'
-                ,ids: ids.join(',')
-            }
-            ,listeners: {
-                success: {fn:function(r) {this.refresh();},scope:this}
+            },
+            listeners: {
+                success: {fn:function() {this.refresh();},scope:this}
             }
         });
-    }
-
-    ,_getSelectedIds: function() {
-        var ids = [];
-        var selected = this.getSelectionModel().getSelections();
-
-        for (var i in selected) {
-            if (!selected.hasOwnProperty(i)) {continue;}
-            ids.push(selected[i]['id']);
-        }
-
-        return ids;
     }
 
     ,exportSubscribers: function() {
@@ -553,5 +509,5 @@ Ext.extend(Sendex.grid.NewsletterSubscribers,MODx.grid.Grid, {
         window.URL.revokeObjectURL(url);
     }
 
-});
+}, Sendex.grid.SelectionMixin));
 Ext.reg('sendex-grid-newsletter-subscribers',Sendex.grid.NewsletterSubscribers);

--- a/assets/components/sendex/js/mgr/widgets/queues.grid.js
+++ b/assets/components/sendex/js/mgr/widgets/queues.grid.js
@@ -60,7 +60,7 @@ Sendex.grid.Queues = function(config) {
 
     Sendex.grid.Queues.superclass.constructor.call(this, config);
 };
-Ext.extend(Sendex.grid.Queues,MODx.grid.Grid, {
+Ext.extend(Sendex.grid.Queues,MODx.grid.Grid, Ext.apply({
     windows: {}
 
     ,getMenu: function(grid, rowIndex) {
@@ -108,36 +108,27 @@ Ext.extend(Sendex.grid.Queues,MODx.grid.Grid, {
     }
 
     ,sendQueue: function(btn,e,row) {
-        var ids = this._getSelectedIds();
-        if (!ids) {return;}
-        Sendex.utils.onAjax(this.getEl());
-
-        MODx.Ajax.request({
-            url: Sendex.config.connector_url
-            ,params: {
+        this.ajaxWithSelection({
+            emptyLex: 'sendex_queue_err_ns',
+            params: {
                 action: 'mgr/queue/send'
-                ,ids: ids.join(',')
-            }
-            ,listeners: {
-                success: {fn:function(r) {this.refresh();},scope:this}
+            },
+            listeners: {
+                success: {fn:function() {this.refresh();},scope:this}
             }
         });
     }
 
     ,removeQueue: function(btn,e,row) {
-        var ids = this._getSelectedIds();
-        if (!ids) {return;}
-
-        MODx.msg.confirm({
-            title: _('sendex_queues_remove')
-            ,text: _('sendex_queues_remove_confirm')
-            ,url: Sendex.config.connector_url
-            ,params: {
+        this.confirmWithSelection({
+            emptyLex: 'sendex_queue_err_ns',
+            title: _('sendex_queues_remove'),
+            text: _('sendex_queues_remove_confirm'),
+            params: {
                 action: 'mgr/queue/remove'
-                ,ids: ids.join(',')
-            }
-            ,listeners: {
-                success: {fn:function(r) {this.refresh();},scope:this}
+            },
+            listeners: {
+                success: {fn:function() {this.refresh();},scope:this}
             }
         });
     }
@@ -182,17 +173,5 @@ Ext.extend(Sendex.grid.Queues,MODx.grid.Grid, {
         });
     }
 
-    ,_getSelectedIds: function() {
-        var ids = [];
-        var selected = this.getSelectionModel().getSelections();
-
-        for (var i in selected) {
-            if (!selected.hasOwnProperty(i)) {continue;}
-            ids.push(selected[i]['id']);
-        }
-
-        return ids;
-    }
-
-});
+}, Sendex.grid.SelectionMixin));
 Ext.reg('sendex-grid-queues',Sendex.grid.Queues);

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Phinx migrations: `core/components/sendex/phinx.php`, `migrations/`, install/upgrade resolver; metadata table `{prefix}sendex_migrations`.
 
 ### Fixed
+- [#60] Mgr grids: empty checkbox selection no longer sends `ids:''`; alert via `Sendex.utils.requireSelectedIds`, row action falls back to `menu.record`.
 - [#59] Deleting a newsletter removes its `sxQueue` rows via xPDO composite `Queues`; upgrade migration purges queue rows left orphaned by earlier deletes.
 - [#57] `addQueues` returns an error when 0 queue rows were created (all subscribers skipped); mgr `queue/add` reports the created count on success.
 - [#55] Queue send claims the row (remove-before-send) so parallel cron/mgr workers do not double-deliver; mail failure requeues and logs; cron logs non-true `send()` results.
@@ -36,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#28] `sxProcessorInput::parseIds` accepts `ids` as array or CSV; queue send from snippet/code matches ExtJS `runProcessor` input.
 
 ### Changed
+- [#68] ExtJS mgr grids share `Sendex.grid.SelectionMixin` (`getSelectedIds`, `confirmWithSelection`, `ajaxWithSelection`) instead of per-grid `_getSelectedIds` copy-paste.
 - [#73] Newsletter mgr `getlist`: COUNT runs on filters only; JOIN/COUNT(`Subscribers`)/GROUP BY moved to `prepareQueryAfterCount` via `sxNewsletterListQuery`.
 - [#71] Confirm/subscribe reuses one `sxSubscriber` lookup (`findSubscriber`) instead of SELECT in `isSubscribed` plus a second SELECT in `attachUserToSubscriber`.
 - [#70] `add_group` bulk-subscribes group members via one query + chunked multi-row INSERT; mgr sync path skips per-row subscribe events (#44).

--- a/core/components/sendex/lexicon/en/default.inc.php
+++ b/core/components/sendex/lexicon/en/default.inc.php
@@ -57,6 +57,7 @@ $_lang['sendex_subscriber_err_ae'] = 'This user is already subscribed.';
 $_lang['sendex_subscriber_err_nf'] = 'Subscriber not found.';
 $_lang['sendex_subscriber_err_ns'] = 'Subscriber not set.';
 $_lang['sendex_subscribers_err_ns'] = 'Subscribers not set.';
+$_lang['sendex_selection_err_ns'] = 'Select at least one row.';
 $_lang['sendex_subscriber_err_remove'] = 'Error when remove subscriber.';
 $_lang['sendex_subscriber_err_save'] = 'Error when save subscriber.';
 $_lang['sendex_subscriber_err_email'] = 'Email of subscriber is not set.';

--- a/core/components/sendex/lexicon/ru/default.inc.php
+++ b/core/components/sendex/lexicon/ru/default.inc.php
@@ -57,6 +57,7 @@ $_lang['sendex_subscriber_err_ae'] = 'Этот пользователь уже �
 $_lang['sendex_subscriber_err_nf'] = 'Подписчик не найден.';
 $_lang['sendex_subscriber_err_ns'] = 'Подписчик не указан.';
 $_lang['sendex_subscribers_err_ns'] = 'Подписчики не указаны.';
+$_lang['sendex_selection_err_ns'] = 'Выберите хотя бы одну строку.';
 $_lang['sendex_subscriber_err_remove'] = 'Ошибка при удалении подписчика.';
 $_lang['sendex_subscriber_err_save'] = 'Ошибка при сохранении подписчика.';
 $_lang['sendex_subscriber_err_email'] = 'Не указан email пописчика.';

--- a/tests/Unit/MgrGridSelectionContractTest.php
+++ b/tests/Unit/MgrGridSelectionContractTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Contract tests for mgr grid selection mixin (#68 / #60).
+ */
+class MgrGridSelectionContractTest extends TestCase
+{
+    public function testUtilsExposeSelectionHelpers()
+    {
+        $source = file_get_contents(
+            dirname(__DIR__, 2) . '/assets/components/sendex/js/mgr/misc/utils.js'
+        );
+
+        $this->assertStringContainsString('Sendex.utils.getSelectedIds', $source);
+        $this->assertStringContainsString('Sendex.utils.requireSelectedIds', $source);
+        $this->assertStringContainsString('Sendex.grid.SelectionMixin', $source);
+        $this->assertStringContainsString('return ids.length > 0 ? ids : null', $source);
+        $this->assertStringContainsString('grid.menu.record', $source);
+    }
+
+    public function testGridsUseSelectionMixinAndDropLocalCopyPaste()
+    {
+        $base = dirname(__DIR__, 2) . '/assets/components/sendex/js/mgr/widgets/';
+        $files = array(
+            'newsletters.grid.js',
+            'queues.grid.js',
+        );
+
+        foreach ($files as $file) {
+            $source = file_get_contents($base . $file);
+            $this->assertStringContainsString('Sendex.grid.SelectionMixin', $source, $file);
+            $this->assertStringNotContainsString('_getSelectedIds', $source, $file);
+            $this->assertStringContainsString('confirmWithSelection', $source, $file);
+        }
+    }
+
+    public function testBatchProcessorsRejectEmptyIds()
+    {
+        $base = dirname(__DIR__, 2) . '/core/components/sendex/processors/mgr/';
+        $files = array(
+            'newsletter/remove.class.php',
+            'newsletter/enable.class.php',
+            'newsletter/disable.class.php',
+            'newsletter/subscriber/remove.class.php',
+            'queue/remove.class.php',
+            'queue/send.class.php',
+        );
+
+        foreach ($files as $file) {
+            $source = file_get_contents($base . $file);
+            $this->assertStringContainsString('requireIds(', $source, $file);
+        }
+    }
+
+    public function testSelectionEmptyLexiconExists()
+    {
+        $en = file_get_contents(
+            dirname(__DIR__, 2) . '/core/components/sendex/lexicon/en/default.inc.php'
+        );
+        $ru = file_get_contents(
+            dirname(__DIR__, 2) . '/core/components/sendex/lexicon/ru/default.inc.php'
+        );
+
+        $this->assertStringContainsString('sendex_selection_err_ns', $en);
+        $this->assertStringContainsString('sendex_selection_err_ns', $ru);
+    }
+}


### PR DESCRIPTION
Общий mixin для selection/batch в mgr grids вместо копипасты `_getSelectedIds`. Пустой selection больше не шлёт `ids:''`.

## Что сделано
- `Sendex.utils.getSelectedIds` / `requireSelectedIds` и `Sendex.grid.SelectionMixin` (`confirmWithSelection`, `ajaxWithSelection`) в `utils.js`
- Grids newsletters / newsletter-subscribers / queues переведены на mixin, локальные `_getSelectedIds` удалены
- Lexicon `sendex_selection_err_ns` (en/ru)
- Contract-тесты: `tests/Unit/MgrGridSelectionContractTest.php`
- миграция: не нужна (ExtJS + lexicon)

## Review
- Findings: нет (pass 2 после fix config guard в mixin)

## Проверка
- `composer test` — exit 0 (169 tests, +4 в `MgrGridSelectionContractTest`)
- phpcs — не применялся (новый PHP только contract-тест)
- waive: ручной прогон ExtJS mgr UI (нет MODX в CI)

Fixes #68
Fixes #60