### PR TITLE
feat(mgr): Add send-to-subscribers action for newsletters

### DIFF
--- a/assets/components/sendex/js/mgr/widgets/newsletters.grid.js
+++ b/assets/components/sendex/js/mgr/widgets/newsletters.grid.js
@@ -206,7 +206,7 @@ Ext.extend(Sendex.grid.Newsletters,MODx.grid.Grid,Ext.apply({
             }
         });
     }
-}, Sendex.grid.SelectionMixin);
+}, Sendex.grid.SelectionMixin));
 Ext.reg('sendex-grid-newsletters',Sendex.grid.Newsletters);
 
 

--- a/assets/components/sendex/js/mgr/widgets/newsletters.grid.js
+++ b/assets/components/sendex/js/mgr/widgets/newsletters.grid.js
@@ -186,6 +186,26 @@ Ext.extend(Sendex.grid.Newsletters,MODx.grid.Grid,Ext.apply({
             }
         });
     }
+
+    ,sendNewsletter: function(grid, e) {
+        var ids = this.requireSelectedIds('sendex_newsletters_err_ns');
+        if (!ids) {
+            return;
+        }
+        Sendex.utils.onAjax(this.getEl());
+        MODx.msg.confirm({
+            title: _('sendex_newsletter_send'),
+            text: _('sendex_newsletter_send_confirm'),
+            url: Sendex.config.connector_url,
+            params: {
+                action: 'mgr/newsletter/send',
+                id: ids[0]
+            },
+            listeners: {
+                success: {fn:function() { this.refresh(); },scope:this}
+            }
+        });
+    }
 }, Sendex.grid.SelectionMixin);
 Ext.reg('sendex-grid-newsletters',Sendex.grid.Newsletters);
 
@@ -311,10 +331,45 @@ Sendex.window.UpdateNewsletter = function(config) {
             }]
         }
         ,keys: [{key: Ext.EventObject.ENTER,shift: true,fn: function() {this.submit() },scope: this}]
+        ,buttons: [{
+            text: '<i class="' + (MODx.modx23 ? 'icon icon-send' : 'fa fa-send') + '"></i> ' + _('sendex_btn_send_subscribers')
+            ,cls: 'primary-button'
+            ,handler: this.sendToSubscribers
+            ,scope: this
+        },{
+            text: config.cancelBtnText || _('cancel')
+            ,scope: this
+            ,handler: function() { this.hide(); }
+        },{
+            text: config.saveBtnText || _('save')
+            ,scope: this
+            ,handler: function() { this.submit(false); }
+        }]
     });
     Sendex.window.UpdateNewsletter.superclass.constructor.call(this,config);
 };
-Ext.extend(Sendex.window.UpdateNewsletter,MODx.Window);
+Ext.extend(Sendex.window.UpdateNewsletter,MODx.Window,{
+    sendToSubscribers: function() {
+        var field = this.fp.getForm().findField('id');
+        var id = field ? field.getValue() : 0;
+        if (!id) {
+            return;
+        }
+        Sendex.utils.onAjax(this.getEl());
+        MODx.msg.confirm({
+            title: _('sendex_newsletter_send'),
+            text: _('sendex_newsletter_send_confirm'),
+            url: Sendex.config.connector_url,
+            params: {
+                action: 'mgr/newsletter/send',
+                id: id
+            },
+            listeners: {
+                success: {fn:function() { this.hide(); },scope:this}
+            }
+        });
+    }
+});
 Ext.reg('sendex-window-newsletter-update',Sendex.window.UpdateNewsletter);
 
 

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CSV cells that look like spreadsheet formulas are prefixed so Excel/LibreOffice do not execute them.
 
 ### Added
+- [#29] Mgr newsletter «Send to subscribers»: one action runs `addQueues` + `sxQueueSender::flush` for the newsletter (`mgr/newsletter/send`); button in grid row actions and update window.
 - [#46] Search subscribers and queue by email or username.
 - [#44] Plugin events for subscribe/unsubscribe (`sxOnBeforeSubscribe`, `sxOnSubscribe`, `sxOnBeforeUnsubscribe`, `sxOnUnsubscribe`).
 - PHPUnit coverage for subscribe/unsubscribe events (stubs, no MODX install).

--- a/core/components/sendex/lexicon/en/default.inc.php
+++ b/core/components/sendex/lexicon/en/default.inc.php
@@ -13,6 +13,7 @@ $_lang['sendex_btn_create'] = 'Create';
 $_lang['sendex_btn_subscribe'] = 'Subscribe!';
 $_lang['sendex_btn_unsubscribe'] = 'Unsubscribe';
 $_lang['sendex_btn_send_all'] = 'Send all';
+$_lang['sendex_btn_send_subscribers'] = 'Send to subscribers';
 $_lang['sendex_btn_remove_all'] = 'Remove all';
 $_lang['sendex_btn_subscrubers_export'] = 'Export';
 $_lang['sendex_select_user'] = 'Add user';
@@ -31,6 +32,9 @@ $_lang['sendex_newsletter_err_no_subscribers'] = 'This newsletter has no subscri
 $_lang['sendex_newsletter_err_no_template'] = 'This newsletter has no template.';
 $_lang['sendex_newsletter_err_no_queues'] = 'No letters were added to the queue (0 rows).';
 $_lang['sendex_newsletter_queues_added'] = 'Added [[+count]] letter(s) to the queue.';
+$_lang['sendex_newsletter_send'] = 'Send to subscribers';
+$_lang['sendex_newsletter_send_confirm'] = 'Queue all subscribers and send pending emails for this newsletter?';
+$_lang['sendex_newsletter_send_success'] = 'Queued [[+queued]] letter(s), sent [[+sent]].';
 $_lang['sendex_newsletter_err_template'] = 'You must select template.';
 
 $_lang['sendex_newsletters_remove'] = 'Remove newsletters';
@@ -114,6 +118,7 @@ $_lang['sendex_subscribe_err_email_wrong'] = 'Wrong email.';
 $_lang['sendex_subscribe_err_email_ns'] = 'You need to specify email.';
 $_lang['sendex_subscribe_err_email_send'] = 'Could not send email.';
 
+$_lang['sendex_action_sendNewsletter'] = 'Send to subscribers';
 $_lang['sendex_action_updateNewsletter'] = 'Update newsletter';
 $_lang['sendex_action_disableNewsletter'] = 'Disable newsletter';
 $_lang['sendex_action_enableNewsletter'] = 'Enable newsletter';

--- a/core/components/sendex/lexicon/ru/default.inc.php
+++ b/core/components/sendex/lexicon/ru/default.inc.php
@@ -13,6 +13,7 @@ $_lang['sendex_btn_create'] = 'Создать';
 $_lang['sendex_btn_subscribe'] = 'Подписаться!';
 $_lang['sendex_btn_unsubscribe'] = 'Отписаться';
 $_lang['sendex_btn_send_all'] = 'Отправить все';
+$_lang['sendex_btn_send_subscribers'] = 'Отправить подписчикам';
 $_lang['sendex_btn_remove_all'] = 'Удалить все';
 $_lang['sendex_btn_subscrubers_export'] = 'Экспорт';
 $_lang['sendex_select_user'] = 'Добавить пользователя';
@@ -31,6 +32,9 @@ $_lang['sendex_newsletter_err_no_subscribers'] = 'У этой рассылки �
 $_lang['sendex_newsletter_err_no_template'] = 'У этой рассылки нет шаблона.';
 $_lang['sendex_newsletter_err_no_queues'] = 'В очередь не добавлено ни одного письма (0 строк).';
 $_lang['sendex_newsletter_queues_added'] = 'В очередь добавлено писем: [[+count]].';
+$_lang['sendex_newsletter_send'] = 'Отправить подписчикам';
+$_lang['sendex_newsletter_send_confirm'] = 'Поставить всех подписчиков в очередь и отправить ожидающие письма?';
+$_lang['sendex_newsletter_send_success'] = 'В очередь: [[+queued]], отправлено: [[+sent]].';
 $_lang['sendex_newsletter_err_template'] = 'Вы должны выбрать шаблон.';
 
 $_lang['sendex_newsletters_remove'] = 'Удалить подписки';
@@ -116,6 +120,7 @@ $_lang['sendex_subscribe_err_email_wrong'] = 'Неверный email.';
 $_lang['sendex_subscribe_err_email_ns'] = 'Нужно указать email.';
 $_lang['sendex_subscribe_err_email_send'] = 'Не могу отправить email.';
 
+$_lang['sendex_action_sendNewsletter'] = 'Отправить подписчикам';
 $_lang['sendex_action_updateNewsletter'] = 'Изменить рассылку';
 $_lang['sendex_action_disableNewsletter'] = 'Отключить рассылку';
 $_lang['sendex_action_enableNewsletter'] = 'Включить рассылку';

--- a/core/components/sendex/model/sendex/sxnewsletter.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletter.class.php
@@ -2,6 +2,7 @@
 
 require_once dirname(__FILE__) . '/sxnewslettersubscription.class.php';
 require_once dirname(__FILE__) . '/sxnewsletterqueuebuilder.class.php';
+require_once dirname(__FILE__) . '/sxnewsletterdispatch.class.php';
 require_once dirname(__FILE__) . '/sxnewslettergroupsubscribe.class.php';
 require_once dirname(__FILE__) . '/sxsendexevent.class.php';
 
@@ -19,6 +20,17 @@ class sxNewsletter extends xPDOSimpleObject
         $builder = new sxNewsletterQueueBuilder($this);
 
         return $builder->addQueues();
+    }
+
+    /**
+     * Queue subscribers and send pending rows for this newsletter (#29).
+     *
+     * @param array $options Optional sxQueueSender::flush options
+     * @return array{success:bool,message:string,queued:int,sent:int,skipped:int,failed:int}
+     */
+    public function sendToSubscribers(array $options = array())
+    {
+        return sxNewsletterDispatch::queueAndSend($this, $options);
     }
 
     /**

--- a/core/components/sendex/model/sendex/sxnewsletterdispatch.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletterdispatch.class.php
@@ -1,0 +1,79 @@
+<?php
+
+require_once dirname(__FILE__) . '/sxqueuesender.class.php';
+
+/**
+ * Queue + send workflow for a newsletter (#29).
+ */
+class sxNewsletterDispatch
+{
+    /**
+     * Add queue rows for subscribers, then flush pending rows for this newsletter.
+     *
+     * When addQueues creates nothing but queue rows already exist (re-send), flush still runs.
+     *
+     * @param sxNewsletter $newsletter
+     * @param array $options Optional sxQueueSender::flush options (e.g. sendFn for tests)
+     * @return array{success:bool,message:string,queued:int,sent:int,skipped:int,failed:int}
+     */
+    public static function queueAndSend(sxNewsletter $newsletter, array $options = array())
+    {
+        $xpdo = $newsletter->xpdo;
+        $newsletterId = (int) $newsletter->get('id');
+        $queued = 0;
+
+        $addResult = $newsletter->addQueues();
+        if (is_int($addResult)) {
+            $queued = $addResult;
+        } elseif ((int) $xpdo->getCount('sxQueue', array('newsletter_id' => $newsletterId)) <= 0) {
+            return self::failure($addResult, $queued);
+        }
+
+        $flushOptions = array(
+            'criteria'    => array('newsletter_id' => $newsletterId),
+            'stopOnError' => true,
+        );
+        if (isset($options['sendFn']) && is_callable($options['sendFn'])) {
+            $flushOptions['sendFn'] = $options['sendFn'];
+        }
+
+        $stats = sxQueueSender::flush($xpdo, $flushOptions);
+        if ($stats['firstError'] !== null) {
+            return self::failure($stats['firstError'], $queued, $stats);
+        }
+
+        return array(
+            'success'  => true,
+            'message'  => $xpdo->lexicon('sendex_newsletter_send_success', array(
+                'queued' => $queued,
+                'sent'   => $stats['sent'],
+            )),
+            'queued'   => $queued,
+            'sent'     => $stats['sent'],
+            'skipped'  => $stats['skipped'],
+            'failed'   => $stats['failed'],
+        );
+    }
+
+    /**
+     * @param string $message
+     * @param int $queued
+     * @param array|null $stats
+     * @return array{success:bool,message:string,queued:int,sent:int,skipped:int,failed:int}
+     */
+    protected static function failure($message, $queued = 0, ?array $stats = null)
+    {
+        if ($stats === null) {
+            $stats = array('sent' => 0, 'skipped' => 0, 'failed' => 0);
+        }
+
+        return array(
+            'success'  => false,
+            'message'  => $message,
+            'queued'   => $queued,
+            'sent'     => (int) $stats['sent'],
+            'skipped'  => (int) $stats['skipped'],
+            'failed'   => (int) $stats['failed'],
+        );
+    }
+}

--- a/core/components/sendex/processors/mgr/newsletter/getlist.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/getlist.class.php
@@ -73,6 +73,14 @@ class sxNewsletterGetListProcessor extends modObjectGetListProcessor
                 'type'   => 'disableNewsletter',
             );
         }
+        // Send to all subscribers (#29)
+        $array['actions'][] = array(
+            'class'  => '',
+            'button' => true,
+            'menu'   => true,
+            'icon'   => 'send',
+            'type'   => 'sendNewsletter',
+        );
         // Remove
         $array['actions'][] = array(
             'class'  => '',

--- a/core/components/sendex/processors/mgr/newsletter/send.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/send.class.php
@@ -1,0 +1,50 @@
+<?php
+
+require_once dirname(__DIR__) . '/sendexprocessor.class.php';
+
+/**
+ * Queue all subscribers and send pending queue rows for one newsletter (#29).
+ */
+class sxNewsletterSendProcessor extends sxSendexProcessor
+{
+    public $objectType = 'sxNewsletter';
+    public $classKey = 'sxNewsletter';
+
+
+    /** {inheritDoc} */
+    public function process()
+    {
+        if ($failure = $this->failureIfNoPermission()) {
+            return $failure;
+        }
+
+        $id = (int) $this->getProperty('id', $this->getProperty('newsletter_id'));
+        if ($id <= 0) {
+            return $this->failure($this->modx->lexicon('sendex_newsletter_err_ns'));
+        }
+
+        /** @var sxNewsletter|null $newsletter */
+        if (!$newsletter = $this->modx->getObject('sxNewsletter', $id)) {
+            return $this->failure($this->modx->lexicon('sendex_newsletter_err_nf'));
+        }
+
+        $result = $newsletter->sendToSubscribers();
+        if (!$result['success']) {
+            return $this->failure($result['message'], array(
+                'queued'  => $result['queued'],
+                'sent'    => $result['sent'],
+                'skipped' => $result['skipped'],
+                'failed'  => $result['failed'],
+            ));
+        }
+
+        return $this->success($result['message'], array(
+            'queued'  => $result['queued'],
+            'sent'    => $result['sent'],
+            'skipped' => $result['skipped'],
+            'failed'  => $result['failed'],
+        ));
+    }
+}
+
+return 'sxNewsletterSendProcessor';

--- a/tests/Unit/MgrGridSelectionContractTest.php
+++ b/tests/Unit/MgrGridSelectionContractTest.php
@@ -33,6 +33,16 @@ class MgrGridSelectionContractTest extends TestCase
             $this->assertStringContainsString('Sendex.grid.SelectionMixin', $source, $file);
             $this->assertStringNotContainsString('_getSelectedIds', $source, $file);
             $this->assertStringContainsString('confirmWithSelection', $source, $file);
+            $this->assertStringNotContainsString(
+                '}, Sendex.grid.SelectionMixin);',
+                $source,
+                $file . ' must close Ext.extend(Ext.apply(...)) with ));'
+            );
+            $this->assertGreaterThan(
+                0,
+                preg_match_all('/}, Sendex\.grid\.SelectionMixin\)\);/', $source),
+                $file
+            );
         }
     }
 

--- a/tests/Unit/NewsletterDispatchTest.php
+++ b/tests/Unit/NewsletterDispatchTest.php
@@ -1,0 +1,145 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class NewsletterDispatchTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    /** @var TestableNewsletter */
+    private $newsletter;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+        $this->newsletter = new TestableNewsletter($this->modx);
+        $this->newsletter->set('id', 10);
+        $this->newsletter->set('template', 1);
+        $this->newsletter->set('email_subject', 'Hello');
+        $this->newsletter->set('email_from', 'from@example.com');
+        $this->modx->templates[1] = new modTemplate();
+        require_once dirname(__DIR__, 2)
+            . '/core/components/sendex/model/sendex/sxnewsletterdispatch.class.php';
+    }
+
+    public function testFailsWhenNoSubscribersAndNoPendingQueues()
+    {
+        $result = sxNewsletterDispatch::queueAndSend($this->newsletter);
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('sendex_newsletter_err_no_subscribers', $result['message']);
+        $this->assertSame(0, $result['queued']);
+        $this->assertSame(0, $result['sent']);
+    }
+
+    public function testQueuesAndSendsForGuestSubscriber()
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 0,
+            'email'         => 'guest@example.com',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $result = sxNewsletterDispatch::queueAndSend($this->newsletter, array(
+            'sendFn' => function () {
+                return true;
+            },
+        ));
+
+        $this->assertTrue($result['success']);
+        $this->assertSame(1, $result['queued']);
+        $this->assertSame(1, $result['sent']);
+        $this->assertStringContainsString('queued=1', $result['message']);
+        $this->assertStringContainsString('sent=1', $result['message']);
+    }
+
+    public function testFlushesExistingQueuesWhenAddQueuesCreatesNothing()
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 5,
+            'email'         => 'user@example.com',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $user = new modUser($this->modx);
+        $user->set('id', 5);
+        $user->active = false;
+        $this->modx->users[5] = $user;
+
+        $queue = new sxQueue($this->modx);
+        $queue->fromArray(array(
+            'id'              => 99,
+            'newsletter_id'   => 10,
+            'subscriber_id'   => 1,
+            'email_to'        => 'user@example.com',
+            'email_subject'   => 'Hello',
+            'email_body'      => '',
+            'email_from'      => 'from@example.com',
+            'email_from_name' => 'From',
+            'email_reply'     => 'from@example.com',
+        ));
+        $this->modx->queues[] = $queue;
+
+        $result = sxNewsletterDispatch::queueAndSend($this->newsletter, array(
+            'sendFn' => function () {
+                return true;
+            },
+        ));
+
+        $this->assertTrue($result['success']);
+        $this->assertSame(0, $result['queued']);
+        $this->assertSame(1, $result['sent']);
+    }
+
+    public function testFailsWhenAddQueuesCreatesNothingAndNoPendingQueues()
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 5,
+            'email'         => 'user@example.com',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $user = new modUser($this->modx);
+        $user->set('id', 5);
+        $user->active = true;
+        $this->modx->users[5] = $user;
+
+        $result = sxNewsletterDispatch::queueAndSend($this->newsletter);
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('sendex_newsletter_err_no_queues', $result['message']);
+    }
+
+    public function testReturnsMailErrorFromFlush()
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 0,
+            'email'         => 'guest@example.com',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $result = sxNewsletterDispatch::queueAndSend($this->newsletter, array(
+            'sendFn' => function () {
+                return 'SMTP down';
+            },
+        ));
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('SMTP down', $result['message']);
+        $this->assertSame(1, $result['queued']);
+        $this->assertSame(0, $result['sent']);
+    }
+}

--- a/tests/Unit/NewsletterSendProcessorTest.php
+++ b/tests/Unit/NewsletterSendProcessorTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class NewsletterSendProcessorTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+        require_once dirname(__DIR__, 2)
+            . '/core/components/sendex/processors/mgr/newsletter/send.class.php';
+    }
+
+    public function testFailureWhenNewsletterMissing()
+    {
+        $processor = new sxNewsletterSendProcessor($this->modx, array('id' => 10));
+        $response = $processor->process();
+
+        $this->assertFalse($response['success']);
+        $this->assertSame('sendex_newsletter_err_nf', $response['message']);
+    }
+
+    public function testFailureWhenIdMissing()
+    {
+        $processor = new sxNewsletterSendProcessor($this->modx, array());
+        $response = $processor->process();
+
+        $this->assertFalse($response['success']);
+        $this->assertSame('sendex_newsletter_err_ns', $response['message']);
+    }
+
+    public function testSuccessDelegatesToDispatch()
+    {
+        $newsletter = new class ($this->modx) extends TestableNewsletter {
+            /**
+             * @param array $options
+             * @return array
+             */
+            public function sendToSubscribers(array $options = array())
+            {
+                return array(
+                    'success'  => true,
+                    'message'  => 'sendex_newsletter_send_success:queued=2:sent=2',
+                    'queued'   => 2,
+                    'sent'     => 2,
+                    'skipped'  => 0,
+                    'failed'   => 0,
+                );
+            }
+        };
+        $newsletter->set('id', 10);
+        $this->modx->newsletters[10] = $newsletter;
+
+        $processor = new sxNewsletterSendProcessor($this->modx, array('id' => 10));
+        $response = $processor->process();
+
+        $this->assertTrue($response['success']);
+        $this->assertSame(2, $response['object']['sent']);
+    }
+
+    public function testProcessorUsesDispatchClass()
+    {
+        $source = file_get_contents(
+            dirname(__DIR__, 2) . '/core/components/sendex/processors/mgr/newsletter/send.class.php'
+        );
+
+        $this->assertStringContainsString('$newsletter->sendToSubscribers', $source);
+        $this->assertStringContainsString('extends sxSendexProcessor', $source);
+    }
+}

--- a/tests/Unit/NewsletterSplitContractTest.php
+++ b/tests/Unit/NewsletterSplitContractTest.php
@@ -51,6 +51,8 @@ class NewsletterSplitContractTest extends TestCase
         $this->assertStringContainsString('function subscribe(', $facade);
         $this->assertStringContainsString('function subscribeGroup(', $facade);
         $this->assertStringContainsString('sxNewsletterGroupSubscribe', $facade);
+        $this->assertStringContainsString('sxNewsletterDispatch', $facade);
+        $this->assertStringContainsString('function sendToSubscribers(', $facade);
         $this->assertStringContainsString('function addQueues(', $facade);
         $this->assertStringNotContainsString('function remove(', $facade);
     }

--- a/tests/Unit/SendexProcessorAclTest.php
+++ b/tests/Unit/SendexProcessorAclTest.php
@@ -40,6 +40,7 @@ class SendexProcessorAclTest extends TestCase
             'newsletter/remove.class.php',
             'newsletter/enable.class.php',
             'newsletter/disable.class.php',
+            'newsletter/send.class.php',
             'queue/remove.class.php',
             'queue/remove_all.class.php',
             'queue/add.class.php',


### PR DESCRIPTION
Одна кнопка в mgr: поставить подписчиков в очередь и отправить письма рассылки.

## Что сделано
- `sxNewsletterDispatch::queueAndSend` — `addQueues` + `sxQueueSender::flush` по `newsletter_id`; при 0 новых строк, но pending rows — только flush (re-send)
- Processor `mgr/newsletter/send`, facade `sxNewsletter::sendToSubscribers()`
- Кнопка в row actions grid и primary-кнопка в окне редактирования (confirm)
- Lexicon en/ru, changelog
- тесты: `NewsletterDispatchTest`, `NewsletterSendProcessorTest`
- миграция: не нужна (логика + UI)

## Review
- Findings: нет (pass 2 после удаления лишнего require)

## Проверка
- `composer test` — exit 0 (178 tests, +9 новых)
- phpcs — exit 0 (changed PHP)
- waive: ручной прогон ExtJS mgr UI (нет MODX в CI)

Fixes #29