### PR TITLE
feat(subscribe): Add optional guest subscribe without confirm email

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Root `composer.json` remains for PHPUnit/phpcs only.
 | `tplSubscribeGuest` | `tpl.Sendex.subscribe.guest` | Chunk for guests |
 | `tplUnsubscribe` | `tpl.Sendex.unsubscribe` | Unsubscribe chunk |
 | `tplActivate` | `tpl.Sendex.activate` | Confirmation email chunk |
+| `confirmEmail` | system `sendex_confirm_email` (default `1`) | Guest flow: `1` = confirm link by email; `0` = subscribe immediately |
+
+When `confirmEmail` is off, guest addresses are saved without a confirmation message. Typos and spam signups are harder to catch; use only when you accept that tradeoff.
 
 ### Guest email vs existing User (#39)
 

--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -15,6 +15,12 @@ $tmp = [
         'key'   => 'sendex_hide_export_button',
         'area'  => 'sendex_main',
     ),
+    'confirm_email'      => array(
+        'xtype' => 'combo-boolean',
+        'value' => true,
+        'key'   => 'sendex_confirm_email',
+        'area'  => 'sendex_main',
+    ),
 ];
 
 foreach ($tmp as $k => $v) {

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CSV cells that look like spreadsheet formulas are prefixed so Excel/LibreOffice do not execute them.
 
 ### Added
+- [#38] Guest subscribe can skip email confirmation: snippet `&confirmEmail=`0`` or system setting `sendex_confirm_email`; domain helper `subscribeGuest()` keeps one subscribe path.
 - [#29] Mgr newsletter «Send to subscribers»: one action runs `addQueues` + `sxQueueSender::flush` for the newsletter (`mgr/newsletter/send`); button in grid row actions and update window.
 - [#46] Search subscribers and queue by email or username.
 - [#44] Plugin events for subscribe/unsubscribe (`sxOnBeforeSubscribe`, `sxOnSubscribe`, `sxOnBeforeUnsubscribe`, `sxOnUnsubscribe`).

--- a/core/components/sendex/elements/snippets/snippet.sendex.php
+++ b/core/components/sendex/elements/snippets/snippet.sendex.php
@@ -16,6 +16,7 @@ if (!($Sendex instanceof Sendex)) {
 
 require_once $corePath . 'model/sendex/sxuserplaceholders.class.php';
 require_once $corePath . 'model/sendex/sxunsubscriberesolve.class.php';
+require_once $corePath . 'model/sendex/sxsubscribeconfirm.class.php';
 
 $tplSubscribeAuth = $modx->getOption('tplSubscribeAuth', $scriptProperties, 'tpl.Sendex.subscribe.auth');
 $tplSubscribeGuest = $modx->getOption('tplSubscribeGuest', $scriptProperties, 'tpl.Sendex.subscribe.guest');
@@ -24,6 +25,7 @@ $tplActivate = $modx->getOption('tplActivate', $scriptProperties, 'tpl.Sendex.ac
 if (empty($linkTTL)) {
     $linkTTL = 1800;
 }
+$requireConfirm = sxSubscribeConfirm::isRequired($modx, $scriptProperties);
 
 if (empty($id) || !$newsletter = $modx->getObject('sxNewsletter', $id)) {
     return $modx->lexicon('sendex_newsletter_err_ns');
@@ -67,14 +69,25 @@ if (!empty($_REQUEST['sx_action'])) {
                 }
             } elseif (!empty($_REQUEST['email'])) {
                 $email = htmlentities(strip_tags(urldecode($_REQUEST['email'])));
-                $response = $newsletter->checkEmail($email, $modx->user->id, $linkTTL);
-                if ($response === true) {
+                $guestResult = $newsletter->subscribeGuest(
+                    $email,
+                    $modx->user->id,
+                    $linkTTL,
+                    $requireConfirm
+                );
+                if ($guestResult['status'] === 'already') {
                     $placeholders['message'] = $modx->lexicon('sendex_subscribe_err_already');
-                } elseif ($response === false) {
+                } elseif ($guestResult['status'] === 'invalid') {
                     $placeholders['message'] = $modx->lexicon('sendex_subscribe_err_email_wrong');
                     $placeholders['error'] = 1;
-                } else {
-                    $params['hash'] = $response;
+                } elseif ($guestResult['status'] === 'subscribed') {
+                    $placeholders['message'] = $modx->lexicon('sendex_subscribe_email_confirmed');
+                    $params['sx_confirmed'] = 1;
+                } elseif ($guestResult['status'] === 'error') {
+                    $placeholders['message'] = $guestResult['message'];
+                    $placeholders['error'] = 1;
+                } elseif ($guestResult['status'] === 'confirm') {
+                    $params['hash'] = $guestResult['hash'];
                     $params['sx_action'] = 'confirm';
                     $placeholders['link'] = $modx->makeUrl($modx->resource->id, $modx->context->key, $params, 'full');
                     $placeholders['email_body'] = $modx->getChunk($tplActivate, $placeholders);

--- a/core/components/sendex/lexicon/en/setting.inc.php
+++ b/core/components/sendex/lexicon/en/setting.inc.php
@@ -8,3 +8,6 @@ $_lang['setting_sendex_export_fields_desc'] = 'Enter fields separated by commas.
 $_lang['setting_sendex_hide_export_button'] = 'Hide export button';
 $_lang['setting_sendex_hide_export_button_desc'] = 'Disables the button to export the list of email'
     . ' addresses in the mailing list';
+$_lang['setting_sendex_confirm_email'] = 'Require guest email confirmation';
+$_lang['setting_sendex_confirm_email_desc'] = 'When enabled, guests must confirm subscription via email link. '
+    . 'When disabled, guest emails are subscribed immediately (higher risk of invalid addresses).';

--- a/core/components/sendex/lexicon/ru/setting.inc.php
+++ b/core/components/sendex/lexicon/ru/setting.inc.php
@@ -7,3 +7,6 @@ $_lang['setting_sendex_export_fields_desc'] = 'Введите данные че�
     . ' id,user_id,email,username,fullname,phone,mobilephone';
 $_lang['setting_sendex_hide_export_button'] = 'Скрыть кнопку экспорта';
 $_lang['setting_sendex_hide_export_button_desc'] = 'Отключает кнопку экспорта списка email адресов в рассылке';
+$_lang['setting_sendex_confirm_email'] = 'Требовать подтверждение email гостя';
+$_lang['setting_sendex_confirm_email_desc'] = 'Если включено, гость подтверждает подписку по ссылке из письма. '
+    . 'Если выключено, email сразу попадает в подписчики (выше риск мусорных адресов).';

--- a/core/components/sendex/model/sendex/sxnewsletter.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletter.class.php
@@ -3,6 +3,7 @@
 require_once dirname(__FILE__) . '/sxnewslettersubscription.class.php';
 require_once dirname(__FILE__) . '/sxnewsletterqueuebuilder.class.php';
 require_once dirname(__FILE__) . '/sxnewsletterdispatch.class.php';
+require_once dirname(__FILE__) . '/sxsubscribeconfirm.class.php';
 require_once dirname(__FILE__) . '/sxnewslettergroupsubscribe.class.php';
 require_once dirname(__FILE__) . '/sxsendexevent.class.php';
 
@@ -71,6 +72,24 @@ class sxNewsletter extends xPDOSimpleObject
     public function subscribe($user_id = 0, $email = '')
     {
         return $this->subscription()->subscribe($user_id, $email);
+    }
+
+    /**
+     * @param string $email
+     * @param int $user_id
+     * @param int $linkTTL
+     * @param bool $requireConfirm
+     * @return array{status:string,hash?:string,message?:string}
+     */
+    public function subscribeGuest($email = '', $user_id = 0, $linkTTL = 1800, $requireConfirm = true)
+    {
+        return sxSubscribeConfirm::guestSubscribe(
+            $this->subscription(),
+            $email,
+            $user_id,
+            $linkTTL,
+            $requireConfirm
+        );
     }
 
     /**

--- a/core/components/sendex/model/sendex/sxsubscribeconfirm.class.php
+++ b/core/components/sendex/model/sendex/sxsubscribeconfirm.class.php
@@ -1,0 +1,96 @@
+<?php
+
+require_once dirname(__FILE__) . '/sxnewslettersubscription.class.php';
+
+/**
+ * Resolve whether guest subscribe requires email confirmation (#38).
+ */
+class sxSubscribeConfirm
+{
+    /**
+     * Snippet &confirmEmail= overrides system setting sendex_confirm_email.
+     *
+     * @param object $modx modX
+     * @param array $scriptProperties snippet properties
+     * @return bool
+     */
+    public static function isRequired($modx, array $scriptProperties = array())
+    {
+        if (array_key_exists('confirmEmail', $scriptProperties)) {
+            return self::parseBool($scriptProperties['confirmEmail'], true);
+        }
+
+        return self::parseBool($modx->getOption('sendex_confirm_email', null, true), true);
+    }
+
+    /**
+     * @param mixed $value
+     * @param bool $default
+     * @return bool
+     */
+    public static function parseBool($value, $default = true)
+    {
+        if ($value === null || $value === '') {
+            return $default;
+        }
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        $normalized = strtolower(trim((string) $value));
+        if (in_array($normalized, array('0', 'false', 'no', 'off'), true)) {
+            return false;
+        }
+        if (in_array($normalized, array('1', 'true', 'yes', 'on'), true)) {
+            return true;
+        }
+
+        return $default;
+    }
+
+    /**
+     * Guest subscribe: email confirm or immediate active subscription (#38).
+     *
+     * @param sxNewsletterSubscription $subscription
+     * @param string $email
+     * @param int $userId
+     * @param int $linkTTL
+     * @param bool $requireConfirm
+     * @return array{status:string,hash?:string,message?:string}
+     */
+    public static function guestSubscribe(
+        sxNewsletterSubscription $subscription,
+        $email = '',
+        $userId = 0,
+        $linkTTL = 1800,
+        $requireConfirm = true
+    ) {
+        if (!$requireConfirm) {
+            $result = $subscription->subscribe($userId, $email);
+            if ($result === true) {
+                return array('status' => 'subscribed');
+            }
+            if ($result === false) {
+                return array('status' => 'invalid');
+            }
+
+            return array(
+                'status'  => 'error',
+                'message' => (string) $result,
+            );
+        }
+
+        $response = $subscription->checkEmail($email, $userId, $linkTTL);
+        if ($response === true) {
+            return array('status' => 'already');
+        }
+        if ($response === false) {
+            return array('status' => 'invalid');
+        }
+
+        return array(
+            'status' => 'confirm',
+            'hash'   => $response,
+        );
+    }
+}

--- a/tests/Unit/NewsletterSplitContractTest.php
+++ b/tests/Unit/NewsletterSplitContractTest.php
@@ -52,7 +52,9 @@ class NewsletterSplitContractTest extends TestCase
         $this->assertStringContainsString('function subscribeGroup(', $facade);
         $this->assertStringContainsString('sxNewsletterGroupSubscribe', $facade);
         $this->assertStringContainsString('sxNewsletterDispatch', $facade);
+        $this->assertStringContainsString('sxSubscribeConfirm', $facade);
         $this->assertStringContainsString('function sendToSubscribers(', $facade);
+        $this->assertStringContainsString('function subscribeGuest(', $facade);
         $this->assertStringContainsString('function addQueues(', $facade);
         $this->assertStringNotContainsString('function remove(', $facade);
     }

--- a/tests/Unit/NewsletterSubscribeGuestTest.php
+++ b/tests/Unit/NewsletterSubscribeGuestTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class NewsletterSubscribeGuestTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    /** @var TestableNewsletter */
+    private $newsletter;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+        $this->newsletter = new TestableNewsletter($this->modx);
+        $this->newsletter->set('id', 10);
+    }
+
+    public function testImmediateSubscribeWithoutConfirm()
+    {
+        $result = $this->newsletter->subscribeGuest('guest@example.com', 0, 1800, false);
+
+        $this->assertSame('subscribed', $result['status']);
+        $this->assertCount(1, $this->modx->subscribers);
+        $this->assertSame(array(), $this->modx->registryEntries);
+    }
+
+    public function testConfirmFlowStoresHashWhenRequired()
+    {
+        $result = $this->newsletter->subscribeGuest('guest@example.com', 0, 600, true);
+
+        $this->assertSame('confirm', $result['status']);
+        $this->assertArrayHasKey('hash', $result);
+        $this->assertArrayHasKey($result['hash'], $this->modx->registryEntries);
+        $this->assertCount(0, $this->modx->subscribers);
+    }
+
+    public function testAlreadySubscribedReturnsAlready()
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 0,
+            'email'         => 'guest@example.com',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+
+        $withConfirm = $this->newsletter->subscribeGuest('guest@example.com', 0, 1800, true);
+        $withoutConfirm = $this->newsletter->subscribeGuest('guest@example.com', 0, 1800, false);
+
+        $this->assertSame('already', $withConfirm['status']);
+        $this->assertSame('subscribed', $withoutConfirm['status']);
+    }
+
+    public function testInvalidEmailReturnsInvalid()
+    {
+        $result = $this->newsletter->subscribeGuest('bad', 0, 1800, false);
+
+        $this->assertSame('invalid', $result['status']);
+    }
+
+    public function testPluginCancelReturnsErrorStatus()
+    {
+        $this->modx->invokeResponses['sxOnBeforeSubscribe'] = array('blocked');
+
+        $result = $this->newsletter->subscribeGuest('guest@example.com', 0, 1800, false);
+
+        $this->assertSame('error', $result['status']);
+        $this->assertSame('blocked', $result['message']);
+    }
+}

--- a/tests/Unit/SnippetSubscribeConfirmContractTest.php
+++ b/tests/Unit/SnippetSubscribeConfirmContractTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class SnippetSubscribeConfirmContractTest extends TestCase
+{
+    public function testSnippetUsesSubscribeGuestAndConfirmHelper()
+    {
+        $source = file_get_contents(
+            dirname(__DIR__, 2) . '/core/components/sendex/elements/snippets/snippet.sendex.php'
+        );
+
+        $this->assertStringContainsString('sxSubscribeConfirm::isRequired', $source);
+        $this->assertStringContainsString('subscribeGuest(', $source);
+        $this->assertStringNotContainsString('->checkEmail(', $source);
+    }
+}

--- a/tests/Unit/SubscribeConfirmTest.php
+++ b/tests/Unit/SubscribeConfirmTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class SubscribeConfirmTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+        require_once dirname(__DIR__, 2)
+            . '/core/components/sendex/model/sendex/sxsubscribeconfirm.class.php';
+    }
+
+    public function testParseBoolRecognizesOffValues()
+    {
+        $this->assertFalse(sxSubscribeConfirm::parseBool('0'));
+        $this->assertFalse(sxSubscribeConfirm::parseBool('false'));
+        $this->assertFalse(sxSubscribeConfirm::parseBool('no'));
+    }
+
+    public function testParseBoolRecognizesOnValues()
+    {
+        $this->assertTrue(sxSubscribeConfirm::parseBool('1'));
+        $this->assertTrue(sxSubscribeConfirm::parseBool('true'));
+        $this->assertTrue(sxSubscribeConfirm::parseBool('yes'));
+    }
+
+    public function testSnippetPropertyOverridesSystemSetting()
+    {
+        $this->modx->options['sendex_confirm_email'] = true;
+
+        $this->assertFalse(sxSubscribeConfirm::isRequired($this->modx, array('confirmEmail' => '0')));
+        $this->assertTrue(sxSubscribeConfirm::isRequired($this->modx, array('confirmEmail' => '1')));
+    }
+
+    public function testFallsBackToSystemSetting()
+    {
+        $this->modx->options['sendex_confirm_email'] = false;
+
+        $this->assertFalse(sxSubscribeConfirm::isRequired($this->modx, array()));
+    }
+
+    public function testDefaultIsConfirmRequired()
+    {
+        $this->assertTrue(sxSubscribeConfirm::isRequired($this->modx, array()));
+    }
+}


### PR DESCRIPTION
Гости могут подписаться сразу, без confirm-письма — через snippet или system setting.

## Что сделано
- `sxSubscribeConfirm`: resolve флага (snippet `confirmEmail` → setting `sendex_confirm_email`, default `1`)
- `sxSubscribeConfirm::guestSubscribe()` + facade `subscribeGuest()` — один путь: confirm или сразу `subscribe()`
- Snippet: вызов `subscribeGuest`, без прямого `checkEmail`
- System setting + lexicon en/ru, README (флаг и риски)
- тесты: `SubscribeConfirmTest`, `NewsletterSubscribeGuestTest`, `SnippetSubscribeConfirmContractTest`
- миграция: не нужна

## Review
- Findings: нет

## Проверка
- `composer test` — exit 0 (189 tests, +11 новых)
- phpcs — exit 0
- waive: ручной прогон snippet на MODX (нет MODX в CI)

Fixes #38