### PR TITLE
feat(frontend): Add AJAX subscribe/unsubscribe out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,34 @@ Root `composer.json` remains for PHPUnit/phpcs only.
 | `tplUnsubscribe` | `tpl.Sendex.unsubscribe` | Unsubscribe chunk |
 | `tplActivate` | `tpl.Sendex.activate` | Confirmation email chunk |
 | `confirmEmail` | system `sendex_confirm_email` (default `1`) | Guest flow: `1` = confirm link by email; `0` = subscribe immediately |
+| `loadJs` | `1` | Register `assets/components/sendex/js/web/sendex.js` for AJAX forms |
 
 When `confirmEmail` is off, guest addresses are saved without a confirmation message. Typos and spam signups are harder to catch; use only when you accept that tradeoff.
+
+### AJAX subscribe / unsubscribe (#42)
+
+Default chunks include `data-sendex-*` hooks; the snippet registers `sendex.js`, which submits forms via `fetch` and swaps the widget without a full page reload. The server answers with JSON `{success, message, html}`.
+
+Minimal page markup:
+
+```html
+[[!Sendex? &id=`1`]]
+```
+
+Guest chunk structure (for custom templates):
+
+```html
+<div class="sendex-widget" data-sendex-widget>
+  <p class="sendex-message [[+class]]" data-sendex-message><b>[[+message]]</b></p>
+  <form action="" method="post" data-sendex-form>
+    <input type="hidden" name="sx_action" value="subscribe">
+    <input type="email" name="email" required>
+    <button type="submit">Subscribe</button>
+  </form>
+</div>
+```
+
+Set `&loadJs=`0`` if you ship your own JS but keep the same JSON contract (`X-Requested-With: XMLHttpRequest` or `ajax=1`).
 
 ### Guest email vs existing User (#39)
 

--- a/assets/components/sendex/js/web/sendex.js
+++ b/assets/components/sendex/js/web/sendex.js
@@ -1,0 +1,108 @@
+(function (window, document) {
+    'use strict';
+
+    var SendexForm = {
+        init: function (root) {
+            var scope = root || document;
+            var forms = scope.querySelectorAll('[data-sendex-form]');
+            var i;
+
+            for (i = 0; i < forms.length; i++) {
+                SendexForm.bind(forms[i]);
+            }
+        },
+
+        bind: function (form) {
+            if (form.getAttribute('data-sendex-bound') === '1') {
+                return;
+            }
+            form.setAttribute('data-sendex-bound', '1');
+            form.addEventListener('submit', SendexForm.onSubmit);
+        },
+
+        onSubmit: function (event) {
+            var form = event.target;
+            var widget;
+            var body;
+            var action;
+
+            if (!form || !form.getAttribute('data-sendex-form')) {
+                return;
+            }
+
+            event.preventDefault();
+            widget = form.closest('[data-sendex-widget]');
+            body = new FormData(form);
+            body.append('ajax', '1');
+            action = form.getAttribute('action') || window.location.href;
+
+            fetch(action, {
+                method: (form.getAttribute('method') || 'POST').toUpperCase(),
+                body: body,
+                credentials: 'same-origin',
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest',
+                    'Accept': 'application/json'
+                }
+            })
+                .then(function (response) {
+                    return response.json();
+                })
+                .then(function (data) {
+                    SendexForm.applyResponse(widget, data);
+                })
+                .catch(function () {
+                    SendexForm.applyResponse(widget, {
+                        success: false,
+                        message: 'Request failed',
+                        html: ''
+                    });
+                });
+        },
+
+        applyResponse: function (widget, data) {
+            var html;
+            var messageNode;
+
+            if (!data) {
+                return;
+            }
+
+            html = data.html || '';
+            if (html && widget && widget.parentNode) {
+                widget.outerHTML = html;
+                SendexForm.init(document);
+                return;
+            }
+
+            if (!widget) {
+                return;
+            }
+
+            messageNode = widget.querySelector('[data-sendex-message]');
+            if (messageNode && data.message) {
+                messageNode.innerHTML = '<b>' + SendexForm.escapeHtml(data.message) + '</b>';
+                messageNode.className = 'sendex-message ' + (data.success ? 'active' : 'sendex-error');
+            }
+        },
+
+        escapeHtml: function (value) {
+            return String(value)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function () {
+            SendexForm.init(document);
+        });
+    } else {
+        SendexForm.init(document);
+    }
+
+    window.SendexForm = SendexForm;
+}(window, document));

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CSV cells that look like spreadsheet formulas are prefixed so Excel/LibreOffice do not execute them.
 
 ### Added
+- [#42] Frontend AJAX subscribe/unsubscribe: JSON `{success, message, html}` from snippet, default chunks + `assets/components/sendex/js/web/sendex.js`.
 - [#38] Guest subscribe can skip email confirmation: snippet `&confirmEmail=`0`` or system setting `sendex_confirm_email`; domain helper `subscribeGuest()` keeps one subscribe path.
 - [#29] Mgr newsletter «Send to subscribers»: one action runs `addQueues` + `sxQueueSender::flush` for the newsletter (`mgr/newsletter/send`); button in grid row actions and update window.
 - [#46] Search subscribers and queue by email or username.

--- a/core/components/sendex/elements/chunks/chunk.subscribe.auth.tpl
+++ b/core/components/sendex/elements/chunks/chunk.subscribe.auth.tpl
@@ -1,12 +1,14 @@
-<p>
-    [[%sendex_subscribe_intro?name=`[[+name]]`]]
-    <small>[[+description]]</small>
-</p>
+<div class="sendex-widget" data-sendex-widget>
+    <p>
+        [[%sendex_subscribe_intro?name=`[[+name]]`]]
+        <small>[[+description]]</small>
+    </p>
 
-<p class="[[+class]]"><b>[[+message]]</b></p>
+    <p class="sendex-message [[+class]]" data-sendex-message><b>[[+message]]</b></p>
 
-<form action="" method="post">
-    <input type="hidden" name="sx_action" value="subscribe">
+    <form action="" method="post" data-sendex-form>
+        <input type="hidden" name="sx_action" value="subscribe">
 
-    <button type="submit">[[%sendex_btn_subscribe]]</button>
-</form>
+        <button type="submit">[[%sendex_btn_subscribe]]</button>
+    </form>
+</div>

--- a/core/components/sendex/elements/chunks/chunk.subscribe.guest.tpl
+++ b/core/components/sendex/elements/chunks/chunk.subscribe.guest.tpl
@@ -1,14 +1,16 @@
-<p>
-    [[%sendex_subscribe_intro?name=`[[+name]]`]]
-    <small>[[+description]]</small>
-</p>
+<div class="sendex-widget" data-sendex-widget>
+    <p>
+        [[%sendex_subscribe_intro?name=`[[+name]]`]]
+        <small>[[+description]]</small>
+    </p>
 
-<p class="[[+class]]"><b>[[+message]]</b></p>
+    <p class="sendex-message [[+class]]" data-sendex-message><b>[[+message]]</b></p>
 
-<form action="" method="post">
-    <input type="hidden" name="sx_action" value="subscribe">
+    <form action="" method="post" data-sendex-form>
+        <input type="hidden" name="sx_action" value="subscribe">
 
-    <input type="email" name="email" value="" placeholder="Email">
+        <input type="email" name="email" value="" placeholder="Email" required>
 
-    <button type="submit">[[%sendex_btn_subscribe]]</button>
-</form>
+        <button type="submit">[[%sendex_btn_subscribe]]</button>
+    </form>
+</div>

--- a/core/components/sendex/elements/chunks/chunk.unsubscribe.tpl
+++ b/core/components/sendex/elements/chunks/chunk.unsubscribe.tpl
@@ -1,14 +1,16 @@
-<p>
-    [[%sendex_unsubscribe_intro?name=`[[+name]]`]]
-    <small>[[+description]]</small>
-</p>
+<div class="sendex-widget" data-sendex-widget>
+    <p>
+        [[%sendex_unsubscribe_intro?name=`[[+name]]`]]
+        <small>[[+description]]</small>
+    </p>
 
-<p class="[[+class]]"><b>[[+message]]</b></p>
+    <p class="sendex-message [[+class]]" data-sendex-message><b>[[+message]]</b></p>
 
-<form action="" method="post">
-    <input type="hidden" name="sx_action" value="unsubscribe">
+    <form action="" method="post" data-sendex-form>
+        <input type="hidden" name="sx_action" value="unsubscribe">
 
-    <input type="hidden" name="code" value="[[+code]]">
+        <input type="hidden" name="code" value="[[+code]]">
 
-    <button type="submit">[[%sendex_btn_unsubscribe]]</button>
-</form>
+        <button type="submit">[[%sendex_btn_unsubscribe]]</button>
+    </form>
+</div>

--- a/core/components/sendex/elements/snippets/snippet.sendex.php
+++ b/core/components/sendex/elements/snippets/snippet.sendex.php
@@ -17,6 +17,7 @@ if (!($Sendex instanceof Sendex)) {
 require_once $corePath . 'model/sendex/sxuserplaceholders.class.php';
 require_once $corePath . 'model/sendex/sxunsubscriberesolve.class.php';
 require_once $corePath . 'model/sendex/sxsubscribeconfirm.class.php';
+require_once $corePath . 'model/sendex/sxsubscribeajaxresponse.class.php';
 
 $tplSubscribeAuth = $modx->getOption('tplSubscribeAuth', $scriptProperties, 'tpl.Sendex.subscribe.auth');
 $tplSubscribeGuest = $modx->getOption('tplSubscribeGuest', $scriptProperties, 'tpl.Sendex.subscribe.guest');
@@ -26,6 +27,11 @@ if (empty($linkTTL)) {
     $linkTTL = 1800;
 }
 $requireConfirm = sxSubscribeConfirm::isRequired($modx, $scriptProperties);
+$loadJs = sxSubscribeAjaxResponse::parseEnabled(
+    $modx->getOption('loadJs', $scriptProperties, true),
+    true
+);
+$isAjax = sxSubscribeAjaxResponse::isRequest($scriptProperties);
 
 if (empty($id) || !$newsletter = $modx->getObject('sxNewsletter', $id)) {
     return $modx->lexicon('sendex_newsletter_err_ns');
@@ -51,8 +57,6 @@ if ($isAuthenticated) {
 }
 
 if (!empty($_REQUEST['sx_action'])) {
-    $isAjax = isset($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] == 'XMLHttpRequest';
-
     $params = $_GET;
     unset($params[$modx->getOption('request_param_alias')]);
     unset($params[$modx->getOption('request_param_id')]);
@@ -166,7 +170,9 @@ if (!empty($_REQUEST['sx_action'])) {
 }
 
 if (!empty($placeholders['message'])) {
-    $placeholders['class'] = $modx->getOption('msgClass', $scriptProperties, 'active');
+    $placeholders['class'] = !empty($placeholders['error'])
+        ? 'sendex-error'
+        : $modx->getOption('msgClass', $scriptProperties, 'active');
 }
 
 if ($isAuthenticated && $id = $newsletter->isSubscribed($modx->user->id)) {
@@ -180,9 +186,15 @@ if ($isAuthenticated && $id = $newsletter->isSubscribed($modx->user->id)) {
         : $modx->getChunk($tplSubscribeGuest, $placeholders);
 }
 
-if (!empty($isAjax)) {
-    @session_write_close();
-    exit($output);
-} else {
-    return $output;
+if ($isAjax && !empty($_REQUEST['sx_action'])) {
+    sxSubscribeAjaxResponse::send($placeholders, $output);
 }
+
+if ($loadJs && !defined('SENDEX_FRONTEND_JS')) {
+    define('SENDEX_FRONTEND_JS', true);
+    $modx->regClientScript(
+        $modx->getOption('assets_url') . 'components/sendex/js/web/sendex.js'
+    );
+}
+
+return $output;

--- a/core/components/sendex/model/sendex/sxsubscribeajaxresponse.class.php
+++ b/core/components/sendex/model/sendex/sxsubscribeajaxresponse.class.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Frontend AJAX subscribe/unsubscribe JSON contract (#42).
+ */
+class sxSubscribeAjaxResponse
+{
+    /**
+     * @param array $scriptProperties
+     * @return bool
+     */
+    public static function isRequest(array $scriptProperties = array())
+    {
+        if (
+            isset($_SERVER['HTTP_X_REQUESTED_WITH'])
+            && strtolower((string) $_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest'
+        ) {
+            return true;
+        }
+
+        if (!empty($_REQUEST['ajax']) || !empty($_REQUEST['sendex_ajax'])) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array $placeholders
+     * @param string $html
+     * @return array{success:bool,message:string,html:string}
+     */
+    public static function payload(array $placeholders, $html)
+    {
+        return array(
+            'success' => empty($placeholders['error']),
+            'message' => (string) (isset($placeholders['message']) ? $placeholders['message'] : ''),
+            'html'    => (string) $html,
+        );
+    }
+
+    /**
+     * @param array $placeholders
+     * @param string $html
+     */
+    public static function send(array $placeholders, $html)
+    {
+        if (!headers_sent()) {
+            header('Content-Type: application/json; charset=UTF-8');
+        }
+
+        echo json_encode(
+            self::payload($placeholders, $html),
+            JSON_UNESCAPED_UNICODE
+        );
+        @session_write_close();
+        exit;
+    }
+
+    /**
+     * @param mixed $value
+     * @param bool $default
+     * @return bool
+     */
+    public static function parseEnabled($value, $default = true)
+    {
+        if ($value === null || $value === '') {
+            return $default;
+        }
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        $normalized = strtolower(trim((string) $value));
+        if (in_array($normalized, array('0', 'false', 'no', 'off'), true)) {
+            return false;
+        }
+        if (in_array($normalized, array('1', 'true', 'yes', 'on'), true)) {
+            return true;
+        }
+
+        return $default;
+    }
+}

--- a/tests/Unit/FrontendAjaxContractTest.php
+++ b/tests/Unit/FrontendAjaxContractTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class FrontendAjaxContractTest extends TestCase
+{
+    public function testSnippetUsesJsonAjaxResponse()
+    {
+        $snippet = file_get_contents(
+            dirname(__DIR__, 2) . '/core/components/sendex/elements/snippets/snippet.sendex.php'
+        );
+
+        $this->assertStringContainsString('sxSubscribeAjaxResponse::isRequest', $snippet);
+        $this->assertStringContainsString('sxSubscribeAjaxResponse::send', $snippet);
+        $this->assertStringContainsString('regClientScript', $snippet);
+        $this->assertStringNotContainsString('exit($output)', $snippet);
+    }
+
+    public function testDefaultChunksExposeAjaxHooks()
+    {
+        $base = dirname(__DIR__, 2) . '/core/components/sendex/elements/chunks/';
+        $files = array(
+            'chunk.subscribe.guest.tpl',
+            'chunk.subscribe.auth.tpl',
+            'chunk.unsubscribe.tpl',
+        );
+
+        foreach ($files as $file) {
+            $source = file_get_contents($base . $file);
+            $this->assertStringContainsString('data-sendex-widget', $source, $file);
+            $this->assertStringContainsString('data-sendex-form', $source, $file);
+            $this->assertStringContainsString('data-sendex-message', $source, $file);
+        }
+    }
+
+    public function testFrontendJsUsesFetchAndJson()
+    {
+        $source = file_get_contents(
+            dirname(__DIR__, 2) . '/assets/components/sendex/js/web/sendex.js'
+        );
+
+        $this->assertStringContainsString('fetch(', $source);
+        $this->assertStringContainsString('response.json()', $source);
+        $this->assertStringContainsString('data-sendex-form', $source);
+        $this->assertStringContainsString('XMLHttpRequest', $source);
+    }
+}

--- a/tests/Unit/SubscribeAjaxResponseTest.php
+++ b/tests/Unit/SubscribeAjaxResponseTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class SubscribeAjaxResponseTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        require_once dirname(__DIR__, 2)
+            . '/core/components/sendex/model/sendex/sxsubscribeajaxresponse.class.php';
+        unset($_SERVER['HTTP_X_REQUESTED_WITH'], $_REQUEST['ajax'], $_REQUEST['sendex_ajax']);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['HTTP_X_REQUESTED_WITH'], $_REQUEST['ajax'], $_REQUEST['sendex_ajax']);
+    }
+
+    public function testDetectsXmlHttpRequestHeader()
+    {
+        $_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+
+        $this->assertTrue(sxSubscribeAjaxResponse::isRequest());
+    }
+
+    public function testDetectsAjaxRequestParam()
+    {
+        $_REQUEST['ajax'] = '1';
+
+        $this->assertTrue(sxSubscribeAjaxResponse::isRequest());
+    }
+
+    public function testPayloadMapsSuccessAndMessage()
+    {
+        $payload = sxSubscribeAjaxResponse::payload(
+            array('message' => 'OK', 'error' => 0),
+            '<div>widget</div>'
+        );
+
+        $this->assertTrue($payload['success']);
+        $this->assertSame('OK', $payload['message']);
+        $this->assertSame('<div>widget</div>', $payload['html']);
+    }
+
+    public function testPayloadMarksValidationErrorsAsFailure()
+    {
+        $payload = sxSubscribeAjaxResponse::payload(
+            array('message' => 'Bad email', 'error' => 1),
+            '<div>widget</div>'
+        );
+
+        $this->assertFalse($payload['success']);
+        $this->assertSame('Bad email', $payload['message']);
+    }
+
+    public function testParseEnabledRecognizesOffValues()
+    {
+        $this->assertFalse(sxSubscribeAjaxResponse::parseEnabled('0'));
+        $this->assertTrue(sxSubscribeAjaxResponse::parseEnabled('1'));
+    }
+}


### PR DESCRIPTION
Подписка и отписка на фронте без полного reload: дефолтные чанки + `sendex.js`.

## Что сделано
- `sxSubscribeAjaxResponse` — detect AJAX, JSON `{success, message, html}`
- Snippet: JSON-ответ на XHR/`ajax=1`, регистрация `assets/components/sendex/js/web/sendex.js` (`loadJs`, default `1`)
- Чанки: `data-sendex-widget`, `data-sendex-form`, `data-sendex-message`
- `sendex.js`: fetch + swap widget / message
- README: пример разметки
- тесты: `SubscribeAjaxResponseTest`, `FrontendAjaxContractTest`
- миграция: не нужна

## Review
- Findings: нет

## Проверка
- `composer test` — exit 0 (197 tests, +8 новых)
- phpcs — exit 0
- `node --check assets/components/sendex/js/web/sendex.js` — exit 0
- waive: ручной прогон в браузере (нет MODX в CI)

Fixes #42