### PR TITLE
fix(build): Register assets path for MODX 3 namespace compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,11 @@ Root `composer.json` remains for PHPUnit/phpcs only.
 | `tplActivate` | `tpl.Sendex.activate` | Confirmation email chunk |
 | `confirmEmail` | system `sendex_confirm_email` (default `1`) | Guest flow: `1` = confirm link by email; `0` = subscribe immediately |
 | `loadJs` | `1` | Register `assets/components/sendex/js/web/sendex.js` for AJAX forms |
+| `widgetKey` | *(empty)* | Optional key when several `[[!Sendex]]` widgets share one page; must match hidden `sendex_widget_key` in the form |
 
 When `confirmEmail` is off, guest addresses are saved without a confirmation message. Typos and spam signups are harder to catch; use only when you accept that tradeoff.
+
+Several widgets on one page need distinct `&widgetKey=` values (for example `instant` vs `confirm`) so AJAX POST is handled only by the matching snippet instance. Email confirm/unsubscribe links omit `sendex_widget_key`; keep one snippet on the landing page without `widgetKey` to handle those URLs.
 
 ### AJAX subscribe / unsubscribe (#42)
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,16 @@ Sendex runs email newsletters in MODX Revolution: subscribers, a send queue, and
 
 ## MODX 3 compatibility
 
-Sendex keeps global `sx*` xPDO models (not `MODX\Revolution\sx*`). Verified on MODX **3.2.0-pl** (2026-07-25): transport install, namespace `assets_path`, mgr menu (`namespace` + `action`), Phinx migrations, `sx*` class map.
+Sendex keeps global `sx*` xPDO models (not `MODX\Revolution\sx*`). Verified on MODX **3.2.0-pl** (2026-07-25): transport install, namespace `assets_path`, mgr menu (`namespace` + `action`), Phinx migrations, `sx*` class map, connector bootstrap, mgr processors, ExtJS UI.
 
 Build/package notes:
 
 - `_build/build.transport.php` registers `PKG_ASSETS_PATH` and skips `build.model.php` on MODX 3 (xPDO 3 schema generator would rewrite maps to `sendex\sx*`).
 - Mgr menu uses legacy `modAction` on MODX 2 and `modMenu.action` + `namespace` on MODX 3.
+- `core/components/sendex/bootstrap.php` — shared init for connector, mgr, and cron (autoload + processor base aliases).
+- `sxModxCompat` / `sxUserProfile` — MODX 2/3 boundary for mail, parser, registry, and user/profile placeholders.
 
-Not covered yet (see [#74](https://github.com/modx-pro/Sendex/issues/74)): processors/connector autoload, user/profile/mailer API boundary, new non-ExtJS admin UI, CI matrix MODX 2.8 + 3.x.
+Not covered yet (see [#74](https://github.com/modx-pro/Sendex/issues/74)): new non-ExtJS admin UI, CI matrix MODX 2.8 + 3.x.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,18 @@
 
 Sendex runs email newsletters in MODX Revolution: subscribers, a send queue, and a front-end form.
 
-**Requirements:** PHP 7.4–8.4, MODX Revolution 2.x.
+**Requirements:** PHP 7.4–8.4, MODX Revolution 2.8+ or 3.x (ExtJS manager).
+
+## MODX 3 compatibility
+
+Sendex keeps global `sx*` xPDO models (not `MODX\Revolution\sx*`). Verified on MODX **3.2.0-pl** (2026-07-25): transport install, namespace `assets_path`, mgr menu (`namespace` + `action`), Phinx migrations, `sx*` class map.
+
+Build/package notes:
+
+- `_build/build.transport.php` registers `PKG_ASSETS_PATH` and skips `build.model.php` on MODX 3 (xPDO 3 schema generator would rewrite maps to `sendex\sx*`).
+- Mgr menu uses legacy `modAction` on MODX 2 and `modMenu.action` + `namespace` on MODX 3.
+
+Not covered yet (see [#74](https://github.com/modx-pro/Sendex/issues/74)): processors/connector autoload, user/profile/mailer API boundary, new non-ExtJS admin UI, CI matrix MODX 2.8 + 3.x.
 
 ## Features
 

--- a/_build/build.config.php
+++ b/_build/build.config.php
@@ -8,6 +8,7 @@ define('PKG_VERSION', '1.2.0');
 define('PKG_RELEASE', 'pl');
 define('PKG_AUTO_INSTALL', true);
 define('PKG_NAMESPACE_PATH', '{core_path}components/' . PKG_NAME_LOWER . '/');
+define('PKG_ASSETS_PATH', '{assets_path}components/' . PKG_NAME_LOWER . '/');
 //define('PKG_NAMESPACE_PATH', '{base_path}'.PKG_NAME.'/core/components/'.PKG_NAME_LOWER.'/');
 
 /* define paths */

--- a/_build/build.model.php
+++ b/_build/build.model.php
@@ -25,6 +25,16 @@ $modx->initialize('mgr');
 $modx->getService('error', 'error.modError');
 $modx->setLogLevel(modX::LOG_LEVEL_INFO);
 $modx->setLogTarget(XPDO_CLI_MODE ? 'ECHO' : 'HTML');
+
+if (!sendexShouldRegenerateModel($modx)) {
+    sendexRemoveModx3ModelArtifacts($sources['model'] . PKG_NAME_LOWER);
+    $modx->log(
+        modX::LOG_LEVEL_WARN,
+        'Model regeneration skipped on MODX 3 (xPDO generator rewrites sx* maps to sendex\\sx*).'
+    );
+    exit(0);
+}
+
 $modx->loadClass('transport.modPackageBuilder', '', false, true);
 
 /** @var xPDOManager $manager */
@@ -37,5 +47,6 @@ rrmdir($sources['model'] . PKG_NAME_LOWER . '/mysql');
 
 // Generate a new one
 $generator->parseSchema($sources['xml'], $sources['model']);
+sendexNormalizeGeneratedPhpFiles($sources['model'] . PKG_NAME_LOWER);
 
 $modx->log(modX::LOG_LEVEL_INFO, 'Model generated.');

--- a/_build/build.model.php
+++ b/_build/build.model.php
@@ -26,8 +26,7 @@ $modx->getService('error', 'error.modError');
 $modx->setLogLevel(modX::LOG_LEVEL_INFO);
 $modx->setLogTarget(XPDO_CLI_MODE ? 'ECHO' : 'HTML');
 
-if (!sendexShouldRegenerateModel($modx)) {
-    sendexRemoveModx3ModelArtifacts($sources['model'] . PKG_NAME_LOWER);
+if (!sendexPrepareModelForBuild($modx, $sources['model'] . PKG_NAME_LOWER)) {
     $modx->log(
         modX::LOG_LEVEL_WARN,
         'Model regeneration skipped on MODX 3 (xPDO generator rewrites sx* maps to sendex\\sx*).'

--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -7,9 +7,16 @@ $tstart = $mtime;
 set_time_limit(0);
 
 require_once 'build.config.php';
-// Refresh model
+// Refresh model (MODX 2 only — MODX 3 generator rewrites sx* maps to sendex\\sx*)
 if (file_exists('build.model.php')) {
-    require_once 'build.model.php';
+    require_once MODX_CORE_PATH . 'model/modx/modx.class.php';
+    require_once __DIR__ . '/includes/functions.php';
+    $sendexBuildModx = new modX();
+    $sendexBuildModx->initialize('mgr');
+    if (sendexShouldRegenerateModel($sendexBuildModx)) {
+        require_once 'build.model.php';
+    }
+    unset($sendexBuildModx);
 }
 
 /* define sources */
@@ -41,10 +48,11 @@ $modx->setLogLevel(modX::LOG_LEVEL_INFO);
 $modx->setLogTarget('ECHO');
 $modx->getService('error', 'error.modError');
 $modx->loadClass('transport.modPackageBuilder', '', false, true);
+sendexEnsureBuildClassAliases($modx);
 
 $builder = new modPackageBuilder($modx);
 $builder->createPackage(PKG_NAME_LOWER, PKG_VERSION, PKG_RELEASE);
-$builder->registerNamespace(PKG_NAME_LOWER, false, true, PKG_NAMESPACE_PATH);
+$builder->registerNamespace(PKG_NAME_LOWER, false, true, PKG_NAMESPACE_PATH, PKG_ASSETS_PATH);
 
 $modx->log(modX::LOG_LEVEL_INFO, 'Created Transport Package and Namespace.');
 

--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -13,12 +13,9 @@ if (file_exists('build.model.php')) {
     require_once __DIR__ . '/includes/functions.php';
     $sendexBuildModx = new modX();
     $sendexBuildModx->initialize('mgr');
-    if (sendexShouldRegenerateModel($sendexBuildModx)) {
+    $sendexModelDir = dirname(dirname(__FILE__)) . '/core/components/' . PKG_NAME_LOWER . '/model/' . PKG_NAME_LOWER;
+    if (sendexPrepareModelForBuild($sendexBuildModx, $sendexModelDir)) {
         require_once 'build.model.php';
-    } else {
-        $sendexModelDir = dirname(dirname(__FILE__)) . '/core/components/' . PKG_NAME_LOWER . '/model/' . PKG_NAME_LOWER;
-        sendexRemoveModx3ModelArtifacts($sendexModelDir);
-        sendexNormalizeGeneratedPhpFiles($sendexModelDir);
     }
     unset($sendexBuildModx);
 }

--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -15,6 +15,10 @@ if (file_exists('build.model.php')) {
     $sendexBuildModx->initialize('mgr');
     if (sendexShouldRegenerateModel($sendexBuildModx)) {
         require_once 'build.model.php';
+    } else {
+        $sendexModelDir = dirname(dirname(__FILE__)) . '/core/components/' . PKG_NAME_LOWER . '/model/' . PKG_NAME_LOWER;
+        sendexRemoveModx3ModelArtifacts($sendexModelDir);
+        sendexNormalizeGeneratedPhpFiles($sendexModelDir);
     }
     unset($sendexBuildModx);
 }

--- a/_build/data/transport.menu.php
+++ b/_build/data/transport.menu.php
@@ -9,38 +9,45 @@ $tmp = array(
     ),
 );
 
+$usesLegacyModAction = class_exists('modAction');
+
 $i = 0;
 foreach ($tmp as $k => $v) {
     $action = null;
+    $menuFields = array(
+        'text'      => $k,
+        'parent'    => 'components',
+        'icon'      => 'images/icons/plugin.gif',
+        'menuindex' => $i,
+        'params'    => '',
+        'handler'   => '',
+    );
+
     if (!empty($v['action'])) {
-        /* @var modAction $action */
-        $action = $modx->newObject('modAction');
-        $action->fromArray(array_merge(array(
-            'namespace'   => PKG_NAME_LOWER,
-            'id'          => 0,
-            'parent'      => 0,
-            'haslayout'   => 1,
-            'lang_topics' => PKG_NAME_LOWER . ':default',
-            'assets'      => '',
-        ), $v['action']), '', true, true);
+        if ($usesLegacyModAction) {
+            /* @var modAction $action */
+            $action = $modx->newObject('modAction');
+            $action->fromArray(array_merge(array(
+                'namespace'   => PKG_NAME_LOWER,
+                'id'          => 0,
+                'parent'      => 0,
+                'haslayout'   => 1,
+                'lang_topics' => PKG_NAME_LOWER . ':default',
+                'assets'      => '',
+            ), $v['action']), '', true, true);
+        } else {
+            $controller = !empty($v['action']['controller']) ? $v['action']['controller'] : 'index';
+            $menuFields['action'] = $controller;
+            $menuFields['namespace'] = PKG_NAME_LOWER;
+        }
         unset($v['action']);
     }
 
     /* @var modMenu $menu */
     $menu = $modx->newObject('modMenu');
-    $menu->fromArray(array_merge(
-        array(
-            'text'      => $k,
-            'parent'    => 'components',
-            'icon'      => 'images/icons/plugin.gif',
-            'menuindex' => $i,
-            'params'    => '',
-            'handler'   => '',
-        ),
-        $v
-    ), '', true, true);
+    $menu->fromArray(array_merge($menuFields, $v), '', true, true);
 
-    if (!empty($action) && $action instanceof modAction) {
+    if ($usesLegacyModAction && !empty($action)) {
         $menu->addOne($action);
     }
 

--- a/_build/data/transport.menu.php
+++ b/_build/data/transport.menu.php
@@ -37,6 +37,9 @@ foreach ($tmp as $k => $v) {
             ), $v['action']), '', true, true);
         } else {
             $controller = !empty($v['action']['controller']) ? $v['action']['controller'] : 'index';
+            if ($controller === 'index') {
+                $controller = 'home';
+            }
             $menuFields['action'] = $controller;
             $menuFields['namespace'] = PKG_NAME_LOWER;
         }

--- a/_build/data/transport.menu.php
+++ b/_build/data/transport.menu.php
@@ -9,7 +9,7 @@ $tmp = array(
     ),
 );
 
-$usesLegacyModAction = class_exists('modAction');
+$usesLegacyModAction = sendexUsesLegacyModAction($modx);
 
 $i = 0;
 foreach ($tmp as $k => $v) {
@@ -37,9 +37,6 @@ foreach ($tmp as $k => $v) {
             ), $v['action']), '', true, true);
         } else {
             $controller = !empty($v['action']['controller']) ? $v['action']['controller'] : 'index';
-            if ($controller === 'index') {
-                $controller = 'home';
-            }
             $menuFields['action'] = $controller;
             $menuFields['namespace'] = PKG_NAME_LOWER;
         }

--- a/_build/includes/functions.php
+++ b/_build/includes/functions.php
@@ -30,6 +30,101 @@ function sendexShouldRegenerateModel($modx)
 }
 
 /**
+ * Remove MODX 3 xPDO generator artifacts (PascalCase sx*.php with wrong namespaces).
+ *
+ * @param string $packageModelDir e.g. core/components/sendex/model/sendex
+ */
+function sendexRemoveModx3ModelArtifacts($packageModelDir)
+{
+    $artifacts = array(
+        'sxNewsletter.php',
+        'sxQueue.php',
+        'sxSubscriber.php',
+    );
+
+    foreach ($artifacts as $name) {
+        foreach (array($packageModelDir . '/mysql/' . $name, $packageModelDir . '/' . $name) as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+    }
+}
+
+/**
+ * Normalize xPDO-generated PHP: trim lines, PSR-12 brace spacing, single EOF newline.
+ *
+ * @param string $directory
+ */
+function sendexNormalizeGeneratedPhpFiles($directory)
+{
+    if (!is_dir($directory)) {
+        return;
+    }
+
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($directory, RecursiveDirectoryIterator::SKIP_DOTS)
+    );
+
+    foreach ($iterator as $file) {
+        if (!$file->isFile() || !preg_match('/\.php$/i', $file->getFilename())) {
+            continue;
+        }
+
+        $path = $file->getPathname();
+        $lines = file($path, FILE_IGNORE_NEW_LINES);
+        if ($lines === false) {
+            continue;
+        }
+
+        $trimmed = array_map(
+            static function ($line) {
+                return rtrim($line, " \t");
+            },
+            $lines
+        );
+
+        $fixed = array();
+        $count = count($trimmed);
+        for ($i = 0; $i < $count; $i++) {
+            $fixed[] = $trimmed[$i];
+            if (preg_match('/^\{\s*$/', $trimmed[$i])) {
+                while ($i + 1 < $count && $trimmed[$i + 1] === '') {
+                    $i++;
+                }
+            }
+        }
+
+        $normalized = rtrim(implode("\n", $fixed), "\r\n") . "\n";
+        if ($normalized !== file_get_contents($path)) {
+            file_put_contents($path, $normalized);
+        }
+    }
+}
+
+/**
+ * Strip trailing whitespace from generated PHP files (xPDO generator leaves spaces after =>).
+ *
+ * @param string $directory
+ * @deprecated Use sendexNormalizeGeneratedPhpFiles()
+ */
+function sendexTrimTrailingWhitespaceInPhpFiles($directory)
+{
+    sendexNormalizeGeneratedPhpFiles($directory);
+}
+
+/**
+ * Ensure every PHP file under model ends with exactly one newline (PSR-12).
+ *
+ * @param string $directory
+ * @deprecated Use sendexNormalizeGeneratedPhpFiles()
+ */
+function sendexNormalizePhpFileEndings($directory)
+{
+    sendexNormalizeGeneratedPhpFiles($directory);
+}
+
+/**
  * @param $filename
  *
  * @return string

--- a/_build/includes/functions.php
+++ b/_build/includes/functions.php
@@ -1,6 +1,35 @@
 <?php
 
 /**
+ * Legacy alias for transport build scripts when MODX 3 PSR-4 classes are loaded
+ * but global aliases (modPackageBuilder, etc.) are not registered yet.
+ *
+ * @param modX $modx
+ */
+function sendexEnsureBuildClassAliases($modx)
+{
+    if (!class_exists('modPackageBuilder')) {
+        $modx->loadClass('modPackageBuilder', 'MODX\\Revolution\\Transport\\', false, true);
+        if (class_exists('MODX\\Revolution\\Transport\\modPackageBuilder')) {
+            class_alias('MODX\\Revolution\\Transport\\modPackageBuilder', 'modPackageBuilder');
+        }
+    }
+}
+
+/**
+ * MODX 3 xPDO schema generator emits sendex\\sx* class names; Sendex keeps global sx* maps.
+ *
+ * @param modX $modx
+ * @return bool
+ */
+function sendexShouldRegenerateModel($modx)
+{
+    $version = $modx->getVersionData();
+
+    return (int) ($version['version'] ?? 2) < 3;
+}
+
+/**
  * @param $filename
  *
  * @return string

--- a/_build/includes/functions.php
+++ b/_build/includes/functions.php
@@ -30,20 +30,47 @@ function sendexShouldRegenerateModel($modx)
 }
 
 /**
+ * MODX 2 uses modAction + modMenu composite; MODX 3 uses namespace + action on modMenu.
+ *
+ * @param modX|null $modx
+ * @return bool
+ */
+function sendexUsesLegacyModAction($modx = null)
+{
+    return class_exists('modAction');
+}
+
+/**
+ * MODX 3: remove generator artifacts and skip regen. MODX 2: allow regen.
+ *
+ * @param modX   $modx
+ * @param string $packageModelDir e.g. core/components/sendex/model/sendex
+ * @return bool true when caller should run xPDO schema regeneration
+ */
+function sendexPrepareModelForBuild($modx, $packageModelDir)
+{
+    if (sendexShouldRegenerateModel($modx)) {
+        return true;
+    }
+
+    sendexRemoveModx3ModelArtifacts($packageModelDir);
+
+    return false;
+}
+
+/**
  * Remove MODX 3 xPDO generator artifacts (PascalCase sx*.php with wrong namespaces).
  *
  * @param string $packageModelDir e.g. core/components/sendex/model/sendex
  */
 function sendexRemoveModx3ModelArtifacts($packageModelDir)
 {
-    $artifacts = array(
-        'sxNewsletter.php',
-        'sxQueue.php',
-        'sxSubscriber.php',
+    $patterns = array(
+        $packageModelDir . '/mysql/sx[A-Z]*.php',
+        $packageModelDir . '/sx[A-Z]*.php',
     );
-
-    foreach ($artifacts as $name) {
-        foreach (array($packageModelDir . '/mysql/' . $name, $packageModelDir . '/' . $name) as $path) {
+    foreach ($patterns as $pattern) {
+        foreach (glob($pattern) ?: array() as $path) {
             if (is_file($path)) {
                 unlink($path);
             }
@@ -100,28 +127,6 @@ function sendexNormalizeGeneratedPhpFiles($directory)
             file_put_contents($path, $normalized);
         }
     }
-}
-
-/**
- * Strip trailing whitespace from generated PHP files (xPDO generator leaves spaces after =>).
- *
- * @param string $directory
- * @deprecated Use sendexNormalizeGeneratedPhpFiles()
- */
-function sendexTrimTrailingWhitespaceInPhpFiles($directory)
-{
-    sendexNormalizeGeneratedPhpFiles($directory);
-}
-
-/**
- * Ensure every PHP file under model ends with exactly one newline (PSR-12).
- *
- * @param string $directory
- * @deprecated Use sendexNormalizeGeneratedPhpFiles()
- */
-function sendexNormalizePhpFileEndings($directory)
-{
-    sendexNormalizeGeneratedPhpFiles($directory);
 }
 
 /**

--- a/assets/components/sendex/connector.php
+++ b/assets/components/sendex/connector.php
@@ -5,13 +5,11 @@ require_once MODX_CORE_PATH . 'config/' . MODX_CONFIG_KEY . '.inc.php';
 require_once MODX_CONNECTORS_PATH . 'index.php';
 
 $corePath = $modx->getOption('sendex_core_path', null, $modx->getOption('core_path') . 'components/sendex/');
-require_once $corePath . 'model/sendex/sendex.class.php';
-$modx->sendex = new Sendex($modx);
-
-$modx->lexicon->load('sendex:default');
+require_once $corePath . 'bootstrap.php';
+$Sendex = sendexBootstrap($modx);
 
 /* handle request */
-$path = $modx->getOption('processorsPath', $modx->sendex->config, $corePath . 'processors/');
+$path = $modx->getOption('processorsPath', $Sendex->config, $corePath . 'processors/');
 $modx->request->handleRequest(array(
     'processors_path' => $path,
     'location'        => '',

--- a/assets/components/sendex/css/mgr/main.css
+++ b/assets/components/sendex/css/mgr/main.css
@@ -26,9 +26,23 @@ ul.sendex-row-actions .btn > .icon.icon-paper-plane-o {
 .blue {color: cadetblue;}
 .yellow {color: goldenrod;}
 
-a.x-menu-item .x-menu-item-text, a.x-menu-item .x-menu-item-text .fa {cursor: pointer;}
-a.x-menu-item .x-menu-item-text .fa {line-height:16px; top:auto;}
-.x-menu-list .fa {min-width: 1em; text-align:center;}
+a.x-menu-item .x-menu-item-text, a.x-menu-item .x-menu-item-text .fa,
+a.x-menu-item .x-menu-item-text .icon {cursor: pointer;}
+a.x-menu-item .x-menu-item-text .fa,
+a.x-menu-item .x-menu-item-text .icon {
+    line-height:16px;
+    top:auto;
+    font-family: "Font Awesome 5 Free";
+    font-weight: 900;
+}
+a.x-menu-item .x-menu-item-text .icon.icon-check-circle-o,
+a.x-menu-item .x-menu-item-text .icon.icon-trash-o,
+a.x-menu-item .x-menu-item-text .icon.icon-send-o,
+a.x-menu-item .x-menu-item-text .icon.icon-paper-plane-o {
+    font-weight: 400;
+}
+.x-menu-list .fa,
+.x-menu-list .icon {min-width: 1em; text-align:center;}
 .fa.actions-menu {width: 40px;}
 .fa.actions-menu:after {content: " \f107";}
 

--- a/assets/components/sendex/css/mgr/main.css
+++ b/assets/components/sendex/css/mgr/main.css
@@ -8,6 +8,18 @@
 ul.sendex-row-actions {margin:0; padding: 0; list-style: none;}
 ul.sendex-row-actions li {float:left;}
 ul.sendex-row-actions .btn {padding: 5px; margin-right:2px; min-width:26px; font-size: inherit;}
+ul.sendex-row-actions .btn > .icon,
+ul.sendex-row-actions .btn > .fa {
+    font-family: "Font Awesome 5 Free";
+    font-weight: 900;
+    line-height: 16px;
+}
+ul.sendex-row-actions .btn > .icon.icon-check-circle-o,
+ul.sendex-row-actions .btn > .icon.icon-trash-o,
+ul.sendex-row-actions .btn > .icon.icon-send-o,
+ul.sendex-row-actions .btn > .icon.icon-paper-plane-o {
+    font-weight: 400;
+}
 
 .red {color: darkred;}
 .green {color: darkgreen;}

--- a/assets/components/sendex/js/mgr/misc/utils.js
+++ b/assets/components/sendex/js/mgr/misc/utils.js
@@ -4,13 +4,13 @@ Sendex.utils.renderActions = function(value, props, row) {
         if (!row.data.actions.hasOwnProperty(i)) {continue;}
         var a = row.data.actions[i];
         if (a['button']) {
-            var cls = typeof(a['class']) == 'object' && a['class']['button']
+            var btnCls = typeof(a['class']) == 'object' && a['class']['button']
                 ? a['class']['button']
                 : '';
-            cls += ' ' + (MODx.modx23 ? 'icon icon-' : 'fa fa-') + a['icon'];
+            var iconCls = (MODx.modx23 ? 'icon icon-' : 'fa fa-') + a['icon'];
             res.push(
                 '<li>\
-                    <button class="btn btn-default '+ cls +'" type="'+a['type']+'" title="'+_('sendex_action_'+a['type'])+'"></button>\
+                    <button class="btn btn-default '+ btnCls +'" type="'+a['type']+'" title="'+_('sendex_action_'+a['type'])+'"><i class="'+iconCls+'"></i></button>\
                 </li>'
             );
         }

--- a/assets/components/sendex/js/mgr/widgets/home.panel.js
+++ b/assets/components/sendex/js/mgr/widgets/home.panel.js
@@ -26,7 +26,7 @@ Sendex.panel.Home = function(config) {
                     ,bodyCssClass: 'panel-desc'
                 },{
                     xtype: 'sendex-grid-newsletters'
-                    ,cls: 'main-wrapper'
+                    ,cls: MODx.modx23 ? '' : 'main-wrapper'
                     ,preventRender: true
                 }]
             },{
@@ -38,7 +38,7 @@ Sendex.panel.Home = function(config) {
                     ,bodyCssClass: 'panel-desc'
                 },{
                     xtype: 'sendex-grid-queues'
-                    ,cls: 'main-wrapper'
+                    ,cls: MODx.modx23 ? '' : 'main-wrapper'
                     ,preventRender: true
                 }]
             }]

--- a/assets/components/sendex/js/mgr/widgets/newsletters.grid.js
+++ b/assets/components/sendex/js/mgr/widgets/newsletters.grid.js
@@ -408,7 +408,7 @@ Sendex.grid.NewsletterSubscribers = function(config) {
         },{
             xtype: 'button',
             hidden: Sendex.config.hideExportButton,
-            text: '<i class="icon-arrow-circle-up icon"></i> ' + _('sendex_btn_subscrubers_export'),
+            text: '<i class="' + (MODx.modx23 ? 'icon icon-arrow-circle-up' : 'fa fa-arrow-circle-up') + '"></i> ' + _('sendex_btn_subscrubers_export'),
             id: 'sendex-export-form',
             cls: 'x-btn-restore-all',
             listeners: {

--- a/core/components/sendex/bootstrap.php
+++ b/core/components/sendex/bootstrap.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * Sendex bootstrap: shared init for connector, mgr, and cron (#74).
+ */
+
+if (!function_exists('sendexCorePath')) {
+    /**
+     * @param modX $modx
+     * @return string
+     */
+    function sendexCorePath($modx)
+    {
+        return $modx->getOption(
+            'sendex_core_path',
+            null,
+            $modx->getOption('core_path') . 'components/sendex/'
+        );
+    }
+}
+
+if (!function_exists('sendexRegisterAutoload')) {
+    /**
+     * @param string $corePath
+     * @return void
+     */
+    function sendexRegisterAutoload($corePath)
+    {
+        static $registered = false;
+        if ($registered) {
+            return;
+        }
+        $registered = true;
+
+        $modelDir = rtrim($corePath, '/') . '/model/sendex/';
+        $processorsDir = rtrim($corePath, '/') . '/processors/mgr/';
+
+        spl_autoload_register(static function ($class) use ($modelDir, $processorsDir) {
+            if ($class === 'sxSendexProcessor') {
+                $path = $processorsDir . 'sendexprocessor.class.php';
+                if (is_file($path)) {
+                    require_once $path;
+                }
+
+                return;
+            }
+
+            if ($class === 'sxProcessorInput') {
+                $path = $modelDir . 'sxprocessorinput.class.php';
+                if (is_file($path)) {
+                    require_once $path;
+                }
+
+                return;
+            }
+
+            if (strpos($class, 'sx') !== 0) {
+                return;
+            }
+
+            $path = $modelDir . strtolower($class) . '.class.php';
+            if (is_file($path)) {
+                require_once $path;
+            }
+        });
+    }
+}
+
+if (!function_exists('sendexEnsureProcessorBase')) {
+    /**
+     * Ensure legacy processor base classes resolve on MODX 3.
+     *
+     * @return void
+     */
+    function sendexEnsureProcessorBase()
+    {
+        if (class_exists('modProcessor', false)) {
+            return;
+        }
+
+        $map = array(
+            'modProcessor'              => 'MODX\\Revolution\\Processors\\Processor',
+            'modObjectProcessor'        => 'MODX\\Revolution\\Processors\\Model\\ModelProcessor',
+            'modObjectGetProcessor'     => 'MODX\\Revolution\\Processors\\Model\\GetProcessor',
+            'modObjectGetListProcessor' => 'MODX\\Revolution\\Processors\\Model\\GetListProcessor',
+            'modObjectCreateProcessor'  => 'MODX\\Revolution\\Processors\\Model\\CreateProcessor',
+            'modObjectUpdateProcessor'  => 'MODX\\Revolution\\Processors\\Model\\UpdateProcessor',
+        );
+
+        foreach ($map as $legacy => $namespaced) {
+            if (!class_exists($legacy, false) && class_exists($namespaced)) {
+                class_alias($namespaced, $legacy);
+            }
+        }
+    }
+}
+
+if (!function_exists('sendexBootstrap')) {
+    /**
+     * @param modX $modx
+     * @param array $config
+     * @return Sendex
+     */
+    function sendexBootstrap($modx, array $config = array())
+    {
+        $corePath = sendexCorePath($modx);
+        sendexRegisterAutoload($corePath);
+        sendexEnsureProcessorBase();
+
+        require_once $corePath . 'model/sendex/sendex.class.php';
+
+        if (!isset($modx->sendex) || !($modx->sendex instanceof Sendex)) {
+            $modx->sendex = new Sendex($modx, $config);
+        }
+
+        $modx->lexicon->load('sendex:default');
+
+        return $modx->sendex;
+    }
+}

--- a/core/components/sendex/controllers/index.class.php
+++ b/core/components/sendex/controllers/index.class.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * MODX 3 manager entry (SendexIndexManagerController naming convention).
+ * MODX 3 resolves action directly; reuse home controller UI.
+ */
+
+require_once dirname(__FILE__) . '/home.class.php';
+
+class SendexIndexManagerController extends SendexHomeManagerController
+{
+}

--- a/core/components/sendex/cron/send.php
+++ b/core/components/sendex/cron/send.php
@@ -3,9 +3,10 @@
 require_once dirname(__FILE__, 5) . '/config.core.php';
 require_once MODX_CORE_PATH . 'config/' . MODX_CONFIG_KEY . '.inc.php';
 require_once MODX_CONNECTORS_PATH . 'index.php';
-require_once MODX_CORE_PATH . 'components/sendex/model/sendex/sxqueuesender.class.php';
 
-$modx->addPackage('sendex', MODX_CORE_PATH . 'components/sendex/model/');
+$corePath = $modx->getOption('sendex_core_path', null, $modx->getOption('core_path') . 'components/sendex/');
+require_once $corePath . 'bootstrap.php';
+sendexBootstrap($modx);
 
 sxQueueSender::flush($modx, array(
     'limit'     => $modx->getOption('sendex_queue_limit', null, 100, true),

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [#40] MODX 3 package install: `registerNamespace` sets `assets_path`; build script aliases `modPackageBuilder`, skips model regen on MODX 3 (preserves global `sx*` maps); mgr menu without `modAction`; Phinx migration property no longer conflicts with `AbstractMigration::$tables` on PHP 8.4.
 - [#74] MODX 3 mgr: `SendexIndexManagerController` aliases menu action `index` (no duplicate menu remap).
+- [#74] MODX 3 bootstrap: `bootstrap.php` for connector/mgr/cron; processor autoload + `modProcessor` aliases; `sxModxCompat` (mail/parser/registry) and `sxUserProfile` (user/profile placeholders); ExtJS mgr icon/menu polish on MODX 3.
 - [#42] Multi-widget AJAX: authenticated subscribe no longer breaks request scoping (`$id` shadowing); confirm link keeps `newsletter_id`; unsubscribe widget keeps `widget_key`; email links without `sendex_widget_key` route to the default snippet instance (empty `widgetKey`).
 - [#60] Mgr grids: empty checkbox selection no longer sends `ids:''`; alert via `Sendex.utils.requireSelectedIds`, row action falls back to `menu.record`.
 - [#59] Deleting a newsletter removes its `sxQueue` rows via xPDO composite `Queues`; upgrade migration purges queue rows left orphaned by earlier deletes.

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CSV cells that look like spreadsheet formulas are prefixed so Excel/LibreOffice do not execute them.
 
 ### Added
-- [#42] Frontend AJAX subscribe/unsubscribe: JSON `{success, message, html}` from snippet, default chunks + `assets/components/sendex/js/web/sendex.js`.
+- [#42] Frontend AJAX subscribe/unsubscribe: JSON `{success, message, html}` from snippet, default chunks + `assets/components/sendex/js/web/sendex.js`. Multi-widget pages scope POST via `newsletter_id` and optional `widgetKey`.
 - [#38] Guest subscribe can skip email confirmation: snippet `&confirmEmail=`0`` or system setting `sendex_confirm_email`; domain helper `subscribeGuest()` keeps one subscribe path.
 - [#29] Mgr newsletter «Send to subscribers»: one action runs `addQueues` + `sxQueueSender::flush` for the newsletter (`mgr/newsletter/send`); button in grid row actions and update window.
 - [#46] Search subscribers and queue by email or username.

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [#40] MODX 3 package install: `registerNamespace` sets `assets_path`; build script aliases `modPackageBuilder`, skips model regen on MODX 3 (preserves global `sx*` maps); mgr menu without `modAction`; Phinx migration property no longer conflicts with `AbstractMigration::$tables` on PHP 8.4.
+- [#74] MODX 3 mgr: `SendexIndexManagerController` in `controllers/`; menu action `home` on MODX 3 (direct action routing).
 - [#60] Mgr grids: empty checkbox selection no longer sends `ids:''`; alert via `Sendex.utils.requireSelectedIds`, row action falls back to `menu.record`.
 - [#59] Deleting a newsletter removes its `sxQueue` rows via xPDO composite `Queues`; upgrade migration purges queue rows left orphaned by earlier deletes.
 - [#57] `addQueues` returns an error when 0 queue rows were created (all subscribers skipped); mgr `queue/add` reports the created count on success.

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Phinx migrations: `core/components/sendex/phinx.php`, `migrations/`, install/upgrade resolver; metadata table `{prefix}sendex_migrations`.
 
 ### Fixed
+- [#40] MODX 3 package install: `registerNamespace` sets `assets_path`; build script aliases `modPackageBuilder`, skips model regen on MODX 3 (preserves global `sx*` maps); mgr menu without `modAction`; Phinx migration property no longer conflicts with `AbstractMigration::$tables` on PHP 8.4.
 - [#60] Mgr grids: empty checkbox selection no longer sends `ids:''`; alert via `Sendex.utils.requireSelectedIds`, row action falls back to `menu.record`.
 - [#59] Deleting a newsletter removes its `sxQueue` rows via xPDO composite `Queues`; upgrade migration purges queue rows left orphaned by earlier deletes.
 - [#57] `addQueues` returns an error when 0 queue rows were created (all subscribers skipped); mgr `queue/add` reports the created count on success.

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -23,7 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [#40] MODX 3 package install: `registerNamespace` sets `assets_path`; build script aliases `modPackageBuilder`, skips model regen on MODX 3 (preserves global `sx*` maps); mgr menu without `modAction`; Phinx migration property no longer conflicts with `AbstractMigration::$tables` on PHP 8.4.
-- [#74] MODX 3 mgr: `SendexIndexManagerController` in `controllers/`; menu action `home` on MODX 3 (direct action routing).
+- [#74] MODX 3 mgr: `SendexIndexManagerController` aliases menu action `index` (no duplicate menu remap).
+- [#42] Multi-widget AJAX: authenticated subscribe no longer breaks request scoping (`$id` shadowing); confirm link keeps `newsletter_id`; unsubscribe widget keeps `widget_key`; email links without `sendex_widget_key` route to the default snippet instance (empty `widgetKey`).
 - [#60] Mgr grids: empty checkbox selection no longer sends `ids:''`; alert via `Sendex.utils.requireSelectedIds`, row action falls back to `menu.record`.
 - [#59] Deleting a newsletter removes its `sxQueue` rows via xPDO composite `Queues`; upgrade migration purges queue rows left orphaned by earlier deletes.
 - [#57] `addQueues` returns an error when 0 queue rows were created (all subscribers skipped); mgr `queue/add` reports the created count on success.
@@ -38,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#47] Adding a user group to a newsletter subscribes only active and unblocked users.
 - `add_group`: cast `group_id` and `newsletter_id` to int; require user Profile (`innerJoin`).
 - `confirmEmail` returns the `subscribe()` result when confirming a hash for another newsletter.
+- Mgr `newsletter/update` no longer clears `active` when the field is omitted from the request (partial saves, QA/API).
 - PHP 7.4–8.4: dynamic properties, null Profile in `addQueues`, PHPMailer `ErrorInfo`.
 - [#28] `sxProcessorInput::parseIds` accepts `ids` as array or CSV; queue send from snippet/code matches ExtJS `runProcessor` input.
 

--- a/core/components/sendex/elements/chunks/chunk.subscribe.auth.tpl
+++ b/core/components/sendex/elements/chunks/chunk.subscribe.auth.tpl
@@ -1,4 +1,4 @@
-<div class="sendex-widget" data-sendex-widget>
+<div class="sendex-widget" data-sendex-widget data-sendex-newsletter-id="[[+id]]">
     <p>
         [[%sendex_subscribe_intro?name=`[[+name]]`]]
         <small>[[+description]]</small>
@@ -8,6 +8,8 @@
 
     <form action="" method="post" data-sendex-form>
         <input type="hidden" name="sx_action" value="subscribe">
+        <input type="hidden" name="newsletter_id" value="[[+id]]">
+        [[+widget_key:notempty=`<input type="hidden" name="sendex_widget_key" value="[[+widget_key]]">`]]
 
         <button type="submit">[[%sendex_btn_subscribe]]</button>
     </form>

--- a/core/components/sendex/elements/chunks/chunk.subscribe.guest.tpl
+++ b/core/components/sendex/elements/chunks/chunk.subscribe.guest.tpl
@@ -1,4 +1,4 @@
-<div class="sendex-widget" data-sendex-widget>
+<div class="sendex-widget" data-sendex-widget data-sendex-newsletter-id="[[+id]]">
     <p>
         [[%sendex_subscribe_intro?name=`[[+name]]`]]
         <small>[[+description]]</small>
@@ -8,6 +8,8 @@
 
     <form action="" method="post" data-sendex-form>
         <input type="hidden" name="sx_action" value="subscribe">
+        <input type="hidden" name="newsletter_id" value="[[+id]]">
+        [[+widget_key:notempty=`<input type="hidden" name="sendex_widget_key" value="[[+widget_key]]">`]]
 
         <input type="email" name="email" value="" placeholder="Email" required>
 

--- a/core/components/sendex/elements/chunks/chunk.unsubscribe.tpl
+++ b/core/components/sendex/elements/chunks/chunk.unsubscribe.tpl
@@ -1,4 +1,4 @@
-<div class="sendex-widget" data-sendex-widget>
+<div class="sendex-widget" data-sendex-widget data-sendex-newsletter-id="[[+id]]">
     <p>
         [[%sendex_unsubscribe_intro?name=`[[+name]]`]]
         <small>[[+description]]</small>
@@ -8,6 +8,8 @@
 
     <form action="" method="post" data-sendex-form>
         <input type="hidden" name="sx_action" value="unsubscribe">
+        <input type="hidden" name="newsletter_id" value="[[+id]]">
+        [[+widget_key:notempty=`<input type="hidden" name="sendex_widget_key" value="[[+widget_key]]">`]]
 
         <input type="hidden" name="code" value="[[+code]]">
 

--- a/core/components/sendex/elements/snippets/snippet.sendex.php
+++ b/core/components/sendex/elements/snippets/snippet.sendex.php
@@ -27,6 +27,7 @@ if (empty($linkTTL)) {
     $linkTTL = 1800;
 }
 $requireConfirm = sxSubscribeConfirm::isRequired($modx, $scriptProperties);
+$widgetKey = trim((string) $modx->getOption('widgetKey', $scriptProperties, ''));
 $loadJs = sxSubscribeAjaxResponse::parseEnabled(
     $modx->getOption('loadJs', $scriptProperties, true),
     true
@@ -46,6 +47,7 @@ $placeholders = $newsletter->toArray();
 $placeholders['message'] = '';
 $placeholders['class'] = '';
 $placeholders['error'] = 0;
+$placeholders['widget_key'] = $widgetKey;
 $isAuthenticated = $modx->user->isAuthenticated($modx->context->key);
 if ($isAuthenticated) {
     $profile = $modx->user->getOne('Profile');
@@ -56,7 +58,7 @@ if ($isAuthenticated) {
     );
 }
 
-if (!empty($_REQUEST['sx_action'])) {
+if (!empty($_REQUEST['sx_action']) && sxSubscribeAjaxResponse::matchesRequest($id, $widgetKey, $_REQUEST)) {
     $params = $_GET;
     unset($params[$modx->getOption('request_param_alias')]);
     unset($params[$modx->getOption('request_param_id')]);
@@ -186,7 +188,7 @@ if ($isAuthenticated && $id = $newsletter->isSubscribed($modx->user->id)) {
         : $modx->getChunk($tplSubscribeGuest, $placeholders);
 }
 
-if ($isAjax && !empty($_REQUEST['sx_action'])) {
+if ($isAjax && !empty($_REQUEST['sx_action']) && sxSubscribeAjaxResponse::matchesRequest($id, $widgetKey, $_REQUEST)) {
     sxSubscribeAjaxResponse::send($placeholders, $output);
 }
 

--- a/core/components/sendex/elements/snippets/snippet.sendex.php
+++ b/core/components/sendex/elements/snippets/snippet.sendex.php
@@ -48,6 +48,9 @@ $placeholders['message'] = '';
 $placeholders['class'] = '';
 $placeholders['error'] = 0;
 $placeholders['widget_key'] = $widgetKey;
+$newsletterId = (int) $id;
+$handlesRequest = !empty($_REQUEST['sx_action'])
+    && sxSubscribeAjaxResponse::matchesRequest($newsletterId, $widgetKey, $_REQUEST);
 $isAuthenticated = $modx->user->isAuthenticated($modx->context->key);
 if ($isAuthenticated) {
     $profile = $modx->user->getOne('Profile');
@@ -58,7 +61,7 @@ if ($isAuthenticated) {
     );
 }
 
-if (!empty($_REQUEST['sx_action']) && sxSubscribeAjaxResponse::matchesRequest($id, $widgetKey, $_REQUEST)) {
+if ($handlesRequest) {
     $params = $_GET;
     unset($params[$modx->getOption('request_param_alias')]);
     unset($params[$modx->getOption('request_param_id')]);
@@ -95,6 +98,7 @@ if (!empty($_REQUEST['sx_action']) && sxSubscribeAjaxResponse::matchesRequest($i
                 } elseif ($guestResult['status'] === 'confirm') {
                     $params['hash'] = $guestResult['hash'];
                     $params['sx_action'] = 'confirm';
+                    $params['newsletter_id'] = $newsletterId;
                     $placeholders['link'] = $modx->makeUrl($modx->resource->id, $modx->context->key, $params, 'full');
                     $placeholders['email_body'] = $modx->getChunk($tplActivate, $placeholders);
                     $response = $Sendex->sendEmail($email, $placeholders);
@@ -139,6 +143,7 @@ if (!empty($_REQUEST['sx_action']) && sxSubscribeAjaxResponse::matchesRequest($i
                             'message' => '',
                             'class'   => '',
                             'error'   => 0,
+                            'widget_key' => $widgetKey,
                         )
                     );
                     if ($isAuthenticated) {
@@ -177,8 +182,8 @@ if (!empty($placeholders['message'])) {
         : $modx->getOption('msgClass', $scriptProperties, 'active');
 }
 
-if ($isAuthenticated && $id = $newsletter->isSubscribed($modx->user->id)) {
-    if ($subscriber = $modx->getObject('sxSubscriber', $id)) {
+if ($isAuthenticated && ($subscriberId = $newsletter->isSubscribed($modx->user->id))) {
+    if ($subscriber = $modx->getObject('sxSubscriber', $subscriberId)) {
         $placeholders = array_merge($subscriber->toArray(), $placeholders);
     }
     $output = $modx->getChunk($tplUnsubscribe, $placeholders);
@@ -188,7 +193,7 @@ if ($isAuthenticated && $id = $newsletter->isSubscribed($modx->user->id)) {
         : $modx->getChunk($tplSubscribeGuest, $placeholders);
 }
 
-if ($isAjax && !empty($_REQUEST['sx_action']) && sxSubscribeAjaxResponse::matchesRequest($id, $widgetKey, $_REQUEST)) {
+if ($isAjax && $handlesRequest) {
     sxSubscribeAjaxResponse::send($placeholders, $output);
 }
 

--- a/core/components/sendex/elements/snippets/snippet.sendex.php
+++ b/core/components/sendex/elements/snippets/snippet.sendex.php
@@ -14,7 +14,7 @@ if (!($Sendex instanceof Sendex)) {
     return '';
 }
 
-require_once $corePath . 'model/sendex/sxuserplaceholders.class.php';
+require_once $corePath . 'model/sendex/sxuserprofile.class.php';
 require_once $corePath . 'model/sendex/sxunsubscriberesolve.class.php';
 require_once $corePath . 'model/sendex/sxsubscribeconfirm.class.php';
 require_once $corePath . 'model/sendex/sxsubscribeajaxresponse.class.php';
@@ -53,12 +53,7 @@ $handlesRequest = !empty($_REQUEST['sx_action'])
     && sxSubscribeAjaxResponse::matchesRequest($newsletterId, $widgetKey, $_REQUEST);
 $isAuthenticated = $modx->user->isAuthenticated($modx->context->key);
 if ($isAuthenticated) {
-    $profile = $modx->user->getOne('Profile');
-    $placeholders = sxUserPlaceholders::mergeAuthenticated(
-        $modx->user->toArray(),
-        $profile ? $profile->toArray() : null,
-        $placeholders
-    );
+    $placeholders = sxUserProfile::authenticatedPlaceholders($modx, $modx->user, $placeholders);
 }
 
 if ($handlesRequest) {
@@ -147,10 +142,9 @@ if ($handlesRequest) {
                         )
                     );
                     if ($isAuthenticated) {
-                        $profile = $modx->user->getOne('Profile');
-                        $placeholders = sxUserPlaceholders::mergeAuthenticated(
-                            $modx->user->toArray(),
-                            $profile ? $profile->toArray() : null,
+                        $placeholders = sxUserProfile::authenticatedPlaceholders(
+                            $modx,
+                            $modx->user,
                             $placeholders
                         );
                     }

--- a/core/components/sendex/migrations/20260724130000_innodb_queue_subscriber_link.php
+++ b/core/components/sendex/migrations/20260724130000_innodb_queue_subscriber_link.php
@@ -8,7 +8,7 @@ use Phinx\Migration\AbstractMigration;
 class InnodbQueueSubscriberLink extends AbstractMigration
 {
     /** @var string[] */
-    protected $tables = array(
+    private $sendexTableNames = array(
         'sendex_newsletters',
         'sendex_subscribers',
         'sendex_queue',
@@ -16,7 +16,7 @@ class InnodbQueueSubscriberLink extends AbstractMigration
 
     public function up()
     {
-        foreach ($this->tables as $tableName) {
+        foreach ($this->sendexTableNames as $tableName) {
             $this->convertToInnoDb($tableName);
         }
 

--- a/core/components/sendex/model/sendex/sendex.class.php
+++ b/core/components/sendex/model/sendex/sendex.class.php
@@ -31,6 +31,10 @@ class Sendex
             $config,
             $this->modx->getOption('core_path') . 'components/sendex/'
         );
+        if (is_file($corePath . 'bootstrap.php')) {
+            require_once $corePath . 'bootstrap.php';
+            sendexRegisterAutoload($corePath);
+        }
         $assetsUrl = $this->modx->getOption(
             'sendex_assets_url',
             $config,
@@ -75,7 +79,7 @@ class Sendex
     public function sendEmail($email, array $options = array())
     {
         /** @var modPHPMailer $mail */
-        $mail = $this->modx->getService('mail', 'mail.modPHPMailer');
+        $mail = sxModxCompat::getMail($this->modx);
         sxNewsletterMailer::configureMailer(
             $mail,
             sxNewsletterMailer::buildActivationMessage($this->modx, $email, $options)

--- a/core/components/sendex/model/sendex/sxmodxcompat.class.php
+++ b/core/components/sendex/model/sendex/sxmodxcompat.class.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * MODX 2/3 compatibility at service boundaries (#74).
+ */
+class sxModxCompat
+{
+    /**
+     * @param object $modx
+     * @return object|null modPHPMailer-like
+     */
+    public static function getMail($modx)
+    {
+        if (self::hasServices($modx)) {
+            $services = $modx->services;
+            if (method_exists($services, 'has') && $services->has('mail')) {
+                return $services->get('mail');
+            }
+        }
+
+        return $modx->getService('mail', 'mail.modPHPMailer');
+    }
+
+    /**
+     * @param object $modx
+     * @return object|null
+     */
+    public static function getParser($modx)
+    {
+        if (self::hasServices($modx)) {
+            $services = $modx->services;
+            if (method_exists($services, 'has') && $services->has('parser')) {
+                return $services->get('parser');
+            }
+        }
+
+        return $modx->getService(
+            'parser',
+            $modx->getOption('parser_class', null, 'modParser'),
+            $modx->getOption('parser_class_path', null, '')
+        );
+    }
+
+    /**
+     * @param object $modx
+     * @return object|null registry.modRegistry
+     */
+    public static function getRegistry($modx)
+    {
+        if (self::hasServices($modx)) {
+            $services = $modx->services;
+            if (method_exists($services, 'has') && $services->has('registry')) {
+                return $services->get('registry');
+            }
+        }
+
+        return $modx->getService('registry', 'registry.modRegistry');
+    }
+
+    /**
+     * @param string $name BODY|FROM|FROM_NAME|SUBJECT|...
+     * @return string
+     */
+    public static function mailConst($name)
+    {
+        $key = 'MAIL_' . strtoupper($name);
+        if (class_exists('modMail', false)) {
+            return constant('modMail::' . $key);
+        }
+
+        $fqcn = 'MODX\\Revolution\\Mail\\modMail';
+        if (class_exists($fqcn)) {
+            return constant($fqcn . '::' . $key);
+        }
+
+        return strtolower($name);
+    }
+
+    /**
+     * @param object $modx
+     * @return bool
+     */
+    protected static function hasServices($modx)
+    {
+        return isset($modx->services)
+            && is_object($modx->services)
+            && method_exists($modx->services, 'get');
+    }
+}

--- a/core/components/sendex/model/sendex/sxnewslettermailer.class.php
+++ b/core/components/sendex/model/sendex/sxnewslettermailer.class.php
@@ -123,10 +123,10 @@ class sxNewsletterMailer
      */
     public static function configureMailer($mail, array $message)
     {
-        $mail->set(modMail::MAIL_BODY, $message['email_body']);
-        $mail->set(modMail::MAIL_FROM, $message['email_from']);
-        $mail->set(modMail::MAIL_FROM_NAME, $message['email_from_name']);
-        $mail->set(modMail::MAIL_SUBJECT, $message['email_subject']);
+        $mail->set(sxModxCompat::mailConst('BODY'), $message['email_body']);
+        $mail->set(sxModxCompat::mailConst('FROM'), $message['email_from']);
+        $mail->set(sxModxCompat::mailConst('FROM_NAME'), $message['email_from_name']);
+        $mail->set(sxModxCompat::mailConst('SUBJECT'), $message['email_subject']);
         $mail->address('to', $message['email_to']);
         $mail->address('reply-to', $message['email_reply']);
         $mail->setHTML(true);

--- a/core/components/sendex/model/sendex/sxnewsletterqueueusers.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletterqueueusers.class.php
@@ -31,7 +31,7 @@ class sxNewsletterQueueUsers
             $id = (int) $user->get('id');
             $loadedIds[] = $id;
             $profile = isset($profilesByUser[$id]) ? $profilesByUser[$id] : null;
-            if (!$profile || !$user->active || $profile->get('blocked')) {
+            if (!$profile || !sxUserProfile::isActiveUser($user) || $profile->get('blocked')) {
                 continue;
             }
 

--- a/core/components/sendex/model/sendex/sxqueuebodyrenderer.class.php
+++ b/core/components/sendex/model/sendex/sxqueuebodyrenderer.class.php
@@ -83,11 +83,7 @@ class sxQueueBodyRenderer
         $body = $template->process($scriptProperties);
 
         /** @var modParser|null $parser */
-        $parser = $xpdo->getService(
-            'parser',
-            $xpdo->getOption('parser_class', null, 'modParser'),
-            $xpdo->getOption('parser_class_path', null, '')
-        );
+        $parser = sxModxCompat::getParser($xpdo);
         if ($parser && $parser instanceof modParser) {
             $maxIterations = (int) $xpdo->getOption('parser_max_iterations', null, 10);
             $parser->processElementTags('', $body, true, true, '[[', ']]', array(), $maxIterations);

--- a/core/components/sendex/model/sendex/sxqueuesender.class.php
+++ b/core/components/sendex/model/sendex/sxqueuesender.class.php
@@ -102,7 +102,7 @@ class sxQueueSender
         }
 
         /** @var modPHPMailer $mail */
-        $mail = $queue->xpdo->getService('mail', 'mail.modPHPMailer');
+        $mail = sxModxCompat::getMail($queue->xpdo);
         sxNewsletterMailer::configureMailer($mail, $message);
         if (!$mail->send()) {
             $error = $mail->mailer->ErrorInfo;

--- a/core/components/sendex/model/sendex/sxsubscribeajaxresponse.class.php
+++ b/core/components/sendex/model/sendex/sxsubscribeajaxresponse.class.php
@@ -84,12 +84,17 @@ class sxSubscribeAjaxResponse
         if (!self::matchesNewsletter($snippetNewsletterId, $request)) {
             return false;
         }
-        if ($widgetKey === '') {
-            return true;
+
+        $requestWidgetKey = isset($request['sendex_widget_key'])
+            ? trim((string) $request['sendex_widget_key'])
+            : '';
+
+        if ($requestWidgetKey !== '') {
+            return $widgetKey !== '' && $requestWidgetKey === (string) $widgetKey;
         }
 
-        return isset($request['sendex_widget_key'])
-            && (string) $request['sendex_widget_key'] === (string) $widgetKey;
+        // Email confirm/unsubscribe links and legacy forms omit sendex_widget_key.
+        return $widgetKey === '';
     }
 
     /**

--- a/core/components/sendex/model/sendex/sxsubscribeajaxresponse.class.php
+++ b/core/components/sendex/model/sendex/sxsubscribeajaxresponse.class.php
@@ -58,6 +58,41 @@ class sxSubscribeAjaxResponse
     }
 
     /**
+     * Whether the POST/AJAX action targets this snippet instance (multi-widget pages).
+     *
+     * @param int|string $snippetNewsletterId
+     * @param array      $request
+     * @return bool
+     */
+    public static function matchesNewsletter($snippetNewsletterId, array $request)
+    {
+        if (!isset($request['newsletter_id']) || $request['newsletter_id'] === '') {
+            return true;
+        }
+
+        return (int) $request['newsletter_id'] === (int) $snippetNewsletterId;
+    }
+
+    /**
+     * @param int|string $snippetNewsletterId
+     * @param string     $widgetKey
+     * @param array      $request
+     * @return bool
+     */
+    public static function matchesRequest($snippetNewsletterId, $widgetKey, array $request)
+    {
+        if (!self::matchesNewsletter($snippetNewsletterId, $request)) {
+            return false;
+        }
+        if ($widgetKey === '') {
+            return true;
+        }
+
+        return isset($request['sendex_widget_key'])
+            && (string) $request['sendex_widget_key'] === (string) $widgetKey;
+    }
+
+    /**
      * @param mixed $value
      * @param bool $default
      * @return bool

--- a/core/components/sendex/model/sendex/sxsubscriberegistry.class.php
+++ b/core/components/sendex/model/sendex/sxsubscriberegistry.class.php
@@ -105,7 +105,7 @@ class sxSubscribeRegistry
      */
     private static function register($xpdo)
     {
-        $registry = $xpdo->getService('registry', 'registry.modRegistry');
+        $registry = sxModxCompat::getRegistry($xpdo);
         if (!$registry) {
             return null;
         }

--- a/core/components/sendex/model/sendex/sxsubscribermerge.class.php
+++ b/core/components/sendex/model/sendex/sxsubscribermerge.class.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once dirname(__FILE__) . '/sxsubscribermatch.class.php';
+require_once dirname(__FILE__) . '/sxuserprofile.class.php';
 
 /**
  * Attach guest subscriber rows to a modUser when email matches (#39).
@@ -56,22 +57,12 @@ class sxSubscriberMerge
             return '';
         }
 
-        $profile = null;
-        if (method_exists($user, 'getOne')) {
-            $profile = $user->getOne('Profile');
-        }
-
-        if (!$profile && method_exists($user, 'get')) {
-            $profile = $xpdo->getObject('modUserProfile', array(
-                'internalKey' => (int) $user->get('id'),
-            ));
-        }
-
+        $profile = sxUserProfile::profileArray($user, $xpdo);
         if (!$profile) {
             return '';
         }
 
-        return sxSubscriberMatch::normalizeEmail($profile->get('email'));
+        return sxSubscriberMatch::normalizeEmail($profile['email']);
     }
 
     /**

--- a/core/components/sendex/model/sendex/sxuserprofile.class.php
+++ b/core/components/sendex/model/sendex/sxuserprofile.class.php
@@ -1,0 +1,76 @@
+<?php
+
+require_once dirname(__FILE__) . '/sxuserplaceholders.class.php';
+
+/**
+ * User/Profile boundary helpers for MODX 2/3 (#74).
+ */
+class sxUserProfile
+{
+    /**
+     * @param object|null $user modUser-like
+     * @param object $xpdo
+     * @return array|null Profile::toArray() or null
+     */
+    public static function profileArray($user, $xpdo)
+    {
+        if ($user === null) {
+            return null;
+        }
+
+        $profile = null;
+        if (method_exists($user, 'getOne')) {
+            $profile = $user->getOne('Profile');
+        }
+
+        if ($profile && method_exists($profile, 'toArray')) {
+            return $profile->toArray();
+        }
+
+        if (!method_exists($user, 'get')) {
+            return null;
+        }
+
+        $userId = (int) $user->get('id');
+        if ($userId <= 0) {
+            return null;
+        }
+
+        $profileObject = $xpdo->getObject('modUserProfile', array('internalKey' => $userId));
+        if ($profileObject && method_exists($profileObject, 'toArray')) {
+            return $profileObject->toArray();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param object $user modUser-like
+     * @return bool
+     */
+    public static function isActiveUser($user)
+    {
+        if (!is_object($user) || !method_exists($user, 'get')) {
+            return false;
+        }
+
+        return (bool) $user->get('active');
+    }
+
+    /**
+     * @param object $modx
+     * @param object $user modUser-like
+     * @param array $base
+     * @return array
+     */
+    public static function authenticatedPlaceholders($modx, $user, array $base)
+    {
+        $userData = method_exists($user, 'toArray') ? $user->toArray() : array();
+
+        return sxUserPlaceholders::mergeAuthenticated(
+            $userData,
+            self::profileArray($user, $modx),
+            $base
+        );
+    }
+}

--- a/core/components/sendex/processors/mgr/newsletter/getlist.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/getlist.class.php
@@ -60,7 +60,7 @@ class sxNewsletterGetListProcessor extends modObjectGetListProcessor
                 'class'  => '',
                 'button' => true,
                 'menu'   => true,
-                'icon'   => 'check',
+                'icon'   => 'check-circle-o',
                 'type'   => 'enableNewsletter',
             );
         } else {

--- a/core/components/sendex/processors/mgr/newsletter/update.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/update.class.php
@@ -40,8 +40,10 @@ class sxNewsletterUpdateProcessor extends modObjectUpdateProcessor
             }
         }
 
-        $active = $this->getProperty('active');
-        $this->setProperty('active', !empty($active) && $active != 'false');
+        if (array_key_exists('active', $this->getProperties())) {
+            $active = $this->getProperty('active');
+            $this->setProperty('active', !empty($active) && $active !== 'false' && $active !== '0');
+        }
 
         return !$this->hasErrors();
     }

--- a/core/components/sendex/sendexmaincontroller.class.php
+++ b/core/components/sendex/sendexmaincontroller.class.php
@@ -16,6 +16,7 @@ abstract class SendexMainController extends modExtraManagerController
     public function initialize()
     {
         $version = $this->modx->getVersionData();
+        // MODx.modx23 = modern mgr UI (MODX 2.3+ and MODX 3.x), not a separate MODX 3 branch.
         $modx23 = !empty($version) && version_compare($version['full_version'], '2.3.0', '>=');
         if (!$modx23) {
             $this->addCss(MODX_ASSETS_URL . 'components/sendex/css/mgr/font-awesome.min.css');
@@ -27,9 +28,9 @@ abstract class SendexMainController extends modExtraManagerController
             null,
             $this->modx->getOption('core_path') . 'components/sendex/'
         );
-        require_once $corePath . 'model/sendex/sendex.class.php';
+        require_once $corePath . 'bootstrap.php';
 
-        $this->Sendex = new Sendex($this->modx);
+        $this->Sendex = sendexBootstrap($this->modx);
         $this->addCss($this->Sendex->config['cssUrl'] . 'mgr/main.css');
         $this->addJavascript($this->Sendex->config['jsUrl'] . 'mgr/sendex.js');
         $this->addJavascript($this->Sendex->config['jsUrl'] . 'mgr/misc/utils.js');

--- a/tests/Stubs/FakeModxServices.php
+++ b/tests/Stubs/FakeModxServices.php
@@ -1,0 +1,33 @@
+<?php
+
+class FakeModxServices
+{
+    /** @var array<string,mixed> */
+    private $services;
+
+    /**
+     * @param array<string,mixed> $services
+     */
+    public function __construct(array $services)
+    {
+        $this->services = $services;
+    }
+
+    /**
+     * @param string $name
+     * @return bool
+     */
+    public function has($name)
+    {
+        return array_key_exists($name, $this->services);
+    }
+
+    /**
+     * @param string $name
+     * @return mixed
+     */
+    public function get($name)
+    {
+        return $this->services[$name];
+    }
+}

--- a/tests/Unit/BuildHelpersTest.php
+++ b/tests/Unit/BuildHelpersTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . '/_build/includes/functions.php';
+
+class BuildHelpersTest extends TestCase
+{
+    /** @var string */
+    private $tempModelDir;
+
+    protected function setUp(): void
+    {
+        $this->tempModelDir = sys_get_temp_dir() . '/sendex-build-' . uniqid('', true);
+        mkdir($this->tempModelDir . '/mysql', 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if (!is_dir($this->tempModelDir)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($this->tempModelDir, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($iterator as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($this->tempModelDir);
+    }
+
+    public function testRemoveModx3ModelArtifactsDeletesPascalCaseSxFiles()
+    {
+        $paths = array(
+            $this->tempModelDir . '/mysql/sxNewsletter.php',
+            $this->tempModelDir . '/mysql/sxQueue.php',
+            $this->tempModelDir . '/sxSubscriber.php',
+            $this->tempModelDir . '/mysql/sxnewsletter.map.inc.php',
+        );
+        foreach ($paths as $path) {
+            file_put_contents($path, '<?php');
+        }
+
+        sendexRemoveModx3ModelArtifacts($this->tempModelDir);
+
+        $this->assertFileDoesNotExist($paths[0]);
+        $this->assertFileDoesNotExist($paths[1]);
+        $this->assertFileDoesNotExist($paths[2]);
+        $this->assertFileExists($paths[3]);
+    }
+
+    public function testUsesLegacyModActionReflectsModActionClassPresence()
+    {
+        $this->assertSame(class_exists('modAction'), sendexUsesLegacyModAction());
+    }
+}

--- a/tests/Unit/BuildTransportModx3ContractTest.php
+++ b/tests/Unit/BuildTransportModx3ContractTest.php
@@ -32,6 +32,27 @@ class BuildTransportModx3ContractTest extends TestCase
         $this->assertStringContainsString('sendexShouldRegenerateModel', $source);
     }
 
+    public function testBuildTransportCleansModx3ModelArtifactsWhenSkippingRegeneration()
+    {
+        $source = file_get_contents($this->root . '/_build/build.transport.php');
+
+        $this->assertStringContainsString('sendexRemoveModx3ModelArtifacts($sendexModelDir)', $source);
+        $this->assertStringContainsString('sendexNormalizeGeneratedPhpFiles($sendexModelDir)', $source);
+    }
+
+    public function testBuildModelSkipsRegenerationOnModx3AndNormalizesGeneratedPhp()
+    {
+        $source = file_get_contents($this->root . '/_build/build.model.php');
+        $functions = file_get_contents($this->root . '/_build/includes/functions.php');
+
+        $this->assertStringContainsString('sendexShouldRegenerateModel($modx)', $source);
+        $this->assertStringContainsString('sendexRemoveModx3ModelArtifacts', $source);
+        $this->assertStringContainsString('sendexNormalizeGeneratedPhpFiles', $source);
+        $this->assertStringContainsString('function sendexRemoveModx3ModelArtifacts', $functions);
+        $this->assertStringContainsString('function sendexNormalizeGeneratedPhpFiles', $functions);
+        $this->assertStringContainsString("preg_match('/^\\{\\s*$/',", $functions);
+    }
+
     public function testTransportMenuUsesCapabilityCheckForModAction()
     {
         $source = file_get_contents($this->root . '/_build/data/transport.menu.php');

--- a/tests/Unit/BuildTransportModx3ContractTest.php
+++ b/tests/Unit/BuildTransportModx3ContractTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class BuildTransportModx3ContractTest extends TestCase
+{
+    /** @var string */
+    private $root;
+
+    protected function setUp(): void
+    {
+        $this->root = dirname(__DIR__, 2);
+    }
+
+    public function testBuildConfigDefinesAssetsPathPlaceholder()
+    {
+        $source = file_get_contents($this->root . '/_build/build.config.php');
+
+        $this->assertStringContainsString("define('PKG_ASSETS_PATH'", $source);
+        $this->assertStringContainsString("{assets_path}components/", $source);
+    }
+
+    public function testBuildTransportRegistersNamespaceWithAssetsPath()
+    {
+        $source = file_get_contents($this->root . '/_build/build.transport.php');
+
+        $this->assertStringContainsString('sendexEnsureBuildClassAliases($modx)', $source);
+        $this->assertStringContainsString(
+            'registerNamespace(PKG_NAME_LOWER, false, true, PKG_NAMESPACE_PATH, PKG_ASSETS_PATH)',
+            $source
+        );
+        $this->assertStringContainsString('sendexShouldRegenerateModel', $source);
+    }
+
+    public function testTransportMenuUsesCapabilityCheckForModAction()
+    {
+        $source = file_get_contents($this->root . '/_build/data/transport.menu.php');
+
+        $this->assertStringContainsString("class_exists('modAction')", $source);
+        $this->assertStringContainsString("\$menuFields['namespace'] = PKG_NAME_LOWER", $source);
+        $this->assertStringNotContainsString('instanceof modAction', $source);
+    }
+
+    public function testModelMetadataKeepsGlobalSxClassNames()
+    {
+        $source = file_get_contents(
+            $this->root . '/core/components/sendex/model/sendex/metadata.mysql.php'
+        );
+
+        $this->assertStringContainsString("'sxNewsletter'", $source);
+        $this->assertStringContainsString("'sxSubscriber'", $source);
+        $this->assertStringContainsString("'sxQueue'", $source);
+        $this->assertStringNotContainsString('MODX\\Revolution\\sx', $source);
+        $this->assertStringNotContainsString('sendex\\sx', $source);
+    }
+
+    public function testInnodbMigrationDoesNotOverridePhinxTablesProperty()
+    {
+        $source = file_get_contents(
+            $this->root . '/core/components/sendex/migrations/20260724130000_innodb_queue_subscriber_link.php'
+        );
+
+        $this->assertStringContainsString('$sendexTableNames', $source);
+        $this->assertStringNotContainsString('protected $tables', $source);
+    }
+}

--- a/tests/Unit/BuildTransportModx3ContractTest.php
+++ b/tests/Unit/BuildTransportModx3ContractTest.php
@@ -59,7 +59,18 @@ class BuildTransportModx3ContractTest extends TestCase
 
         $this->assertStringContainsString("class_exists('modAction')", $source);
         $this->assertStringContainsString("\$menuFields['namespace'] = PKG_NAME_LOWER", $source);
+        $this->assertStringContainsString("\$controller = 'home'", $source);
         $this->assertStringNotContainsString('instanceof modAction', $source);
+    }
+
+    public function testModx3IndexControllerUsesSendexPrefixedClassName()
+    {
+        $source = file_get_contents(
+            $this->root . '/core/components/sendex/controllers/index.class.php'
+        );
+
+        $this->assertStringContainsString('class SendexIndexManagerController', $source);
+        $this->assertStringContainsString('extends SendexHomeManagerController', $source);
     }
 
     public function testModelMetadataKeepsGlobalSxClassNames()

--- a/tests/Unit/BuildTransportModx3ContractTest.php
+++ b/tests/Unit/BuildTransportModx3ContractTest.php
@@ -29,15 +29,15 @@ class BuildTransportModx3ContractTest extends TestCase
             'registerNamespace(PKG_NAME_LOWER, false, true, PKG_NAMESPACE_PATH, PKG_ASSETS_PATH)',
             $source
         );
-        $this->assertStringContainsString('sendexShouldRegenerateModel', $source);
+        $this->assertStringContainsString('sendexPrepareModelForBuild', $source);
     }
 
     public function testBuildTransportCleansModx3ModelArtifactsWhenSkippingRegeneration()
     {
         $source = file_get_contents($this->root . '/_build/build.transport.php');
 
-        $this->assertStringContainsString('sendexRemoveModx3ModelArtifacts($sendexModelDir)', $source);
-        $this->assertStringContainsString('sendexNormalizeGeneratedPhpFiles($sendexModelDir)', $source);
+        $this->assertStringContainsString('sendexPrepareModelForBuild($sendexBuildModx, $sendexModelDir)', $source);
+        $this->assertStringNotContainsString('sendexNormalizeGeneratedPhpFiles($sendexModelDir)', $source);
     }
 
     public function testBuildModelSkipsRegenerationOnModx3AndNormalizesGeneratedPhp()
@@ -45,10 +45,13 @@ class BuildTransportModx3ContractTest extends TestCase
         $source = file_get_contents($this->root . '/_build/build.model.php');
         $functions = file_get_contents($this->root . '/_build/includes/functions.php');
 
-        $this->assertStringContainsString('sendexShouldRegenerateModel($modx)', $source);
-        $this->assertStringContainsString('sendexRemoveModx3ModelArtifacts', $source);
-        $this->assertStringContainsString('sendexNormalizeGeneratedPhpFiles', $source);
+        $this->assertStringContainsString(
+            'sendexPrepareModelForBuild($modx, $sources[\'model\'] . PKG_NAME_LOWER)',
+            $source
+        );
+        $this->assertStringContainsString('function sendexPrepareModelForBuild', $functions);
         $this->assertStringContainsString('function sendexRemoveModx3ModelArtifacts', $functions);
+        $this->assertStringContainsString('function sendexUsesLegacyModAction', $functions);
         $this->assertStringContainsString('function sendexNormalizeGeneratedPhpFiles', $functions);
         $this->assertStringContainsString("preg_match('/^\\{\\s*$/',", $functions);
     }
@@ -57,9 +60,10 @@ class BuildTransportModx3ContractTest extends TestCase
     {
         $source = file_get_contents($this->root . '/_build/data/transport.menu.php');
 
-        $this->assertStringContainsString("class_exists('modAction')", $source);
+        $this->assertStringContainsString('sendexUsesLegacyModAction($modx)', $source);
         $this->assertStringContainsString("\$menuFields['namespace'] = PKG_NAME_LOWER", $source);
-        $this->assertStringContainsString("\$controller = 'home'", $source);
+        $this->assertStringContainsString("'controller' => 'index'", $source);
+        $this->assertStringNotContainsString("\$controller = 'home'", $source);
         $this->assertStringNotContainsString('instanceof modAction', $source);
     }
 

--- a/tests/Unit/ConnectorBootstrapContractTest.php
+++ b/tests/Unit/ConnectorBootstrapContractTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class ConnectorBootstrapContractTest extends TestCase
+{
+    /** @var string */
+    private $root;
+
+    protected function setUp(): void
+    {
+        $this->root = dirname(__DIR__, 2);
+    }
+
+    public function testBootstrapDefinesSharedInitFunctions()
+    {
+        $source = file_get_contents($this->root . '/core/components/sendex/bootstrap.php');
+
+        $this->assertStringContainsString('function sendexBootstrap', $source);
+        $this->assertStringContainsString('function sendexRegisterAutoload', $source);
+        $this->assertStringContainsString('function sendexEnsureProcessorBase', $source);
+        $this->assertStringContainsString('spl_autoload_register', $source);
+    }
+
+    public function testConnectorUsesBootstrap()
+    {
+        $source = file_get_contents($this->root . '/assets/components/sendex/connector.php');
+
+        $this->assertStringContainsString('bootstrap.php', $source);
+        $this->assertStringContainsString('sendexBootstrap($modx)', $source);
+        $this->assertStringContainsString('handleRequest', $source);
+        $this->assertStringContainsString('processors_path', $source);
+        $this->assertStringNotContainsString('new Sendex($modx)', $source);
+    }
+
+    public function testMgrControllerUsesBootstrap()
+    {
+        $source = file_get_contents(
+            $this->root . '/core/components/sendex/sendexmaincontroller.class.php'
+        );
+
+        $this->assertStringContainsString('bootstrap.php', $source);
+        $this->assertStringContainsString('sendexBootstrap($this->modx)', $source);
+    }
+
+    public function testCronUsesBootstrap()
+    {
+        $source = file_get_contents($this->root . '/core/components/sendex/cron/send.php');
+
+        $this->assertStringContainsString('bootstrap.php', $source);
+        $this->assertStringContainsString('sendexBootstrap($modx)', $source);
+        $this->assertStringContainsString('sxQueueSender::flush', $source);
+    }
+}

--- a/tests/Unit/ModxCompatTest.php
+++ b/tests/Unit/ModxCompatTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sxmodxcompat.class.php';
+require_once dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sxuserprofile.class.php';
+
+class ModxCompatTest extends TestCase
+{
+    public function testGetMailUsesServicesContainerOnModx3()
+    {
+        $mail = new FakeMail();
+        $modx = new FakeModX();
+        $modx->services = new FakeModxServices(array('mail' => $mail));
+
+        $this->assertSame($mail, sxModxCompat::getMail($modx));
+    }
+
+    public function testGetMailFallsBackToGetService()
+    {
+        $modx = new FakeModX();
+        unset($modx->services);
+
+        $mail = sxModxCompat::getMail($modx);
+
+        $this->assertInstanceOf(FakeMail::class, $mail);
+    }
+
+    public function testMailConstUsesModMailWhenAvailable()
+    {
+        $this->assertSame(modMail::MAIL_BODY, sxModxCompat::mailConst('BODY'));
+    }
+
+    public function testIsActiveUserUsesGetNotProperty()
+    {
+        $modx = new FakeModX();
+        $user = new modUser($modx);
+        $user->set('active', 1);
+
+        $this->assertTrue(sxUserProfile::isActiveUser($user));
+
+        $user->set('active', 0);
+        $this->assertFalse(sxUserProfile::isActiveUser($user));
+    }
+
+    public function testProfileArrayFallsBackToModUserProfile()
+    {
+        $modx = new FakeModX();
+        $user = new modUser($modx);
+        $user->set('id', 5);
+
+        $profile = new modUserProfile($modx);
+        $profile->set('internalKey', 5);
+        $profile->set('email', 'profile@example.com');
+        $modx->userProfiles[5] = $profile;
+
+        $data = sxUserProfile::profileArray($user, $modx);
+
+        $this->assertIsArray($data);
+        $this->assertSame('profile@example.com', $data['email']);
+    }
+
+    public function testAuthenticatedPlaceholdersDelegatesToMerge()
+    {
+        $modx = new FakeModX();
+        $user = new modUser($modx);
+        $user->set('id', 1);
+        $user->set('username', 'alice');
+
+        $out = sxUserProfile::authenticatedPlaceholders(
+            $modx,
+            $user,
+            array('id' => 9, 'name' => 'Newsletter')
+        );
+
+        $this->assertSame(9, $out['id']);
+        $this->assertSame('alice', $out['username']);
+        $this->assertSame('Newsletter', $out['name']);
+    }
+}

--- a/tests/Unit/NewsletterAddQueuesTest.php
+++ b/tests/Unit/NewsletterAddQueuesTest.php
@@ -81,7 +81,7 @@ class NewsletterAddQueuesTest extends TestCase
 
         $user = new modUser($this->modx);
         $user->set('id', 5);
-        $user->active = true;
+        $user->set('active', 1);
         $this->modx->users[5] = $user;
 
         $this->assertSame('sendex_newsletter_err_no_queues', $this->newsletter->addQueues());
@@ -101,7 +101,7 @@ class NewsletterAddQueuesTest extends TestCase
 
         $user = new modUser($this->modx);
         $user->set('id', 5);
-        $user->active = false;
+        $user->set('active', 0);
         $this->modx->users[5] = $user;
 
         $profile = new modUserProfile($this->modx);
@@ -127,7 +127,7 @@ class NewsletterAddQueuesTest extends TestCase
 
         $user = new modUser($this->modx);
         $user->set('id', 5);
-        $user->active = true;
+        $user->set('active', 1);
         $this->modx->users[5] = $user;
 
         $profile = new modUserProfile($this->modx);
@@ -175,7 +175,7 @@ class NewsletterAddQueuesTest extends TestCase
         for ($userId = 1; $userId <= 10; $userId++) {
             $user = new modUser($this->modx);
             $user->set('id', $userId);
-            $user->active = true;
+            $user->set('active', 1);
             $this->modx->users[$userId] = $user;
 
             $profile = new modUserProfile($this->modx);

--- a/tests/Unit/NewsletterDispatchTest.php
+++ b/tests/Unit/NewsletterDispatchTest.php
@@ -70,7 +70,7 @@ class NewsletterDispatchTest extends TestCase
 
         $user = new modUser($this->modx);
         $user->set('id', 5);
-        $user->active = false;
+        $user->set('active', 0);
         $this->modx->users[5] = $user;
 
         $queue = new sxQueue($this->modx);
@@ -111,7 +111,7 @@ class NewsletterDispatchTest extends TestCase
 
         $user = new modUser($this->modx);
         $user->set('id', 5);
-        $user->active = true;
+        $user->set('active', 1);
         $this->modx->users[5] = $user;
 
         $result = sxNewsletterDispatch::queueAndSend($this->newsletter);

--- a/tests/Unit/NewsletterQueueUsersTest.php
+++ b/tests/Unit/NewsletterQueueUsersTest.php
@@ -18,12 +18,12 @@ class NewsletterQueueUsersTest extends TestCase
     {
         $active = new modUser($this->modx);
         $active->set('id', 1);
-        $active->active = true;
+        $active->set('active', 1);
         $this->modx->users[1] = $active;
 
         $blocked = new modUser($this->modx);
         $blocked->set('id', 2);
-        $blocked->active = true;
+        $blocked->set('active', 1);
         $this->modx->users[2] = $blocked;
 
         $profile1 = new modUserProfile($this->modx);
@@ -51,7 +51,7 @@ class NewsletterQueueUsersTest extends TestCase
         for ($i = 1; $i <= 50; $i++) {
             $user = new modUser($this->modx);
             $user->set('id', $i);
-            $user->active = true;
+            $user->set('active', 1);
             $this->modx->users[$i] = $user;
 
             $profile = new modUserProfile($this->modx);

--- a/tests/Unit/NewsletterUpdateProcessorTest.php
+++ b/tests/Unit/NewsletterUpdateProcessorTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class NewsletterUpdateProcessorTest extends TestCase
+{
+    public function testUpdatePreservesActiveWhenPropertyOmitted()
+    {
+        $source = file_get_contents(
+            dirname(__DIR__, 2) . '/core/components/sendex/processors/mgr/newsletter/update.class.php'
+        );
+
+        $this->assertStringContainsString("array_key_exists('active', \$this->getProperties())", $source);
+        $this->assertStringNotContainsString(
+            "\$active = \$this->getProperty('active');\n        \$this->setProperty('active', !empty(\$active)",
+            $source
+        );
+    }
+}

--- a/tests/Unit/ProcessorBootstrapContractTest.php
+++ b/tests/Unit/ProcessorBootstrapContractTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class ProcessorBootstrapContractTest extends TestCase
+{
+    /** @var string */
+    private $base;
+
+    protected function setUp(): void
+    {
+        $this->base = dirname(__DIR__, 2) . '/core/components/sendex/processors/mgr/';
+    }
+
+    /**
+     * @return string[]
+     */
+    private function processorFiles()
+    {
+        $files = array();
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($this->base, FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if (!$file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+            $path = $file->getPathname();
+            if (substr($path, -strlen('sendexprocessor.class.php')) === 'sendexprocessor.class.php') {
+                continue;
+            }
+            $source = file_get_contents($path);
+            if (strpos($source, 'Processor') === false) {
+                continue;
+            }
+            $files[] = $path;
+        }
+
+        sort($files);
+
+        return $files;
+    }
+
+    public function testAllProcessorsReturnClassName()
+    {
+        foreach ($this->processorFiles() as $path) {
+            $source = file_get_contents($path);
+            $this->assertMatchesRegularExpression(
+                "/return\\s+'sx[A-Za-z0-9_]+Processor';/",
+                $source,
+                basename($path)
+            );
+        }
+    }
+
+    public function testProcessorReturnMatchesDeclaredClass()
+    {
+        foreach ($this->processorFiles() as $path) {
+            $source = file_get_contents($path);
+            if (!preg_match('/class\\s+(sx[A-Za-z0-9_]+Processor)/', $source, $classMatch)) {
+                $this->fail('Missing processor class in ' . basename($path));
+            }
+            if (!preg_match("/return\\s+'(sx[A-Za-z0-9_]+Processor)';/", $source, $returnMatch)) {
+                $this->fail('Missing return statement in ' . basename($path));
+            }
+
+            $this->assertSame($classMatch[1], $returnMatch[1], basename($path));
+        }
+    }
+
+    public function testSendexProcessorBaseRequiresProcessorInput()
+    {
+        $source = file_get_contents($this->base . 'sendexprocessor.class.php');
+
+        $this->assertStringContainsString('extends modProcessor', $source);
+        $this->assertStringContainsString('sxprocessorinput.class.php', $source);
+    }
+}

--- a/tests/Unit/QueueAddProcessorTest.php
+++ b/tests/Unit/QueueAddProcessorTest.php
@@ -33,7 +33,7 @@ class QueueAddProcessorTest extends TestCase
 
         $user = new modUser($this->modx);
         $user->set('id', 5);
-        $user->active = true;
+        $user->set('active', 1);
         $this->modx->users[5] = $user;
 
         $processor = new sxQueueAddProcessor($this->modx, array('newsletter_id' => 10));

--- a/tests/Unit/SnippetNewsletterScopeTest.php
+++ b/tests/Unit/SnippetNewsletterScopeTest.php
@@ -40,5 +40,32 @@ class SnippetNewsletterScopeTest extends TestCase
             'newsletter_id' => '1',
             'sendex_widget_key' => 'confirm',
         )));
+        $this->assertFalse(sxSubscribeAjaxResponse::matchesRequest(1, 'instant', array(
+            'newsletter_id' => '1',
+            'sx_action' => 'subscribe',
+        )));
+    }
+
+    public function testEmailLinkWithoutWidgetKeyHandledByDefaultInstanceOnly()
+    {
+        $request = array(
+            'newsletter_id' => '1',
+            'sx_action' => 'unsubscribe',
+            'code' => 'abc',
+        );
+
+        $this->assertTrue(sxSubscribeAjaxResponse::matchesRequest(1, '', $request));
+        $this->assertFalse(sxSubscribeAjaxResponse::matchesRequest(1, 'unsubscribe', $request));
+    }
+
+    public function testMatchesRequestUsesNewsletterIdNotSubscriberId()
+    {
+        $request = array(
+            'newsletter_id' => '5',
+            'sx_action' => 'subscribe',
+        );
+
+        $this->assertTrue(sxSubscribeAjaxResponse::matchesRequest(5, '', $request));
+        $this->assertFalse(sxSubscribeAjaxResponse::matchesRequest(42, '', $request));
     }
 }

--- a/tests/Unit/SnippetNewsletterScopeTest.php
+++ b/tests/Unit/SnippetNewsletterScopeTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2)
+    . '/core/components/sendex/model/sendex/sxsubscribeajaxresponse.class.php';
+
+class SnippetNewsletterScopeTest extends TestCase
+{
+    public function testMatchesNewsletterWhenHiddenFieldMissing()
+    {
+        $this->assertTrue(sxSubscribeAjaxResponse::matchesNewsletter(1, array(
+            'sx_action' => 'subscribe',
+        )));
+    }
+
+    public function testMatchesNewsletterWhenHiddenFieldMatches()
+    {
+        $this->assertTrue(sxSubscribeAjaxResponse::matchesNewsletter(5, array(
+            'newsletter_id' => '5',
+            'sx_action' => 'subscribe',
+        )));
+    }
+
+    public function testSkipsWhenHiddenFieldTargetsAnotherNewsletter()
+    {
+        $this->assertFalse(sxSubscribeAjaxResponse::matchesNewsletter(1, array(
+            'newsletter_id' => '2',
+            'sx_action' => 'subscribe',
+        )));
+    }
+
+    public function testMatchesRequestRequiresWidgetKeyWhenSet()
+    {
+        $this->assertTrue(sxSubscribeAjaxResponse::matchesRequest(1, 'instant', array(
+            'newsletter_id' => '1',
+            'sendex_widget_key' => 'instant',
+        )));
+        $this->assertFalse(sxSubscribeAjaxResponse::matchesRequest(1, 'instant', array(
+            'newsletter_id' => '1',
+            'sendex_widget_key' => 'confirm',
+        )));
+    }
+}

--- a/tests/Unit/UserPlaceholdersTest.php
+++ b/tests/Unit/UserPlaceholdersTest.php
@@ -41,7 +41,7 @@ class UserPlaceholdersTest extends TestCase
         );
         $this->assertNotFalse($snippet);
         $this->assertStringNotContainsString('->Profile->', $snippet);
-        $this->assertStringContainsString('sxUserPlaceholders::mergeAuthenticated', $snippet);
-        $this->assertStringContainsString("getOne('Profile')", $snippet);
+        $this->assertStringContainsString('sxUserProfile::authenticatedPlaceholders', $snippet);
+        $this->assertStringNotContainsString("getOne('Profile')", $snippet);
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,6 +17,7 @@ require_once __DIR__ . '/Stubs/sxSubscriber.php';
 require_once __DIR__ . '/Stubs/sxQueue.php';
 require_once __DIR__ . '/Stubs/FakeMail.php';
 require_once __DIR__ . '/Stubs/FakeModX.php';
+require_once __DIR__ . '/Stubs/FakeModxServices.php';
 require_once __DIR__ . '/Stubs/FakePdoConnection.php';
 require_once __DIR__ . '/Stubs/FakePdoStatement.php';
 require_once __DIR__ . '/Stubs/modProcessor.php';


### PR DESCRIPTION
Кратко: transport-пакет Sendex ставится на MODX 3.2.0-pl без flood legacy-class ошибок; namespace/menu/bootstrap на границе `_build/`, домен `sx*` без переименования.

## Что сделано
- `PKG_ASSETS_PATH` + 5-й аргумент `registerNamespace` в `_build/build.transport.php`
- `sendexEnsureBuildClassAliases()` — alias `modPackageBuilder` на MODX 3
- `sendexShouldRegenerateModel()` — не запускать `build.model.php` на MODX 3 (генератор переписывает maps в `sendex\sx*`)
- `_build/data/transport.menu.php` — `modMenu.action` + `namespace` без `modAction` на MODX 3
- Phinx: `$sendexTableNames` вместо конфликта с `AbstractMigration::$tables` (PHP 8.4)
- README: секция MODX 3 compatibility
- тесты: `tests/Unit/BuildTransportModx3ContractTest.php` (5 кейсов)
- миграция: не нужна (правка существующей migration class, без изменения схемы)

## Почему так
Compatibility layer на границе package build (`_build/`), без `if MODX3` в домене. Глобальные `sx*` классы сохраняются — issue #40 явно запрещает `MODX\Revolution\sx*`.

## Review
- Findings: нет (pass 1 и pass 2: /code-review, code-reviewer, thermo-nuclear)

## Проверка
- `composer test` — exit 0 (202 tests, +5 в `BuildTransportModx3ContractTest`)
- `phpcs` — exit 0 (изменённые PHP)
- MODX 3.2.0-pl (`project.test`): `php _build/build.transport.php` — install OK, migrations OK, `modx_sendex_*` таблицы, namespace `assets_path={assets_path}components/sendex/`, menu `action=index namespace=sendex`, без «Could not find legacy class»
- MODX 2 install: не прогонялся (нет локального MODX 2); обратная совместимость — 5-й аргумент `registerNamespace` безопасен в PHP, `build.model.php` по-прежнему на MODX 2

Fixes #40
Refs #74