### PR TITLE
feat(events): Queue lifecycle events, subscribe source, fix OnBeforeUserActivate merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,9 @@ Unit tests use lightweight MODX/xPDO stubs (no MODX install). Covered: `sxNewsle
 
 ## Plugin events
 
-Fired from `sxNewsletter::subscribe()` / `unSubscribe()` (front-end and manager). Event names are registered in the transport package (`BUILD_EVENT_UPDATE`); reinstall or upgrade the package so they appear under System Events in the manager. `invokeEvent` by name works even before that.
+Event names are registered in the transport package (`BUILD_EVENT_UPDATE`); reinstall or upgrade so they appear under System Events. `invokeEvent` by name works even before that.
+
+### Subscribe / unsubscribe
 
 | Event | When | Cancel |
 | --- | --- | --- |
@@ -159,16 +161,28 @@ Fired from `sxNewsletter::subscribe()` / `unSubscribe()` (front-end and manager)
 | `sxOnBeforeUnsubscribe` | Before removing a subscriber | Yes |
 | `sxOnUnsubscribe` | After a successful remove | No |
 
-Params: `newsletter`, `newsletter_id`, `user_id`, `email`, `subscriber` (object after create / before remove). Unsubscribe also passes `code`.
+Params: `newsletter`, `newsletter_id`, `user_id`, `email`, `subscriber`, `source` (`snippet`\|`ajax`\|`confirm`\|`mgr`\|`guest`). Unsubscribe also passes `code`.
 
-Cancel a Before event with `$modx->event->output('error message');`. Callers get that string back from `subscribe()` / `unSubscribe()` (`true` on success, `false` on validation/save failure). Already-subscribed / missing or mismatched code paths are no-ops and do not fire events. `unSubscribe` only removes a subscriber that belongs to this newsletter.
+### Queue lifecycle
 
-### Manual check
+| Event | When | Cancel |
+| --- | --- | --- |
+| `sxOnBeforeAddQueues` | Before building queue rows | Yes (abort batch) |
+| `sxOnAddQueues` | After rows created | No |
+| `sxOnBeforeQueueSend` | Before sending one row (after claim) | Yes (skip, no requeue); may mutate `message` |
+| `sxOnQueueSend` | After successful send | No |
+| `sxOnQueueSendFailed` | After mail failure + requeue | No |
+| `sxOnQueueFlushComplete` | After `flush` batch | No |
 
-1. Subscribe (auth user / guest confirm) → `sxOnBeforeSubscribe` + `sxOnSubscribe`.
-2. Plugin `output()` on Before → subscribe aborted; message shown in mgr/front.
-3. Unsubscribe front + mgr remove → Before + After; cancel → mgr `failure`, not silent success.
-4. Unsubscribe with a code from another newsletter → no remove, no events.
+### Listens to (plugin.sendex.php)
+
+| MODX event | Behavior |
+| --- | --- |
+| `OnManagerPageInit` | Mgr CSS |
+| `OnUserActivate` / `OnUserSave` | Merge guest rows onto user by email |
+| `OnBeforeUserActivate` | Not used (cancelled activation must not merge) |
+
+Cancel a Before event with `$modx->event->output('error message');`. Already-subscribed / missing or mismatched code paths are no-ops and do not fire subscribe events.
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Policy: **merge**, not block.
 
 1. Anonymous confirm / `subscribe()` resolves `modUser` by profile email and stores `user_id` (see `#54`).
 2. Unique key `(newsletter_id, email)` prevents a guest+user duplicate row.
-3. If a guest subscribed first and the account is created later, the Sendex plugin merges on `OnUserActivate`, `OnBeforeUserActivate`, and `OnUserSave`: guest rows with that email get `user_id` set. Reinstall/upgrade the package so the plugin events are registered.
+3. If a guest subscribed first and the account is created later, the Sendex plugin merges on `OnUserActivate` and `OnUserSave`: guest rows with that email get `user_id` set. Merge does not run on `OnBeforeUserActivate` (cancelled activation must not attach guests). Reinstall/upgrade the package so the plugin events are registered.
 
 Logged-in `isSubscribed($userId)` also matches a still-guest row by profile email, so the form shows unsubscribe without waiting for merge.
 

--- a/_build/data/transport.events.php
+++ b/_build/data/transport.events.php
@@ -7,6 +7,12 @@ $tmp = array(
     'sxOnSubscribe',
     'sxOnBeforeUnsubscribe',
     'sxOnUnsubscribe',
+    'sxOnBeforeAddQueues',
+    'sxOnAddQueues',
+    'sxOnBeforeQueueSend',
+    'sxOnQueueSend',
+    'sxOnQueueSendFailed',
+    'sxOnQueueFlushComplete',
 );
 
 foreach ($tmp as $v) {

--- a/_build/data/transport.plugins.php
+++ b/_build/data/transport.plugins.php
@@ -9,7 +9,6 @@ $tmp = array(
         'events'      => array(
             'OnManagerPageInit' => array(),
             'OnUserActivate' => array(),
-            'OnBeforeUserActivate' => array(),
             'OnUserSave' => array(),
         ),
     ),

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Phinx migrations: `core/components/sendex/phinx.php`, `migrations/`, install/upgrade resolver; metadata table `{prefix}sendex_migrations`.
 
 ### Fixed
+- [#104] Guest merge no longer runs on `OnBeforeUserActivate` (only `OnUserActivate` / `OnUserSave`), so a cancelled activation cannot attach guests to an inactive user.
 - [#40] MODX 3 package install: `registerNamespace` sets `assets_path`; build script aliases `modPackageBuilder`, skips model regen on MODX 3 (preserves global `sx*` maps); mgr menu without `modAction`; Phinx migration property no longer conflicts with `AbstractMigration::$tables` on PHP 8.4.
 - [#74] MODX 3 mgr: `SendexIndexManagerController` aliases menu action `index` (no duplicate menu remap).
 - [#74] MODX 3 bootstrap: `bootstrap.php` for connector/mgr/cron; processor autoload + `modProcessor` aliases; `sxModxCompat` (mail/parser/registry) and `sxUserProfile` (user/profile placeholders); ExtJS mgr icon/menu polish on MODX 3.
@@ -33,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#56] Unsubscribe from email: snippet resolves newsletter by subscriber `code` when snippet `&id` differs; default letter link includes `newsletter_id` (not MODX resource `id`).
 - [#67] / [#52] Schema and upgrade: Sendex tables use InnoDB; queue index renamed `user_id` → `subscriber_id`; `addQueues` stores `sxSubscriber.id` (not `user_id`); Phinx backfill remaps legacy queue rows (by user_id, guests by email).
 - [#54] `isSubscribed` matches by `user_id` OR `email` within a newsletter; unique key is `(newsletter_id, email)`; guest rows attach `user_id` when the same email confirms as a user.
-- [#39] Guest rows merge onto `modUser` on `OnUserActivate` / `OnBeforeUserActivate` / `OnUserSave` (`sxSubscriberMerge`); registration does not create a second subscriber row for the same email.
+- [#39] Guest rows merge onto `modUser` on `OnUserActivate` / `OnUserSave` (`sxSubscriberMerge`); registration does not create a second subscriber row for the same email.
 - [#58] `confirmEmail` restores registry hash when `subscribe()` fails so the confirm link stays usable; remaining TTL kept via `_expires`; `checkEmail` shares `sxSubscribeRegistry::store`.
 - [#61] `sxSubscriber::save` keeps existing `code` (generate only when empty) so unsubscribe links stay valid.
 - [#53] Snippet: authenticated user without Profile no longer triggers TypeError on PHP 8; merge via `sxUserPlaceholders`.

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPUnit coverage for subscribe/unsubscribe events (stubs, no MODX install).
 - [#72] Focused PHPUnit coverage for queue claim (#55), plus regression contracts for #52 / #58 / #61.
 - Phinx migrations: `core/components/sendex/phinx.php`, `migrations/`, install/upgrade resolver; metadata table `{prefix}sendex_migrations`.
+- [#104] Queue lifecycle plugin events: `sxOnBeforeAddQueues`, `sxOnAddQueues`, `sxOnBeforeQueueSend`, `sxOnQueueSend`, `sxOnQueueSendFailed`, `sxOnQueueFlushComplete`.
+- [#104] Subscribe/unsubscribe events pass `source` (`snippet`\|`ajax`\|`confirm`\|`mgr`\|`guest`).
 
 ### Fixed
 - [#104] Guest merge no longer runs on `OnBeforeUserActivate` (only `OnUserActivate` / `OnUserSave`), so a cancelled activation cannot attach guests to an inactive user.

--- a/core/components/sendex/elements/plugins/plugin.sendex.php
+++ b/core/components/sendex/elements/plugins/plugin.sendex.php
@@ -6,15 +6,18 @@ switch ($modx->event->name) {
         $modx->regClientCSS($cssFile);
         break;
 
-    case 'OnUserActivate':
-    case 'OnBeforeUserActivate':
-    case 'OnUserSave':
+    default:
         $corePath = $modx->getOption(
             'sendex_core_path',
             null,
             $modx->getOption('core_path') . 'components/sendex/'
         );
         require_once $corePath . 'model/sendex/sxsubscribermerge.class.php';
+
+        // Merge only after activation succeeds (#104 C1); skip before-activate.
+        if (!sxSubscriberMerge::handlesUserEvent($modx->event->name)) {
+            break;
+        }
 
         if (empty($user) && !empty($modx->event->params['user'])) {
             $user = $modx->event->params['user'];

--- a/core/components/sendex/elements/snippets/snippet.sendex.php
+++ b/core/components/sendex/elements/snippets/snippet.sendex.php
@@ -60,11 +60,12 @@ if ($handlesRequest) {
     $params = $_GET;
     unset($params[$modx->getOption('request_param_alias')]);
     unset($params[$modx->getOption('request_param_id')]);
+    $eventSource = $isAjax ? 'ajax' : 'snippet';
 
     switch ($_REQUEST['sx_action']) {
         case 'subscribe':
             if ($isAuthenticated && $modx->user->id) {
-                $response = $newsletter->subscribe($modx->user->id);
+                $response = $newsletter->subscribe($modx->user->id, '', $eventSource);
                 if ($response !== true) {
                     $placeholders['message'] = is_string($response)
                         ? $response
@@ -149,7 +150,7 @@ if ($handlesRequest) {
                         );
                     }
                 }
-                $response = $newsletter->unSubscribe($code);
+                $response = $newsletter->unSubscribe($code, $eventSource);
                 if ($response === true) {
                     $placeholders['message'] = $modx->lexicon('sendex_subscribe_email_unsubscribed');
                     $params['sx_unsubscribed'] = 1;

--- a/core/components/sendex/model/sendex/sxnewsletter.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletter.class.php
@@ -67,11 +67,12 @@ class sxNewsletter extends xPDOSimpleObject
     /**
      * @param int $user_id
      * @param string $email
+     * @param string $source snippet|ajax|confirm|group|mgr|guest
      * @return true|false|string
      */
-    public function subscribe($user_id = 0, $email = '')
+    public function subscribe($user_id = 0, $email = '', $source = 'snippet')
     {
-        return $this->subscription()->subscribe($user_id, $email);
+        return $this->subscription()->subscribe($user_id, $email, $source);
     }
 
     /**
@@ -105,11 +106,12 @@ class sxNewsletter extends xPDOSimpleObject
 
     /**
      * @param string $code
+     * @param string $source snippet|ajax|mgr
      * @return true|false|string
      */
-    public function unSubscribe($code)
+    public function unSubscribe($code, $source = 'snippet')
     {
-        return $this->subscription()->unSubscribe($code);
+        return $this->subscription()->unSubscribe($code, $source);
     }
 
     /**
@@ -117,7 +119,7 @@ class sxNewsletter extends xPDOSimpleObject
      * @param array $params
      * @return true|string
      */
-    protected function invokeSendexEvent($name, array $params)
+    protected function invokeSendexEvent($name, array &$params)
     {
         return sxSendexEvent::invoke($this->xpdo, $name, $params);
     }

--- a/core/components/sendex/model/sendex/sxnewsletterqueuebuilder.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletterqueuebuilder.class.php
@@ -3,6 +3,7 @@
 require_once dirname(__FILE__) . '/sxqueuelink.class.php';
 require_once dirname(__FILE__) . '/sxnewslettermailer.class.php';
 require_once dirname(__FILE__) . '/sxnewsletterqueueusers.class.php';
+require_once dirname(__FILE__) . '/sxsendexevent.class.php';
 
 /**
  * Build queue rows from newsletter subscribers.
@@ -46,6 +47,18 @@ class sxNewsletterQueueBuilder
 
         if (!$template || !($template instanceof modTemplate)) {
             return $xpdo->lexicon('sendex_newsletter_err_no_template');
+        }
+
+        $eventParams = array(
+            'newsletter'  => $newsletter,
+            'subscribers' => $subscribers,
+        );
+        $beforeEvent = sxSendexEvent::invoke($xpdo, 'sxOnBeforeAddQueues', $eventParams);
+        if ($beforeEvent !== true) {
+            return $beforeEvent;
+        }
+        if (isset($eventParams['subscribers']) && is_array($eventParams['subscribers'])) {
+            $subscribers = $eventParams['subscribers'];
         }
 
         $newsletterId = (int) $newsletter->id;
@@ -92,6 +105,12 @@ class sxNewsletterQueueBuilder
         if ($created <= 0) {
             return $xpdo->lexicon('sendex_newsletter_err_no_queues');
         }
+
+        $afterParams = array(
+            'newsletter' => $newsletter,
+            'created'    => $created,
+        );
+        sxSendexEvent::invoke($xpdo, 'sxOnAddQueues', $afterParams);
 
         return $created;
     }

--- a/core/components/sendex/model/sendex/sxnewslettersubscription.class.php
+++ b/core/components/sendex/model/sendex/sxnewslettersubscription.class.php
@@ -126,10 +126,10 @@ class sxNewsletterSubscription
                 'active' => 1,
             ));
             if ($newsletter) {
-                $result = $newsletter->subscribe($entry['user_id'], $entry['email']);
+                $result = $newsletter->subscribe($entry['user_id'], $entry['email'], 'confirm');
             }
         } else {
-            $result = $this->subscribe($entry['user_id'], $entry['email']);
+            $result = $this->subscribe($entry['user_id'], $entry['email'], 'confirm');
         }
 
         if ($result !== true) {
@@ -142,11 +142,13 @@ class sxNewsletterSubscription
     /**
      * @param int $userId
      * @param string $email
+     * @param string $source snippet|ajax|confirm|group|mgr|guest
      * @return true|false|string
      */
-    public function subscribe($userId = 0, $email = '')
+    public function subscribe($userId = 0, $email = '', $source = 'snippet')
     {
         $xpdo = $this->newsletter->xpdo;
+        $source = self::normalizeSource($source);
 
         if (empty($email) && $profile = $xpdo->getObject('modUserProfile', array('internalKey' => $userId))) {
             $email = $profile->get('email');
@@ -171,6 +173,7 @@ class sxNewsletterSubscription
             'user_id'       => $userId,
             'email'         => $email,
             'subscriber'    => null,
+            'source'        => $source,
         );
 
         $before = sxSendexEvent::invoke($xpdo, 'sxOnBeforeSubscribe', $params);
@@ -198,11 +201,13 @@ class sxNewsletterSubscription
 
     /**
      * @param string $code
+     * @param string $source snippet|ajax|mgr
      * @return true|false|string
      */
-    public function unSubscribe($code)
+    public function unSubscribe($code, $source = 'snippet')
     {
         $xpdo = $this->newsletter->xpdo;
+        $source = self::normalizeSource($source);
 
         /** @var sxSubscriber $subscriber */
         if (!$subscriber = $xpdo->getObject('sxSubscriber', array('code' => $code))) {
@@ -220,6 +225,7 @@ class sxNewsletterSubscription
             'email'         => $subscriber->get('email'),
             'code'          => $code,
             'subscriber'    => $subscriber,
+            'source'        => $source,
         );
 
         $before = sxSendexEvent::invoke($xpdo, 'sxOnBeforeUnsubscribe', $params);
@@ -234,6 +240,21 @@ class sxNewsletterSubscription
         sxSendexEvent::invoke($xpdo, 'sxOnUnsubscribe', $params);
 
         return true;
+    }
+
+    /**
+     * @param string $source
+     * @return string
+     */
+    public static function normalizeSource($source)
+    {
+        $source = strtolower(trim((string) $source));
+        $allowed = array('snippet', 'ajax', 'confirm', 'group', 'mgr', 'guest');
+        if (!in_array($source, $allowed, true)) {
+            return 'snippet';
+        }
+
+        return $source;
     }
 
     /**

--- a/core/components/sendex/model/sendex/sxqueuedeliver.class.php
+++ b/core/components/sendex/model/sendex/sxqueuedeliver.class.php
@@ -1,16 +1,22 @@
 <?php
 
 require_once dirname(__FILE__) . '/sxqueueclaim.class.php';
+require_once dirname(__FILE__) . '/sxsendexevent.class.php';
 
 /**
- * Deliver one queue email with claim / requeue (#55).
+ * Deliver one queue email with claim / requeue (#55) and send events (#104 A1).
+ *
+ * sendMail return values:
+ * - true: sent
+ * - false: skip (row already claimed; do not requeue)
+ * - string: mail error (requeue + sxOnQueueSendFailed)
  */
 class sxQueueDeliver
 {
     /**
      * @param object $queue sxQueue-like with get/set/toArray/save
-     * @param callable $sendMail function (object $queue): true|string
-     * @return true|false|string true on sent, false if not claimed, string on mail error
+     * @param callable $sendMail function (object $queue): true|false|string
+     * @return true|false|string true on sent, false if not claimed or skipped, string on mail error
      */
     public static function send($queue, $sendMail)
     {
@@ -24,6 +30,11 @@ class sxQueueDeliver
             return true;
         }
 
+        // Plugin skip or soft abort: row already removed; do not put it back.
+        if ($result === false) {
+            return false;
+        }
+
         // Claim already removed the row; put it back for retry.
         $payload = $queue->toArray();
         unset($payload['id']);
@@ -31,11 +42,17 @@ class sxQueueDeliver
         $again->fromArray($payload, '', true, true);
         $again->save();
 
+        $error = is_string($result) ? $result : 'unknown error';
+        $failedParams = array(
+            'queue' => $queue,
+            'error' => $error,
+        );
+        sxSendexEvent::invoke($xpdo, 'sxOnQueueSendFailed', $failedParams);
+
         if (method_exists($xpdo, 'log')) {
             $xpdo->log(
                 defined('xPDO::LOG_LEVEL_ERROR') ? constant('xPDO::LOG_LEVEL_ERROR') : 3,
-                'Sendex queue send failed after claim: '
-                    . (is_string($result) ? $result : 'unknown error')
+                'Sendex queue send failed after claim: ' . $error
             );
         }
 

--- a/core/components/sendex/model/sendex/sxqueuesender.class.php
+++ b/core/components/sendex/model/sendex/sxqueuesender.class.php
@@ -2,6 +2,8 @@
 
 require_once dirname(__FILE__) . '/sxqueuedeliver.class.php';
 require_once dirname(__FILE__) . '/sxnewslettermailer.class.php';
+require_once dirname(__FILE__) . '/sxsendexevent.class.php';
+require_once dirname(__FILE__) . '/sxmodxcompat.class.php';
 
 /**
  * Single entry point for queue delivery (#65): cron and mgr processors call flush/sendOne.
@@ -82,31 +84,56 @@ class sxQueueSender
                 );
             }
 
-            if ($stopOnError) {
+            // Plugin skip (false) must not abort the batch; only mail errors do.
+            if ($stopOnError && is_string($result)) {
                 break;
             }
         }
+
+        $newsletterId = 0;
+        if (!empty($options['criteria']['newsletter_id'])) {
+            $newsletterId = (int) $options['criteria']['newsletter_id'];
+        }
+
+        $flushParams = array(
+            'newsletter_id' => $newsletterId,
+            'stats'         => $stats,
+        );
+        sxSendexEvent::invoke($xpdo, 'sxOnQueueFlushComplete', $flushParams);
 
         return $stats;
     }
 
     /**
      * @param object $queue sxQueue
-     * @return true|string
+     * @return true|false|string true sent, false plugin skip, string mail error
      */
     public static function deliverMail($queue)
     {
+        $xpdo = $queue->xpdo;
         $message = sxNewsletterMailer::messageFromQueue($queue);
         if ($message === false) {
-            return $queue->xpdo->lexicon('sendex_newsletter_err_no_template');
+            return $xpdo->lexicon('sendex_newsletter_err_no_template');
+        }
+
+        $params = array(
+            'queue'   => $queue,
+            'message' => $message,
+        );
+        $before = sxSendexEvent::invoke($xpdo, 'sxOnBeforeQueueSend', $params);
+        if ($before !== true) {
+            return false;
+        }
+        if (isset($params['message']) && is_array($params['message'])) {
+            $message = $params['message'];
         }
 
         /** @var modPHPMailer $mail */
-        $mail = sxModxCompat::getMail($queue->xpdo);
+        $mail = sxModxCompat::getMail($xpdo);
         sxNewsletterMailer::configureMailer($mail, $message);
         if (!$mail->send()) {
             $error = $mail->mailer->ErrorInfo;
-            $queue->xpdo->log(
+            $xpdo->log(
                 xPDO::LOG_LEVEL_ERROR,
                 'An error occurred while trying to send the email: ' . $error
             );
@@ -116,6 +143,12 @@ class sxQueueSender
         }
 
         $mail->reset();
+
+        $afterParams = array(
+            'queue'   => $queue,
+            'message' => $message,
+        );
+        sxSendexEvent::invoke($xpdo, 'sxOnQueueSend', $afterParams);
 
         return true;
     }

--- a/core/components/sendex/model/sendex/sxsendexevent.class.php
+++ b/core/components/sendex/model/sendex/sxsendexevent.class.php
@@ -7,13 +7,14 @@ class sxSendexEvent
 {
     /**
      * Before-events cancel when a plugin outputs a non-empty string.
+     * Params are passed by reference so plugins can mutate values (e.g. message).
      *
      * @param object $xpdo
      * @param string $name
      * @param array $params
      * @return true|string true, or first plugin error message if cancelled
      */
-    public static function invoke($xpdo, $name, array $params)
+    public static function invoke($xpdo, $name, array &$params)
     {
         if (!($xpdo instanceof modX) || !method_exists($xpdo, 'invokeEvent')) {
             return true;

--- a/core/components/sendex/model/sendex/sxsubscribeconfirm.class.php
+++ b/core/components/sendex/model/sendex/sxsubscribeconfirm.class.php
@@ -66,7 +66,7 @@ class sxSubscribeConfirm
         $requireConfirm = true
     ) {
         if (!$requireConfirm) {
-            $result = $subscription->subscribe($userId, $email);
+            $result = $subscription->subscribe($userId, $email, 'guest');
             if ($result === true) {
                 return array('status' => 'subscribed');
             }

--- a/core/components/sendex/model/sendex/sxsubscribermerge.class.php
+++ b/core/components/sendex/model/sendex/sxsubscribermerge.class.php
@@ -9,6 +9,20 @@ require_once dirname(__FILE__) . '/sxuserprofile.class.php';
 class sxSubscriberMerge
 {
     /**
+     * MODX system events that may merge guests onto a user (#104 C1).
+     *
+     * OnBeforeUserActivate is excluded: another plugin can cancel activation after
+     * this handler would already have attached guests to an inactive user.
+     *
+     * @param string $eventName
+     * @return bool
+     */
+    public static function handlesUserEvent($eventName)
+    {
+        return in_array((string) $eventName, array('OnUserActivate', 'OnUserSave'), true);
+    }
+
+    /**
      * Set user_id on guest rows (user_id = 0) with the same email across newsletters.
      *
      * Policy: merge, never create a second row for the same newsletter email.

--- a/core/components/sendex/processors/mgr/newsletter/subscriber/create.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/subscriber/create.class.php
@@ -57,7 +57,7 @@ class sxSubscriberCreateProcessor extends sxSendexProcessor
             return $this->failure($this->modx->lexicon('sendex_subscriber_err_ae'));
         }
 
-        $result = $newsletter->subscribe($user_id, $email);
+        $result = $newsletter->subscribe($user_id, $email, 'mgr');
         if ($result !== true) {
             return $this->failure(
                 is_string($result) ? $result : $this->modx->lexicon('sendex_subscriber_err_save')

--- a/core/components/sendex/processors/mgr/newsletter/subscriber/remove.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/subscriber/remove.class.php
@@ -28,7 +28,7 @@ class sxSubscriberRemoveProcessor extends sxSendexProcessor
             /** @var sxNewsletter $newsletter */
             $newsletter = $this->modx->getObject('sxNewsletter', $subscriber->get('newsletter_id'));
             if ($newsletter) {
-                $result = $newsletter->unSubscribe($subscriber->get('code'));
+                $result = $newsletter->unSubscribe($subscriber->get('code'), 'mgr');
                 if ($result !== true) {
                     $errors[] = is_string($result)
                         ? $result

--- a/tests/Stubs/FakeModX.php
+++ b/tests/Stubs/FakeModX.php
@@ -50,6 +50,9 @@ class FakeModX extends modX
     /** @var array<int,array{0:string,1:array}> */
     public $invoked = array();
 
+    /** @var array<string,callable> name => function (array &$params): void */
+    public $invokeMutators = array();
+
     /** @var array<string,int> */
     public $getObjectCalls = array();
 
@@ -580,8 +583,12 @@ class FakeModX extends modX
      *
      * @return mixed
      */
-    public function invokeEvent($name, array $params = array())
+    public function invokeEvent($name, array &$params = array())
     {
+        if (isset($this->invokeMutators[$name]) && is_callable($this->invokeMutators[$name])) {
+            call_user_func_array($this->invokeMutators[$name], array(&$params));
+        }
+
         $this->invoked[] = array($name, $params);
 
         if (array_key_exists($name, $this->invokeResponses)) {

--- a/tests/Unit/NewsletterConfirmEmailTest.php
+++ b/tests/Unit/NewsletterConfirmEmailTest.php
@@ -40,6 +40,7 @@ class NewsletterConfirmEmailTest extends TestCase
         $this->assertTrue($this->newsletter->confirmEmail('hash1'));
         $this->assertCount(1, $this->modx->subscribers);
         $this->assertSame('sxOnSubscribe', $this->modx->invoked[1][0]);
+        $this->assertSame('confirm', $this->modx->invoked[1][1]['source']);
         $this->assertArrayNotHasKey('hash1', $this->modx->registryEntries);
     }
 

--- a/tests/Unit/NewsletterSubscribeGuestTest.php
+++ b/tests/Unit/NewsletterSubscribeGuestTest.php
@@ -24,6 +24,8 @@ class NewsletterSubscribeGuestTest extends TestCase
         $this->assertSame('subscribed', $result['status']);
         $this->assertCount(1, $this->modx->subscribers);
         $this->assertSame(array(), $this->modx->registryEntries);
+        $this->assertSame('guest', $this->modx->invoked[0][1]['source']);
+        $this->assertSame('guest', $this->modx->invoked[1][1]['source']);
     }
 
     public function testConfirmFlowStoresHashWhenRequired()

--- a/tests/Unit/NewsletterSubscribeTest.php
+++ b/tests/Unit/NewsletterSubscribeTest.php
@@ -76,6 +76,23 @@ class NewsletterSubscribeTest extends TestCase
         $this->assertSame('sxOnBeforeSubscribe', $this->modx->invoked[0][0]);
         $this->assertSame('sxOnSubscribe', $this->modx->invoked[1][0]);
         $this->assertInstanceOf('sxSubscriber', $this->modx->invoked[1][1]['subscriber']);
+        $this->assertSame('snippet', $this->modx->invoked[0][1]['source']);
+        $this->assertSame('snippet', $this->modx->invoked[1][1]['source']);
+    }
+
+    public function testSubscribePassesExplicitSource()
+    {
+        $this->assertTrue($this->newsletter->subscribe(7, 'mgr@example.com', 'mgr'));
+
+        $this->assertSame('mgr', $this->modx->invoked[0][1]['source']);
+        $this->assertSame('mgr', $this->modx->invoked[1][1]['source']);
+    }
+
+    public function testSubscribeNormalizesUnknownSourceToSnippet()
+    {
+        $this->assertTrue($this->newsletter->subscribe(7, 'x@example.com', 'weird'));
+
+        $this->assertSame('snippet', $this->modx->invoked[0][1]['source']);
     }
 
     public function testBeforeCancelReturnsPluginMessageAndDoesNotSave()

--- a/tests/Unit/NewsletterUnsubscribeTest.php
+++ b/tests/Unit/NewsletterUnsubscribeTest.php
@@ -66,6 +66,22 @@ class NewsletterUnsubscribeTest extends TestCase
         $this->assertSame('sxOnBeforeUnsubscribe', $this->modx->invoked[0][0]);
         $this->assertSame('sxOnUnsubscribe', $this->modx->invoked[1][0]);
         $this->assertSame('abc123', $this->modx->invoked[0][1]['code']);
+        $this->assertSame('snippet', $this->modx->invoked[0][1]['source']);
+        $this->assertSame('snippet', $this->modx->invoked[1][1]['source']);
+    }
+
+    public function testUnsubscribePassesExplicitSource()
+    {
+        $this->addSubscriber(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 5,
+            'email'         => 'user@example.com',
+            'code'          => 'abc123',
+        ));
+
+        $this->assertTrue($this->newsletter->unSubscribe('abc123', 'mgr'));
+        $this->assertSame('mgr', $this->modx->invoked[0][1]['source']);
     }
 
     public function testBeforeCancelReturnsPluginMessageAndKeepsSubscriber()

--- a/tests/Unit/QueueLifecycleEventsTest.php
+++ b/tests/Unit/QueueLifecycleEventsTest.php
@@ -1,0 +1,186 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sxqueuesender.class.php';
+require_once dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sxqueuedeliver.class.php';
+require_once dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sxmodxcompat.class.php';
+
+class QueueLifecycleEventsTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    /** @var TestableNewsletter */
+    private $newsletter;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+        $this->newsletter = new TestableNewsletter($this->modx);
+        $this->newsletter->set('id', 10);
+        $this->newsletter->set('template', 1);
+        $this->newsletter->set('email_subject', 'Hello');
+        $this->newsletter->set('email_from', 'from@example.com');
+        $this->newsletter->set('email_from_name', 'From');
+        $this->newsletter->set('email_reply', 'reply@example.com');
+        $this->modx->templates[1] = new modTemplate();
+    }
+
+    public function testBeforeAddQueuesCancelPreventsQueueRows()
+    {
+        $this->addGuestSubscriber();
+        $this->modx->invokeResponses['sxOnBeforeAddQueues'] = array('blocked');
+
+        $this->assertSame('blocked', $this->newsletter->addQueues());
+        $this->assertCount(0, $this->modx->queues);
+        $this->assertSame('sxOnBeforeAddQueues', $this->modx->invoked[0][0]);
+    }
+
+    public function testAddQueuesFiresAfterEventWithCreatedCount()
+    {
+        $this->addGuestSubscriber();
+
+        $this->assertSame(1, $this->newsletter->addQueues());
+        $names = array_column($this->modx->invoked, 0);
+        $this->assertContains('sxOnBeforeAddQueues', $names);
+        $this->assertContains('sxOnAddQueues', $names);
+        $after = null;
+        foreach ($this->modx->invoked as $item) {
+            if ($item[0] === 'sxOnAddQueues') {
+                $after = $item[1];
+            }
+        }
+        $this->assertSame(1, $after['created']);
+    }
+
+    public function testBeforeQueueSendCancelSkipsWithoutRequeue()
+    {
+        $queue = $this->queueRow(5);
+        $this->modx->queues[] = $queue;
+        $this->modx->invokeResponses['sxOnBeforeQueueSend'] = array('skip me');
+
+        $result = sxQueueSender::sendOne($queue);
+
+        $this->assertFalse($result);
+        $this->assertCount(0, $this->modx->queues);
+        $names = array_column($this->modx->invoked, 0);
+        $this->assertContains('sxOnBeforeQueueSend', $names);
+        $this->assertNotContains('sxOnQueueSend', $names);
+        $this->assertNotContains('sxOnQueueSendFailed', $names);
+    }
+
+    public function testBeforeQueueSendCanMutateMessageBody()
+    {
+        $queue = $this->queueRow(6);
+        $queue->set('email_body', '<p>orig</p>');
+        $this->modx->queues[] = $queue;
+
+        $this->modx->invokeMutators['sxOnBeforeQueueSend'] = function (array &$params) {
+            $params['message']['email_body'] = '<p>tracked</p>';
+        };
+
+        $mail = new FakeMail();
+        $this->modx->services['mail'] = $mail;
+
+        $this->assertTrue(sxQueueSender::sendOne($queue));
+        $this->assertSame('<p>tracked</p>', $mail->sets[sxModxCompat::mailConst('BODY')]);
+        $names = array_column($this->modx->invoked, 0);
+        $this->assertContains('sxOnQueueSend', $names);
+    }
+
+    public function testQueueSendFailedFiresOnMailError()
+    {
+        $queue = $this->queueRow(7);
+        $queue->set('email_body', 'body');
+        $this->modx->queues[] = $queue;
+
+        $mail = new FakeMail();
+        $mail->sendResult = false;
+        $this->modx->services['mail'] = $mail;
+
+        $result = sxQueueSender::sendOne($queue);
+
+        $this->assertSame('SMTP down', $result);
+        $this->assertCount(1, $this->modx->queues);
+        $names = array_column($this->modx->invoked, 0);
+        $this->assertContains('sxOnQueueSendFailed', $names);
+        $this->assertNotContains('sxOnQueueSend', $names);
+    }
+
+    public function testFlushCompleteFiresWithStats()
+    {
+        $this->modx->queues[] = $this->queueRow(1);
+        $this->modx->queues[] = $this->queueRow(2);
+
+        $stats = sxQueueSender::flush($this->modx, array(
+            'criteria' => array('newsletter_id' => 10),
+            'sendFn'   => function () {
+                return true;
+            },
+        ));
+
+        $this->assertSame(2, $stats['sent']);
+        $found = null;
+        foreach ($this->modx->invoked as $item) {
+            if ($item[0] === 'sxOnQueueFlushComplete') {
+                $found = $item[1];
+            }
+        }
+        $this->assertNotNull($found);
+        $this->assertSame(10, $found['newsletter_id']);
+        $this->assertSame(2, $found['stats']['sent']);
+    }
+
+    public function testTransportRegistersQueueEvents()
+    {
+        $transport = file_get_contents(
+            dirname(__DIR__, 2) . '/_build/data/transport.events.php'
+        );
+        $eventNames = array(
+            'sxOnBeforeAddQueues',
+            'sxOnAddQueues',
+            'sxOnBeforeQueueSend',
+            'sxOnQueueSend',
+            'sxOnQueueSendFailed',
+            'sxOnQueueFlushComplete',
+        );
+        foreach ($eventNames as $name) {
+            $this->assertStringContainsString("'" . $name . "'", $transport);
+        }
+    }
+
+    private function addGuestSubscriber()
+    {
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 0,
+            'email'         => 'guest@example.com',
+        ));
+        $this->modx->subscribers[] = $subscriber;
+    }
+
+    /**
+     * @param int $id
+     * @return sxQueue
+     */
+    private function queueRow($id)
+    {
+        $queue = new sxQueue($this->modx);
+        $queue->fromArray(array(
+            'id'              => $id,
+            'newsletter_id'   => 10,
+            'subscriber_id'   => 1,
+            'email_to'        => 'a@example.com',
+            'email_subject'   => 'Hi',
+            'email_body'      => '<p>hi</p>',
+            'email_from'      => 'from@example.com',
+            'email_from_name' => 'From',
+            'email_reply'     => 'from@example.com',
+        ));
+
+        return $queue;
+    }
+}

--- a/tests/Unit/QueueSenderTest.php
+++ b/tests/Unit/QueueSenderTest.php
@@ -57,6 +57,29 @@ class QueueSenderTest extends TestCase
         $this->assertSame(1, $calls);
     }
 
+    public function testFlushStopOnErrorContinuesAfterPluginSkip()
+    {
+        $this->addQueue(1);
+        $this->addQueue(2);
+
+        $calls = 0;
+        $stats = sxQueueSender::flush($this->modx, array(
+            'stopOnError' => true,
+            'sendFn'      => function () use (&$calls) {
+                $calls++;
+                if ($calls === 1) {
+                    return false;
+                }
+
+                return true;
+            },
+        ));
+
+        $this->assertSame(1, $stats['skipped']);
+        $this->assertSame(1, $stats['sent']);
+        $this->assertSame(2, $calls);
+    }
+
     public function testFlushRespectsLimitAndCriteria()
     {
         $this->addQueue(1);

--- a/tests/Unit/SubscriberMergeTest.php
+++ b/tests/Unit/SubscriberMergeTest.php
@@ -68,6 +68,15 @@ class SubscriberMergeTest extends TestCase
         $this->assertSame('', sxSubscriberMerge::emailFromUser($this->modx, null));
     }
 
+    public function testHandlesUserEventAllowsActivateAndSaveOnly()
+    {
+        $this->assertTrue(sxSubscriberMerge::handlesUserEvent('OnUserActivate'));
+        $this->assertTrue(sxSubscriberMerge::handlesUserEvent('OnUserSave'));
+        $this->assertFalse(sxSubscriberMerge::handlesUserEvent('OnBeforeUserActivate'));
+        $this->assertFalse(sxSubscriberMerge::handlesUserEvent('OnManagerPageInit'));
+        $this->assertFalse(sxSubscriberMerge::handlesUserEvent(''));
+    }
+
     public function testPluginSourceRegistersActivateAndSaveEvents()
     {
         $plugin = file_get_contents(
@@ -77,13 +86,12 @@ class SubscriberMergeTest extends TestCase
             dirname(__DIR__, 2) . '/_build/data/transport.plugins.php'
         );
 
-        $this->assertStringContainsString("case 'OnUserActivate':", $plugin);
-        $this->assertStringContainsString("case 'OnBeforeUserActivate':", $plugin);
-        $this->assertStringContainsString("case 'OnUserSave':", $plugin);
+        $this->assertStringContainsString('sxSubscriberMerge::handlesUserEvent', $plugin);
         $this->assertStringContainsString('sxSubscriberMerge::attachGuestsForUser', $plugin);
+        $this->assertStringNotContainsString('OnBeforeUserActivate', $plugin);
         $this->assertStringContainsString("'OnUserActivate'", $transport);
-        $this->assertStringContainsString("'OnBeforeUserActivate'", $transport);
         $this->assertStringContainsString("'OnUserSave'", $transport);
+        $this->assertStringNotContainsString("'OnBeforeUserActivate'", $transport);
     }
 
     /**


### PR DESCRIPTION
### Кратко

Закрывает #104 по «Готово когда»: C1 (merge не на BeforeActivate), A1 (queue events), B1 (`source` в subscribe/unsubscribe), регистрация events + README.

## Что сделано

- C1: guest merge только на `OnUserActivate` / `OnUserSave` (`handlesUserEvent`)
- A1: `sxOnBeforeAddQueues`, `sxOnAddQueues`, `sxOnBeforeQueueSend` (mutable `message`, cancel = skip без requeue), `sxOnQueueSend`, `sxOnQueueSendFailed`, `sxOnQueueFlushComplete`
- B1: `source` (`snippet`|`ajax`|`confirm`|`mgr`|`guest`) во всех 4 subscribe/unsubscribe events
- `stopOnError` не обрывает batch на plugin skip
- тесты: `QueueLifecycleEventsTest`, source asserts, skip+stopOnError
- миграция: не нужна

## Review

- Findings: нет (pass 2: /code-review + code-reviewer + thermo-nuclear)
- (Medium) stopOnError на skip → исправлено до commit

## Проверка

- `composer test` — exit 0 (239 tests)
- phpcs — exit 0
- waive live MODX / Phinx: unit stubs

## Связанные issue

Fixes #104