### PR TITLE
fix(security): sanitize Sendex mail header fields

### DIFF
--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - [#51] Subscriber export goes through the authenticated manager connector (no public CSV under `assets/`); processor requires `edit_document`.
 - CSV cells that look like spreadsheet formulas are prefixed so Excel/LibreOffice do not execute them.
+- [#103] Mail header fields (`email_from`, `email_reply`, `email_to`) are sanitized to strip CR/LF/control characters before PHPMailer configuration.
 
 ### Added
 - [#42] Frontend AJAX subscribe/unsubscribe: JSON `{success, message, html}` from snippet, default chunks + `assets/components/sendex/js/web/sendex.js`. Multi-widget pages scope POST via `newsletter_id` and optional `widgetKey`.

--- a/core/components/sendex/model/sendex/sxnewslettermailer.class.php
+++ b/core/components/sendex/model/sendex/sxnewslettermailer.class.php
@@ -21,17 +21,17 @@ class sxNewsletterMailer
      */
     public static function resolveHeaders($source, $xpdo)
     {
-        $from = trim((string) self::readField($source, 'email_from'));
+        $from = self::sanitizeHeader(self::readField($source, 'email_from'));
         if ($from === '') {
-            $from = (string) $xpdo->getOption('emailsender');
+            $from = self::sanitizeHeader($xpdo->getOption('emailsender'));
         }
 
-        $fromName = trim((string) self::readField($source, 'email_from_name'));
+        $fromName = self::sanitizeHeader(self::readField($source, 'email_from_name'));
         if ($fromName === '') {
-            $fromName = (string) $xpdo->getOption('site_name');
+            $fromName = self::sanitizeHeader($xpdo->getOption('site_name'));
         }
 
-        $reply = trim((string) self::readField($source, 'email_reply'));
+        $reply = self::sanitizeHeader(self::readField($source, 'email_reply'));
         if ($reply === '') {
             $reply = $from;
         }
@@ -58,7 +58,7 @@ class sxNewsletterMailer
         return array_merge(
             self::resolveHeaders($newsletter, $xpdo),
             array(
-                'email_to'      => $subscriber->get('email'),
+                'email_to'      => self::sanitizeHeader($subscriber->get('email')),
                 'email_subject' => $subject,
                 'email_body'    => $body,
             )
@@ -78,7 +78,7 @@ class sxNewsletterMailer
         $headers = self::resolveHeaders($options, $xpdo);
 
         return array(
-            'email_to'        => $to,
+            'email_to'        => self::sanitizeHeader($to),
             'email_body'      => $xpdo->getOption('email_body', $options, ''),
             'email_subject'   => $xpdo->getOption(
                 'email_subject',
@@ -108,12 +108,12 @@ class sxNewsletterMailer
         }
 
         return array(
-            'email_to'        => self::readField($queue, 'email_to'),
+            'email_to'        => self::sanitizeHeader(self::readField($queue, 'email_to')),
             'email_body'      => $body,
-            'email_from'      => self::readField($queue, 'email_from'),
-            'email_from_name' => self::readField($queue, 'email_from_name'),
+            'email_from'      => self::sanitizeHeader(self::readField($queue, 'email_from')),
+            'email_from_name' => self::sanitizeHeader(self::readField($queue, 'email_from_name')),
             'email_subject'   => self::readField($queue, 'email_subject'),
-            'email_reply'     => self::readField($queue, 'email_reply'),
+            'email_reply'     => self::sanitizeHeader(self::readField($queue, 'email_reply')),
         );
     }
 
@@ -148,5 +148,26 @@ class sxNewsletterMailer
         }
 
         return '';
+    }
+
+    /**
+     * Remove CR/LF and control chars from email header fields (#103 P3).
+     *
+     * @param mixed $value
+     * @return string
+     */
+    public static function sanitizeHeader($value)
+    {
+        $value = (string) $value;
+        $value = preg_replace('/[\r\n]+/', ' ', $value);
+        if ($value === null) {
+            return '';
+        }
+        $value = preg_replace('/[\x00-\x1F\x7F]/', '', $value);
+        if ($value === null) {
+            return '';
+        }
+
+        return trim($value);
     }
 }

--- a/tests/Unit/NewsletterMailerTest.php
+++ b/tests/Unit/NewsletterMailerTest.php
@@ -39,6 +39,20 @@ class NewsletterMailerTest extends TestCase
         $this->assertSame('noreply@example.com', $headers['email_reply']);
     }
 
+    public function testResolveHeadersSanitizesCrLfInHeaderFields()
+    {
+        $newsletter = new TestableNewsletter($this->modx);
+        $newsletter->set('email_from', "from@example.com\r\nBcc:bad@example.com");
+        $newsletter->set('email_from_name', "From\r\nTeam");
+        $newsletter->set('email_reply', "reply@example.com\nCc:bad@example.com");
+
+        $headers = sxNewsletterMailer::resolveHeaders($newsletter, $this->modx);
+
+        $this->assertSame('from@example.com Bcc:bad@example.com', $headers['email_from']);
+        $this->assertSame('From Team', $headers['email_from_name']);
+        $this->assertSame('reply@example.com Cc:bad@example.com', $headers['email_reply']);
+    }
+
     public function testBuildMessageForSubscriber()
     {
         $newsletter = new TestableNewsletter($this->modx);
@@ -68,6 +82,28 @@ class NewsletterMailerTest extends TestCase
         $this->assertSame('reply@example.com', $message['email_reply']);
     }
 
+    public function testBuildMessageSanitizesRecipientHeader()
+    {
+        $newsletter = new TestableNewsletter($this->modx);
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array(
+            'id'            => 1,
+            'newsletter_id' => 10,
+            'user_id'       => 0,
+            'email'         => "guest@example.com\r\nBcc:bad@example.com",
+        ));
+
+        $message = sxNewsletterMailer::buildMessage(
+            $newsletter,
+            $subscriber,
+            'Hello',
+            '<p>Body</p>',
+            $this->modx
+        );
+
+        $this->assertSame('guest@example.com Bcc:bad@example.com', $message['email_to']);
+    }
+
     public function testBuildActivationMessageUsesEmailReply()
     {
         $message = sxNewsletterMailer::buildActivationMessage(
@@ -84,6 +120,19 @@ class NewsletterMailerTest extends TestCase
 
         $this->assertSame('reply@example.com', $message['email_reply']);
         $this->assertSame('Confirm', $message['email_subject']);
+    }
+
+    public function testBuildActivationMessageSanitizesToHeader()
+    {
+        $message = sxNewsletterMailer::buildActivationMessage(
+            $this->modx,
+            "guest@example.com\nCc:bad@example.com",
+            array(
+                'email_body' => 'Activate',
+            )
+        );
+
+        $this->assertSame('guest@example.com Cc:bad@example.com', $message['email_to']);
     }
 
     public function testConfigureMailerSetsHeadersAndHtml()
@@ -104,6 +153,34 @@ class NewsletterMailerTest extends TestCase
         $this->assertSame('Subject', $mail->sets[modMail::MAIL_SUBJECT]);
         $this->assertSame('to@example.com', $mail->addresses['to']);
         $this->assertSame('reply@example.com', $mail->addresses['reply-to']);
+    }
+
+    public function testMessageFromQueueSanitizesHeaderFields()
+    {
+        $queue = new sxQueue($this->modx);
+        $queue->fromArray(array(
+            'id'              => 1,
+            'newsletter_id'   => 10,
+            'subscriber_id'   => 1,
+            'email_to'        => "to@example.com\r\nBcc:bad@example.com",
+            'email_subject'   => 'Subject',
+            'email_body'      => 'Body',
+            'email_from'      => "from@example.com\nCc:bad@example.com",
+            'email_from_name' => "From\r\nTeam",
+            'email_reply'     => "reply@example.com\r\nBcc:bad@example.com",
+        ));
+
+        $message = sxNewsletterMailer::messageFromQueue($queue);
+
+        $this->assertSame('to@example.com Bcc:bad@example.com', $message['email_to']);
+        $this->assertSame('from@example.com Cc:bad@example.com', $message['email_from']);
+        $this->assertSame('From Team', $message['email_from_name']);
+        $this->assertSame('reply@example.com Bcc:bad@example.com', $message['email_reply']);
+    }
+
+    public function testSanitizeHeaderStripsControlCharacters()
+    {
+        $this->assertSame('from@example.comBcc:bad@example.com', sxNewsletterMailer::sanitizeHeader("from@example.com\x00Bcc:bad@example.com"));
     }
 
     public function testMailPathsDelegateToNewsletterMailer()


### PR DESCRIPTION
### Кратко

Закрывает пункт #103 P3: перед настройкой PHPMailer очищаем `email_from`, `email_reply` и `email_to` от CR/LF и control chars.

## Что сделано

- добавлен helper `sxNewsletterMailer::sanitizeHeader()`
- helper применяется в `resolveHeaders`, `buildMessage`, `buildActivationMessage`, `messageFromQueue`
- добавлены unit-тесты для CR/LF кейсов по всем трём полям
- changelog обновлён
- миграция: не нужна (runtime-only изменение)

## Почему так

Один helper держит правило в одном месте и убирает расхождения между activation/queue paths.

## Review

- Findings: нет (pass 2: /code-review + code-reviewer + thermo-nuclear)

## Проверка

- `composer test -- --filter NewsletterMailerTest` — exit 0
- `composer test` — exit 0 (244 tests)
- `vendor/bin/phpcs --standard=phpcs.xml -n core/components/sendex/model/sendex/sxnewslettermailer.class.php tests/Unit/NewsletterMailerTest.php core/components/sendex/docs/changelog.txt` — exit 0
- waive: live MODX/Phinx не нужен (схема БД не менялась)

## Связанные issue

Refs #103 (P3)