### PR TITLE
fix(sendex): close #103 hardening backlog in one PR

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,7 +12,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        include:
+          - php: '7.4'
+            coverage: none
+          - php: '8.0'
+            coverage: none
+          - php: '8.1'
+            coverage: none
+          - php: '8.2'
+            coverage: pcov
+          - php: '8.3'
+            coverage: none
+          - php: '8.4'
+            coverage: none
 
     steps:
       - uses: actions/checkout@v5
@@ -21,7 +33,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          coverage: none
+          coverage: ${{ matrix.coverage }}
           tools: composer
 
       - name: Install dependencies
@@ -33,6 +45,17 @@ jobs:
 
       - name: PHPUnit
         run: composer test
+
+      - name: PHPUnit coverage report
+        if: matrix.coverage == 'pcov'
+        run: vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+
+      - name: Upload coverage artifact
+        if: matrix.coverage == 'pcov'
+        uses: actions/upload-artifact@v4
+        with:
+          name: phpunit-coverage-clover
+          path: build/logs/clover.xml
 
   phpcs:
     name: PHPCS
@@ -73,3 +96,32 @@ jobs:
           while IFS= read -r -d '' file; do
             php -l "$file"
           done < <(find . -name '*.php' -not -path './.git/*' -not -path './vendor/*' -print0)
+
+  integration:
+    name: Integration smoke (MODX ${{ matrix.modx }})
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        modx: ['2.8', '3.x']
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: none
+          tools: composer
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Install component Phinx deps
+        run: composer install --no-interaction --no-dev --prefer-dist
+        working-directory: core/components/sendex
+
+      - name: Contract smoke for connector/cron paths
+        run: composer test -- --filter "ModxCompatTest|BuildTransportModx3ContractTest|QueueClaimTest"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.2"
+          tools: composer
+          coverage: none
+
+      - name: Install root dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Install component Phinx deps
+        run: composer install --no-interaction --no-dev --prefer-dist
+        working-directory: core/components/sendex
+
+      - name: Build transport package
+        run: php _build/build.transport.php
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: _packages/*.transport.zip

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ composer test
 composer test:coverage   # needs phpdbg
 ```
 
-Unit tests use lightweight MODX/xPDO stubs (no MODX install). Covered: `sxNewsletter` (100%), subscriber create/remove processors. CI runs `php -l`, PHPUnit, and phpcs on PHP 7.4–8.4.
+Unit tests use lightweight MODX/xPDO stubs (no MODX install). Coverage includes subscription/confirm flows, queue lifecycle events, queue claim, group subscribe, ACL contracts, frontend snippet contracts, and mail header sanitization. CI runs `php -l`, PHPUnit, and PHPCS on PHP 7.4–8.4; one PHP 8.2 job publishes Clover coverage as an artifact. Remaining integration gaps are tracked in issue [#103](https://github.com/modx-pro/Sendex/issues/103).
 
 ## Plugin events
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Guest chunk structure (for custom templates):
 </div>
 ```
 
-Set `&loadJs=`0`` if you ship your own JS but keep the same JSON contract (`X-Requested-With: XMLHttpRequest` or `ajax=1`).
+Set `&loadJs=0` if you ship your own JS but keep the same JSON contract (`X-Requested-With: XMLHttpRequest` or `ajax=1`).
 
 ### Guest email vs existing User (#39)
 
@@ -118,7 +118,7 @@ Logged-in `isSubscribed($userId)` also matches a still-guest row by profile emai
 
 ### Unsubscribe from email (#56)
 
-The page must call `[[!Sendex? &id=`…`]]` (any newsletter id is fine). Query params:
+The page must call `[[!Sendex? &id=...]]` (any newsletter id is fine). Query params:
 
 | Param | Required | Meaning |
 | --- | --- | --- |

--- a/_build/build.config.php
+++ b/_build/build.config.php
@@ -4,7 +4,7 @@
 define('PKG_NAME', 'Sendex');
 define('PKG_NAME_LOWER', strtolower(PKG_NAME));
 
-define('PKG_VERSION', '1.2.0');
+define('PKG_VERSION', '2.0.0');
 define('PKG_RELEASE', 'pl');
 define('PKG_AUTO_INSTALL', true);
 define('PKG_NAMESPACE_PATH', '{core_path}components/' . PKG_NAME_LOWER . '/');

--- a/_build/data/transport.menu.php
+++ b/_build/data/transport.menu.php
@@ -18,6 +18,7 @@ foreach ($tmp as $k => $v) {
         'text'      => $k,
         'parent'    => 'components',
         'icon'      => 'images/icons/plugin.gif',
+        'permissions' => 'view_document',
         'menuindex' => $i,
         'params'    => '',
         'handler'   => '',

--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -21,6 +21,18 @@ $tmp = [
         'key'   => 'sendex_confirm_email',
         'area'  => 'sendex_main',
     ),
+    'confirm_rate_limit' => array(
+        'xtype' => 'textfield',
+        'value' => 0,
+        'key'   => 'sendex_confirm_rate_limit',
+        'area'  => 'sendex_main',
+    ),
+    'csrf_protect'       => array(
+        'xtype' => 'combo-boolean',
+        'value' => false,
+        'key'   => 'sendex_csrf_protect',
+        'area'  => 'sendex_main',
+    ),
 ];
 
 foreach ($tmp as $k => $v) {

--- a/assets/components/sendex/js/mgr/widgets/newsletters.grid.js
+++ b/assets/components/sendex/js/mgr/widgets/newsletters.grid.js
@@ -84,8 +84,16 @@ Ext.extend(Sendex.grid.Newsletters,MODx.grid.Grid,Ext.apply({
 
     ,_renderBoolean: function(val,cell,row) {
         return val == '' || val == 0
-            ? '<span style="color:red">' + _('no') + '<span>'
-            : '<span style="color:green">' + _('yes') + '<span>';
+            ? '<span style="color:red">' + _('no') + '</span>'
+            : '<span style="color:green">' + _('yes') + '</span>';
+    }
+
+    ,_escapeHtmlAttr: function(value) {
+        return String(value)
+            .replace(/&/g, '&amp;')
+            .replace(/"/g, '&quot;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
     }
 
     ,_renderImage: function(val,cell,row) {
@@ -94,7 +102,7 @@ Ext.extend(Sendex.grid.Newsletters,MODx.grid.Grid,Ext.apply({
             val = '/' + val;
         }
 
-        return '<img src="' + val + '" alt="" height="50" />';
+        return '<img src="' + this._escapeHtmlAttr(val) + '" alt="" height="50" />';
     }
 
     ,_renderTemplate: function(val,cell,row) {

--- a/assets/components/sendex/js/web/sendex.js
+++ b/assets/components/sendex/js/web/sendex.js
@@ -54,10 +54,18 @@
                 .catch(function () {
                     SendexForm.applyResponse(widget, {
                         success: false,
-                        message: 'Request failed',
+                        message: SendexForm.requestFailedMessage(),
                         html: ''
                     });
                 });
+        },
+
+        requestFailedMessage: function () {
+            if (window.SendexFormMessages && window.SendexFormMessages.requestFailed) {
+                return window.SendexFormMessages.requestFailed;
+            }
+
+            return 'Request failed';
         },
 
         applyResponse: function (widget, data) {

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.0-pl] - 2026-07-25
+## [2.0.0-pl] - 2026-07-25
 
 ### Security
 - [#51] Subscriber export goes through the authenticated manager connector (no public CSV under `assets/`); processor requires `edit_document`.

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#51] Subscriber export goes through the authenticated manager connector (no public CSV under `assets/`); processor requires `edit_document`.
 - CSV cells that look like spreadsheet formulas are prefixed so Excel/LibreOffice do not execute them.
 - [#103] Mail header fields (`email_from`, `email_reply`, `email_to`) are sanitized to strip CR/LF/control characters before PHPMailer configuration.
+- [#103] Mgr newsletters grid escapes image `src` and fixes broken boolean renderer span tags to prevent stored XSS via crafted image values.
 
 ### Added
 - [#42] Frontend AJAX subscribe/unsubscribe: JSON `{success, message, html}` from snippet, default chunks + `assets/components/sendex/js/web/sendex.js`. Multi-widget pages scope POST via `newsletter_id` and optional `widgetKey`.

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CSV cells that look like spreadsheet formulas are prefixed so Excel/LibreOffice do not execute them.
 - [#103] Mail header fields (`email_from`, `email_reply`, `email_to`) are sanitized to strip CR/LF/control characters before PHPMailer configuration.
 - [#103] Mgr newsletters grid escapes image `src` and fixes broken boolean renderer span tags to prevent stored XSS via crafted image values.
+- [#103] Frontend subscribe/unsubscribe adds optional CSRF token validation (`sendex_csrf_protect`).
+- [#103] Guest confirm flow adds per-email rate limiting (`sendex_confirm_rate_limit`, seconds; `0` disables).
 
 ### Added
 - [#42] Frontend AJAX subscribe/unsubscribe: JSON `{success, message, html}` from snippet, default chunks + `assets/components/sendex/js/web/sendex.js`. Multi-widget pages scope POST via `newsletter_id` and optional `widgetKey`.
@@ -35,10 +37,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#59] Deleting a newsletter removes its `sxQueue` rows via xPDO composite `Queues`; upgrade migration purges queue rows left orphaned by earlier deletes.
 - [#57] `addQueues` returns an error when 0 queue rows were created (all subscribers skipped); mgr `queue/add` reports the created count on success.
 - [#55] Queue send claims the row (remove-before-send) so parallel cron/mgr workers do not double-deliver; mail failure requeues and logs; cron logs non-true `send()` results.
+- [#103] Queue claim uses atomic `DELETE ... WHERE id = ?` with `rowCount()` fallback-safe behavior for single-owner delivery.
 - [#56] Unsubscribe from email: snippet resolves newsletter by subscriber `code` when snippet `&id` differs; default letter link includes `newsletter_id` (not MODX resource `id`).
 - [#67] / [#52] Schema and upgrade: Sendex tables use InnoDB; queue index renamed `user_id` → `subscriber_id`; `addQueues` stores `sxSubscriber.id` (not `user_id`); Phinx backfill remaps legacy queue rows (by user_id, guests by email).
 - [#54] `isSubscribed` matches by `user_id` OR `email` within a newsletter; unique key is `(newsletter_id, email)`; guest rows attach `user_id` when the same email confirms as a user.
 - [#39] Guest rows merge onto `modUser` on `OnUserActivate` / `OnUserSave` (`sxSubscriberMerge`); registration does not create a second subscriber row for the same email.
+- [#103] Guest merge query filters `user_id=0` + email at SQL level (no full scan in PHP).
 - [#58] `confirmEmail` restores registry hash when `subscribe()` fails so the confirm link stays usable; remaining TTL kept via `_expires`; `checkEmail` shares `sxSubscribeRegistry::store`.
 - [#61] `sxSubscriber::save` keeps existing `code` (generate only when empty) so unsubscribe links stay valid.
 - [#53] Snippet: authenticated user without Profile no longer triggers TypeError on PHP 8; merge via `sxUserPlaceholders`.
@@ -52,6 +56,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - [#68] ExtJS mgr grids share `Sendex.grid.SelectionMixin` (`getSelectedIds`, `confirmWithSelection`, `ajaxWithSelection`) instead of per-grid `_getSelectedIds` copy-paste.
 - [#73] Newsletter mgr `getlist`: COUNT runs on filters only; JOIN/COUNT(`Subscribers`)/GROUP BY moved to `prepareQueryAfterCount` via `sxNewsletterListQuery`.
+- [#103] Group subscribe loads only relevant existing rows (`user_id/email` subset) instead of all newsletter subscribers.
+- [#103] Subscriber schema adds `user_id` index via Phinx migration `20260725170000_subscriber_user_id_index.php`.
+- [#103] Mgr controller ACL now checks `view_sendex` or `view_document`; transport menu declares explicit `view_document` permission.
+- [#103] Frontend i18n cleanup: lexicon-based request failure text, guest/anonymous labels, and email placeholder.
+- [#103] CI adds integration smoke matrix (MODX 2.8/3.x, allow-failure), Clover coverage artifact, and tag-driven release workflow.
 - [#71] Confirm/subscribe reuses one `sxSubscriber` lookup (`findSubscriber`) instead of SELECT in `isSubscribed` plus a second SELECT in `attachUserToSubscriber`.
 - [#70] `add_group` bulk-subscribes group members via one query + chunked multi-row INSERT; mgr sync path skips per-row subscribe events (#44).
 - [#64] New queue rows store empty `email_body` (compact mode); body is rendered at send from newsletter template; legacy rows with stored HTML still send as-is.

--- a/core/components/sendex/elements/chunks/chunk.subscribe.auth.tpl
+++ b/core/components/sendex/elements/chunks/chunk.subscribe.auth.tpl
@@ -10,6 +10,7 @@
         <input type="hidden" name="sx_action" value="subscribe">
         <input type="hidden" name="newsletter_id" value="[[+id]]">
         [[+widget_key:notempty=`<input type="hidden" name="sendex_widget_key" value="[[+widget_key]]">`]]
+        [[+csrf_token:notempty=`<input type="hidden" name="sendex_csrf" value="[[+csrf_token]]">`]]
 
         <button type="submit">[[%sendex_btn_subscribe]]</button>
     </form>

--- a/core/components/sendex/elements/chunks/chunk.subscribe.guest.tpl
+++ b/core/components/sendex/elements/chunks/chunk.subscribe.guest.tpl
@@ -10,8 +10,9 @@
         <input type="hidden" name="sx_action" value="subscribe">
         <input type="hidden" name="newsletter_id" value="[[+id]]">
         [[+widget_key:notempty=`<input type="hidden" name="sendex_widget_key" value="[[+widget_key]]">`]]
+        [[+csrf_token:notempty=`<input type="hidden" name="sendex_csrf" value="[[+csrf_token]]">`]]
 
-        <input type="email" name="email" value="" placeholder="Email" required>
+        <input type="email" name="email" value="" placeholder="[[%sendex_email_placeholder]]" required>
 
         <button type="submit">[[%sendex_btn_subscribe]]</button>
     </form>

--- a/core/components/sendex/elements/chunks/chunk.unsubscribe.tpl
+++ b/core/components/sendex/elements/chunks/chunk.unsubscribe.tpl
@@ -10,6 +10,7 @@
         <input type="hidden" name="sx_action" value="unsubscribe">
         <input type="hidden" name="newsletter_id" value="[[+id]]">
         [[+widget_key:notempty=`<input type="hidden" name="sendex_widget_key" value="[[+widget_key]]">`]]
+        [[+csrf_token:notempty=`<input type="hidden" name="sendex_csrf" value="[[+csrf_token]]">`]]
 
         <input type="hidden" name="code" value="[[+code]]">
 

--- a/core/components/sendex/elements/snippets/snippet.sendex.php
+++ b/core/components/sendex/elements/snippets/snippet.sendex.php
@@ -19,6 +19,7 @@ require_once $corePath . 'model/sendex/sxunsubscriberesolve.class.php';
 require_once $corePath . 'model/sendex/sxsubscribeconfirm.class.php';
 require_once $corePath . 'model/sendex/sxsubscribeajaxresponse.class.php';
 require_once $corePath . 'model/sendex/sxsubscribecsrf.class.php';
+require_once $corePath . 'model/sendex/sxsubscriberegistry.class.php';
 
 $tplSubscribeAuth = $modx->getOption('tplSubscribeAuth', $scriptProperties, 'tpl.Sendex.subscribe.auth');
 $tplSubscribeGuest = $modx->getOption('tplSubscribeGuest', $scriptProperties, 'tpl.Sendex.subscribe.guest');
@@ -91,12 +92,16 @@ if ($handlesRequest) {
                     }
                 } elseif (!empty($_REQUEST['email'])) {
                     $email = htmlentities(strip_tags(urldecode($_REQUEST['email'])));
+                    if ($requireConfirm && sxSubscribeRegistry::isConfirmRateLimited($modx, $email, $confirmRateLimit)) {
+                        $placeholders['message'] = $modx->lexicon('sendex_subscribe_err_rate_limited');
+                        $placeholders['error'] = 1;
+                        break;
+                    }
                     $guestResult = $newsletter->subscribeGuest(
                         $email,
                         $modx->user->id,
                         $linkTTL,
-                        $requireConfirm,
-                        $confirmRateLimit
+                        $requireConfirm
                     );
                     if ($guestResult['status'] === 'already') {
                         $placeholders['message'] = $modx->lexicon('sendex_subscribe_err_already');

--- a/core/components/sendex/elements/snippets/snippet.sendex.php
+++ b/core/components/sendex/elements/snippets/snippet.sendex.php
@@ -18,6 +18,7 @@ require_once $corePath . 'model/sendex/sxuserprofile.class.php';
 require_once $corePath . 'model/sendex/sxunsubscriberesolve.class.php';
 require_once $corePath . 'model/sendex/sxsubscribeconfirm.class.php';
 require_once $corePath . 'model/sendex/sxsubscribeajaxresponse.class.php';
+require_once $corePath . 'model/sendex/sxsubscribecsrf.class.php';
 
 $tplSubscribeAuth = $modx->getOption('tplSubscribeAuth', $scriptProperties, 'tpl.Sendex.subscribe.auth');
 $tplSubscribeGuest = $modx->getOption('tplSubscribeGuest', $scriptProperties, 'tpl.Sendex.subscribe.guest');
@@ -27,7 +28,9 @@ if (empty($linkTTL)) {
     $linkTTL = 1800;
 }
 $requireConfirm = sxSubscribeConfirm::isRequired($modx, $scriptProperties);
+$confirmRateLimit = sxSubscribeConfirm::rateLimitSeconds($modx, $scriptProperties);
 $widgetKey = trim((string) $modx->getOption('widgetKey', $scriptProperties, ''));
+$csrfRequired = sxSubscribeCsrf::isRequired($modx, $scriptProperties);
 $loadJs = sxSubscribeAjaxResponse::parseEnabled(
     $modx->getOption('loadJs', $scriptProperties, true),
     true
@@ -48,6 +51,7 @@ $placeholders['message'] = '';
 $placeholders['class'] = '';
 $placeholders['error'] = 0;
 $placeholders['widget_key'] = $widgetKey;
+$placeholders['csrf_token'] = $csrfRequired ? sxSubscribeCsrf::token() : '';
 $newsletterId = (int) $id;
 $handlesRequest = !empty($_REQUEST['sx_action'])
     && sxSubscribeAjaxResponse::matchesRequest($newsletterId, $widgetKey, $_REQUEST);
@@ -61,113 +65,148 @@ if ($handlesRequest) {
     unset($params[$modx->getOption('request_param_alias')]);
     unset($params[$modx->getOption('request_param_id')]);
     $eventSource = $isAjax ? 'ajax' : 'snippet';
+    $action = (string) $modx->getOption('sx_action', $_REQUEST, '');
+    $method = strtoupper((string) $modx->getOption('REQUEST_METHOD', $_SERVER, 'GET'));
+    $mustValidateCsrf = $csrfRequired
+        && $method === 'POST'
+        && in_array($action, array('subscribe', 'unsubscribe'), true);
+    if ($mustValidateCsrf && !sxSubscribeCsrf::isValid($modx->getOption('sendex_csrf', $_REQUEST, ''))) {
+        $placeholders['message'] = $modx->lexicon('sendex_subscribe_err_csrf');
+        $placeholders['error'] = 1;
+    }
 
-    switch ($_REQUEST['sx_action']) {
-        case 'subscribe':
-            if ($isAuthenticated && $modx->user->id) {
-                $response = $newsletter->subscribe($modx->user->id, '', $eventSource);
-                if ($response !== true) {
-                    $placeholders['message'] = is_string($response)
-                        ? $response
-                        : $modx->lexicon('sendex_subscribe_err_email_wrong');
-                    $placeholders['error'] = 1;
-                }
-            } elseif (!empty($_REQUEST['email'])) {
-                $email = htmlentities(strip_tags(urldecode($_REQUEST['email'])));
-                $guestResult = $newsletter->subscribeGuest(
-                    $email,
-                    $modx->user->id,
-                    $linkTTL,
-                    $requireConfirm
-                );
-                if ($guestResult['status'] === 'already') {
-                    $placeholders['message'] = $modx->lexicon('sendex_subscribe_err_already');
-                } elseif ($guestResult['status'] === 'invalid') {
-                    $placeholders['message'] = $modx->lexicon('sendex_subscribe_err_email_wrong');
-                    $placeholders['error'] = 1;
-                } elseif ($guestResult['status'] === 'subscribed') {
-                    $placeholders['message'] = $modx->lexicon('sendex_subscribe_email_confirmed');
-                    $params['sx_confirmed'] = 1;
-                } elseif ($guestResult['status'] === 'error') {
-                    $placeholders['message'] = $guestResult['message'];
-                    $placeholders['error'] = 1;
-                } elseif ($guestResult['status'] === 'confirm') {
-                    $params['hash'] = $guestResult['hash'];
-                    $params['sx_action'] = 'confirm';
-                    $params['newsletter_id'] = $newsletterId;
-                    $placeholders['link'] = $modx->makeUrl($modx->resource->id, $modx->context->key, $params, 'full');
-                    $placeholders['email_body'] = $modx->getChunk($tplActivate, $placeholders);
-                    $response = $Sendex->sendEmail($email, $placeholders);
+    if (empty($placeholders['message'])) {
+        switch ($action) {
+            case 'subscribe':
+                if ($isAuthenticated && $modx->user->id) {
+                    $response = $newsletter->subscribe($modx->user->id, '', $eventSource);
                     if ($response !== true) {
-                        $placeholders['message'] = $modx->lexicon('sendex_subscribe_err_email_send');
+                        $placeholders['message'] = is_string($response)
+                            ? $response
+                            : $modx->lexicon('sendex_subscribe_err_email_wrong');
                         $placeholders['error'] = 1;
                     } else {
                         $placeholders['message'] = $modx->lexicon('sendex_subscribe_email_subscribed');
                         $params['sx_subscribed'] = 1;
                     }
-                }
-            } else {
-                $placeholders['message'] = $modx->lexicon('sendex_subscribe_err_email_ns');
-                $placeholders['error'] = 1;
-            }
-            unset($params['email'], $params['hash']);
-            break;
-        case 'confirm':
-            if (!empty($_REQUEST['hash'])) {
-                $response = $newsletter->confirmEmail($_REQUEST['hash']);
-                if ($response === true) {
-                    $placeholders['message'] = $modx->lexicon('sendex_subscribe_email_confirmed');
-                    $params['sx_confirmed'] = 1;
+                } elseif (!empty($_REQUEST['email'])) {
+                    $email = htmlentities(strip_tags(urldecode($_REQUEST['email'])));
+                    $guestResult = $newsletter->subscribeGuest(
+                        $email,
+                        $modx->user->id,
+                        $linkTTL,
+                        $requireConfirm,
+                        $confirmRateLimit
+                    );
+                    if ($guestResult['status'] === 'already') {
+                        $placeholders['message'] = $modx->lexicon('sendex_subscribe_err_already');
+                    } elseif ($guestResult['status'] === 'invalid') {
+                        $placeholders['message'] = $modx->lexicon('sendex_subscribe_err_email_wrong');
+                        $placeholders['error'] = 1;
+                    } elseif ($guestResult['status'] === 'rate_limited') {
+                        $placeholders['message'] = $modx->lexicon('sendex_subscribe_err_rate_limited');
+                        $placeholders['error'] = 1;
+                    } elseif ($guestResult['status'] === 'subscribed') {
+                        $placeholders['message'] = $modx->lexicon('sendex_subscribe_email_confirmed');
+                        $params['sx_confirmed'] = 1;
+                    } elseif ($guestResult['status'] === 'error') {
+                        $placeholders['message'] = $guestResult['message'];
+                        $placeholders['error'] = 1;
+                    } elseif ($guestResult['status'] === 'confirm') {
+                        if (!sxSubscribeRegistry::claimConfirmRateLimit($modx, $email, $confirmRateLimit)) {
+                            $placeholders['message'] = $modx->lexicon('sendex_subscribe_err_rate_limited');
+                            $placeholders['error'] = 1;
+                        } else {
+                            $params['hash'] = $guestResult['hash'];
+                            $params['sx_action'] = 'confirm';
+                            $params['newsletter_id'] = $newsletterId;
+                            $placeholders['link'] = $modx->makeUrl(
+                                $modx->resource->id,
+                                $modx->context->key,
+                                $params,
+                                'full'
+                            );
+                            $placeholders['email_body'] = $modx->getChunk($tplActivate, $placeholders);
+                            $response = $Sendex->sendEmail($email, $placeholders);
+                            if ($response !== true) {
+                                sxSubscribeRegistry::releaseConfirmRateLimit($modx, $email);
+                                $placeholders['message'] = $modx->lexicon('sendex_subscribe_err_email_send');
+                                $placeholders['error'] = 1;
+                            } else {
+                                $placeholders['message'] = $modx->lexicon('sendex_subscribe_email_subscribed');
+                                $params['sx_subscribed'] = 1;
+                            }
+                        }
+                    }
                 } else {
-                    $placeholders['message'] = is_string($response)
-                        ? $response
-                        : $modx->lexicon('sendex_subscribe_err_email_wrong');
+                    $placeholders['message'] = $modx->lexicon('sendex_subscribe_err_email_ns');
                     $placeholders['error'] = 1;
                 }
-                unset($params['hash']);
-            }
-            break;
-        case 'unsubscribe':
-            if (!empty($_REQUEST['code'])) {
-                $code = $_REQUEST['code'];
-                $target = sxUnsubscribeResolve::forCode($modx, $code, $newsletter);
-                if ($target) {
-                    $newsletter = $target;
-                    $placeholders = array_merge(
-                        $newsletter->toArray(),
-                        array(
-                            'message' => '',
-                            'class'   => '',
-                            'error'   => 0,
-                            'widget_key' => $widgetKey,
-                        )
-                    );
-                    if ($isAuthenticated) {
-                        $placeholders = sxUserProfile::authenticatedPlaceholders(
-                            $modx,
-                            $modx->user,
-                            $placeholders
+                unset($params['email'], $params['hash']);
+                break;
+            case 'confirm':
+                if (!empty($_REQUEST['hash'])) {
+                    $response = $newsletter->confirmEmail($_REQUEST['hash']);
+                    if ($response === true) {
+                        $placeholders['message'] = $modx->lexicon('sendex_subscribe_email_confirmed');
+                        $params['sx_confirmed'] = 1;
+                    } else {
+                        $placeholders['message'] = is_string($response)
+                            ? $response
+                            : $modx->lexicon('sendex_subscribe_err_email_wrong');
+                        $placeholders['error'] = 1;
+                    }
+                    unset($params['hash']);
+                }
+                break;
+            case 'unsubscribe':
+                if (!empty($_REQUEST['code'])) {
+                    $code = $_REQUEST['code'];
+                    $target = sxUnsubscribeResolve::forCode($modx, $code, $newsletter);
+                    if ($target) {
+                        $newsletter = $target;
+                        $placeholders = array_merge(
+                            $newsletter->toArray(),
+                            array(
+                                'message' => '',
+                                'class'   => '',
+                                'error'   => 0,
+                                'widget_key' => $widgetKey,
+                                'csrf_token' => $csrfRequired ? sxSubscribeCsrf::token() : '',
+                            )
                         );
+                        if ($isAuthenticated) {
+                            $placeholders = sxUserProfile::authenticatedPlaceholders(
+                                $modx,
+                                $modx->user,
+                                $placeholders
+                            );
+                        }
+                    }
+                    $response = $newsletter->unSubscribe($code, $eventSource);
+                    if ($response === true) {
+                        $placeholders['message'] = $modx->lexicon('sendex_subscribe_email_unsubscribed');
+                        $params['sx_unsubscribed'] = 1;
+                    } else {
+                        $placeholders['message'] = is_string($response)
+                            ? $response
+                            : $modx->lexicon('sendex_subscriber_err_remove');
+                        $placeholders['error'] = 1;
                     }
                 }
-                $response = $newsletter->unSubscribe($code, $eventSource);
-                if ($response === true) {
-                    $placeholders['message'] = $modx->lexicon('sendex_subscribe_email_unsubscribed');
-                    $params['sx_unsubscribed'] = 1;
-                } else {
-                    $placeholders['message'] = is_string($response)
-                        ? $response
-                        : $modx->lexicon('sendex_subscriber_err_remove');
-                    $placeholders['error'] = 1;
-                }
-            }
-            unset($params['code'], $params['newsletter_id']);
-            break;
+                unset($params['code'], $params['newsletter_id']);
+                break;
+        }
     }
 
     unset($params['sx_action']);
     if (!$isAjax && empty($placeholders['message'])) {
-        $modx->sendRedirect($modx->makeUrl($modx->resource->id, $modx->context->key, $params, 'full'));
+        $modx->sendRedirect($modx->makeUrl(
+            $modx->resource->id,
+            $modx->context->key,
+            $params,
+            'full'
+        ));
     }
 }
 
@@ -194,6 +233,12 @@ if ($isAjax && $handlesRequest) {
 
 if ($loadJs && !defined('SENDEX_FRONTEND_JS')) {
     define('SENDEX_FRONTEND_JS', true);
+    $modx->regClientStartupHTMLBlock(
+        '<script>window.SendexFormMessages = window.SendexFormMessages || {};'
+        . 'window.SendexFormMessages.requestFailed = '
+        . json_encode($modx->lexicon('sendex_request_failed'))
+        . ';</script>'
+    );
     $modx->regClientScript(
         $modx->getOption('assets_url') . 'components/sendex/js/web/sendex.js'
     );

--- a/core/components/sendex/lexicon/en/default.inc.php
+++ b/core/components/sendex/lexicon/en/default.inc.php
@@ -117,6 +117,12 @@ $_lang['sendex_subscribe_err_already'] = 'This email is already subscribed to ne
 $_lang['sendex_subscribe_err_email_wrong'] = 'Wrong email.';
 $_lang['sendex_subscribe_err_email_ns'] = 'You need to specify email.';
 $_lang['sendex_subscribe_err_email_send'] = 'Could not send email.';
+$_lang['sendex_subscribe_err_csrf'] = 'Request verification failed. Refresh the page and try again.';
+$_lang['sendex_subscribe_err_rate_limited'] = 'Too many confirmation requests for this email. Try later.';
+$_lang['sendex_request_failed'] = 'Request failed';
+$_lang['sendex_email_placeholder'] = 'Email';
+$_lang['sendex_subscriber_guest'] = 'Guest';
+$_lang['sendex_subscriber_anonymous'] = 'Anonymous';
 
 $_lang['sendex_action_sendNewsletter'] = 'Send to subscribers';
 $_lang['sendex_action_updateNewsletter'] = 'Update newsletter';

--- a/core/components/sendex/lexicon/en/setting.inc.php
+++ b/core/components/sendex/lexicon/en/setting.inc.php
@@ -11,3 +11,8 @@ $_lang['setting_sendex_hide_export_button_desc'] = 'Disables the button to expor
 $_lang['setting_sendex_confirm_email'] = 'Require guest email confirmation';
 $_lang['setting_sendex_confirm_email_desc'] = 'When enabled, guests must confirm subscription via email link. '
     . 'When disabled, guest emails are subscribed immediately (higher risk of invalid addresses).';
+$_lang['setting_sendex_confirm_rate_limit'] = 'Confirm email rate limit (seconds)';
+$_lang['setting_sendex_confirm_rate_limit_desc'] = 'Maximum one confirmation email per address in this window. '
+    . 'Set 0 to disable rate limiting.';
+$_lang['setting_sendex_csrf_protect'] = 'Enable frontend CSRF protection';
+$_lang['setting_sendex_csrf_protect_desc'] = 'Adds a CSRF token to subscribe/unsubscribe forms and validates it in snippet/AJAX requests.';

--- a/core/components/sendex/lexicon/ru/default.inc.php
+++ b/core/components/sendex/lexicon/ru/default.inc.php
@@ -119,6 +119,12 @@ $_lang['sendex_subscribe_err_already'] = 'Этот email уже подписан
 $_lang['sendex_subscribe_err_email_wrong'] = 'Неверный email.';
 $_lang['sendex_subscribe_err_email_ns'] = 'Нужно указать email.';
 $_lang['sendex_subscribe_err_email_send'] = 'Не могу отправить email.';
+$_lang['sendex_subscribe_err_csrf'] = 'Проверка запроса не пройдена. Обновите страницу и повторите.';
+$_lang['sendex_subscribe_err_rate_limited'] = 'Слишком много запросов подтверждения для этого email. Попробуйте позже.';
+$_lang['sendex_request_failed'] = 'Запрос завершился ошибкой';
+$_lang['sendex_email_placeholder'] = 'Email';
+$_lang['sendex_subscriber_guest'] = 'Гость';
+$_lang['sendex_subscriber_anonymous'] = 'Аноним';
 
 $_lang['sendex_action_sendNewsletter'] = 'Отправить подписчикам';
 $_lang['sendex_action_updateNewsletter'] = 'Изменить рассылку';

--- a/core/components/sendex/lexicon/ru/setting.inc.php
+++ b/core/components/sendex/lexicon/ru/setting.inc.php
@@ -10,3 +10,8 @@ $_lang['setting_sendex_hide_export_button_desc'] = 'Отключает кноп�
 $_lang['setting_sendex_confirm_email'] = 'Требовать подтверждение email гостя';
 $_lang['setting_sendex_confirm_email_desc'] = 'Если включено, гость подтверждает подписку по ссылке из письма. '
     . 'Если выключено, email сразу попадает в подписчики (выше риск мусорных адресов).';
+$_lang['setting_sendex_confirm_rate_limit'] = 'Лимит confirm-писем (секунды)';
+$_lang['setting_sendex_confirm_rate_limit_desc'] = 'Не более одного confirm-письма на адрес за окно. '
+    . '0 отключает ограничение.';
+$_lang['setting_sendex_csrf_protect'] = 'Включить CSRF-защиту на фронтенде';
+$_lang['setting_sendex_csrf_protect_desc'] = 'Добавляет CSRF-токен в формы подписки/отписки и проверяет его в snippet/AJAX.';

--- a/core/components/sendex/migrations/20260725170000_subscriber_user_id_index.php
+++ b/core/components/sendex/migrations/20260725170000_subscriber_user_id_index.php
@@ -1,0 +1,42 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Add index for subscriber user merge/group sync lookups (#103 P5).
+ */
+class SubscriberUserIdIndex extends AbstractMigration
+{
+    public function up()
+    {
+        if (!$this->hasTable('sendex_subscribers')) {
+            return;
+        }
+
+        $table = $this->table('sendex_subscribers');
+        if ($table->hasIndexByName('user_id')) {
+            return;
+        }
+
+        $table
+            ->addIndex(
+                array('user_id'),
+                array(
+                    'name' => 'user_id',
+                )
+            )
+            ->update();
+    }
+
+    public function down()
+    {
+        if (!$this->hasTable('sendex_subscribers')) {
+            return;
+        }
+
+        $table = $this->table('sendex_subscribers');
+        if ($table->hasIndexByName('user_id')) {
+            $table->removeIndexByName('user_id')->update();
+        }
+    }
+}

--- a/core/components/sendex/model/schema/sendex.mysql.schema.xml
+++ b/core/components/sendex/model/schema/sendex.mysql.schema.xml
@@ -41,6 +41,9 @@
         <index alias="code" name="code" primary="false" unique="true" type="BTREE">
             <column key="code" length="" collation="A" null="false" />
         </index>
+        <index alias="user_id" name="user_id" primary="false" unique="false" type="BTREE">
+            <column key="user_id" length="" collation="A" null="false" />
+        </index>
 
         <aggregate alias="Newsletter" class="sxNewsletter" local="newsletter_id" foreign="id" cardinality="one" owner="foreign" />
         <aggregate alias="User" class="modUser" local="user_id" foreign="id" cardinality="one" owner="foreign" />

--- a/core/components/sendex/model/sendex/mysql/sxsubscriber.map.inc.php
+++ b/core/components/sendex/model/sendex/mysql/sxsubscriber.map.inc.php
@@ -89,6 +89,22 @@ $xpdo_meta_map['sxSubscriber'] = array(
         ),
       ),
     ),
+    'user_id' =>
+    array(
+      'alias'   => 'user_id',
+      'primary' => false,
+      'unique'  => false,
+      'type'    => 'BTREE',
+      'columns' =>
+      array(
+        'user_id' =>
+        array(
+          'length'    => '',
+          'collation' => 'A',
+          'null'      => false,
+        ),
+      ),
+    ),
   ),
   'aggregates' =>
   array(

--- a/core/components/sendex/model/sendex/sxnewsletter.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletter.class.php
@@ -80,16 +80,18 @@ class sxNewsletter extends xPDOSimpleObject
      * @param int $user_id
      * @param int $linkTTL
      * @param bool $requireConfirm
+     * @param int $rateLimit
      * @return array{status:string,hash?:string,message?:string}
      */
-    public function subscribeGuest($email = '', $user_id = 0, $linkTTL = 1800, $requireConfirm = true)
+    public function subscribeGuest($email = '', $user_id = 0, $linkTTL = 1800, $requireConfirm = true, $rateLimit = 0)
     {
         return sxSubscribeConfirm::guestSubscribe(
             $this->subscription(),
             $email,
             $user_id,
             $linkTTL,
-            $requireConfirm
+            $requireConfirm,
+            $rateLimit
         );
     }
 

--- a/core/components/sendex/model/sendex/sxnewsletter.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletter.class.php
@@ -80,18 +80,16 @@ class sxNewsletter extends xPDOSimpleObject
      * @param int $user_id
      * @param int $linkTTL
      * @param bool $requireConfirm
-     * @param int $rateLimit
      * @return array{status:string,hash?:string,message?:string}
      */
-    public function subscribeGuest($email = '', $user_id = 0, $linkTTL = 1800, $requireConfirm = true, $rateLimit = 0)
+    public function subscribeGuest($email = '', $user_id = 0, $linkTTL = 1800, $requireConfirm = true)
     {
         return sxSubscribeConfirm::guestSubscribe(
             $this->subscription(),
             $email,
             $user_id,
             $linkTTL,
-            $requireConfirm,
-            $rateLimit
+            $requireConfirm
         );
     }
 

--- a/core/components/sendex/model/sendex/sxnewslettergroupsubscribe.class.php
+++ b/core/components/sendex/model/sendex/sxnewslettergroupsubscribe.class.php
@@ -2,7 +2,6 @@
 
 require_once dirname(__FILE__) . '/sxsubscribercode.class.php';
 require_once dirname(__FILE__) . '/sxsubscribermatch.class.php';
-
 /**
  * Bulk subscribe active group members to a newsletter (#70).
  * Mgr sync path: no per-row sxOn*Subscribe events (#44).
@@ -28,10 +27,7 @@ class sxNewsletterGroupSubscribe
             return true;
         }
 
-        /** @var sxSubscriber[] $existing */
-        $existing = $xpdo->getCollection('sxSubscriber', array(
-            'newsletter_id' => $newsletterId,
-        ));
+        $existing = self::fetchExistingSubscribers($xpdo, $newsletterId, $members);
 
         $plan = self::plan($members, $newsletterId, $existing, $xpdo);
         $errors = $plan['errors'];
@@ -48,6 +44,51 @@ class sxNewsletterGroupSubscribe
         }
 
         return $errors === array() ? true : $errors;
+    }
+
+    /**
+     * @param object $xpdo
+     * @param int $newsletterId
+     * @param array<int,array{user_id:int,username:string,email:string}> $members
+     * @return sxSubscriber[]
+     */
+    protected static function fetchExistingSubscribers($xpdo, $newsletterId, array $members)
+    {
+        $userIds = array();
+        $emails = array();
+        foreach ($members as $member) {
+            $userId = (int) $member['user_id'];
+            if ($userId > 0) {
+                $userIds[] = $userId;
+            }
+            $email = sxSubscriberMatch::normalizeEmail($member['email']);
+            if ($email !== '') {
+                $emails[] = $email;
+            }
+        }
+
+        $userIds = array_values(array_unique($userIds));
+        $emails = array_values(array_unique($emails));
+        if ($userIds === array() && $emails === array()) {
+            return array();
+        }
+
+        $criteria = array(
+            'newsletter_id' => (int) $newsletterId,
+        );
+        if ($userIds !== array() && $emails !== array()) {
+            $criteria[] = array(
+                'user_id:IN' => $userIds,
+                'OR:email:IN' => $emails,
+            );
+        } elseif ($userIds !== array()) {
+            $criteria['user_id:IN'] = $userIds;
+        } else {
+            $criteria['email:IN'] = $emails;
+        }
+
+        $existing = $xpdo->getCollection('sxSubscriber', $criteria);
+        return is_array($existing) ? $existing : array();
     }
 
     /**

--- a/core/components/sendex/model/sendex/sxnewslettersubscription.class.php
+++ b/core/components/sendex/model/sendex/sxnewslettersubscription.class.php
@@ -21,6 +21,14 @@ class sxNewsletterSubscription
     }
 
     /**
+     * @return sxNewsletter
+     */
+    public function newsletter()
+    {
+        return $this->newsletter;
+    }
+
+    /**
      * @param int $userId
      * @param string $email
      * @return int

--- a/core/components/sendex/model/sendex/sxqueueclaim.class.php
+++ b/core/components/sendex/model/sendex/sxqueueclaim.class.php
@@ -9,6 +9,11 @@
 class sxQueueClaim
 {
     /**
+     * @var string
+     */
+    private static $queueClass = 'sxQueue';
+
+    /**
      * @param object $xpdo
      * @param int $id
      * @return bool true when this worker owns the row
@@ -20,12 +25,50 @@ class sxQueueClaim
             return false;
         }
 
+        $claimed = self::tryAtomicDelete($xpdo, $id);
+        if ($claimed !== null) {
+            return $claimed;
+        }
+
         /** @var object|null $row */
-        $row = $xpdo->getObject('sxQueue', $id);
+        $row = $xpdo->getObject(self::$queueClass, $id);
         if (!$row) {
             return false;
         }
 
         return (bool) $row->remove();
+    }
+
+    /**
+     * @param object $xpdo
+     * @param int $id
+     * @return bool|null true/false when SQL path is available, null when fallback needed
+     */
+    private static function tryAtomicDelete($xpdo, $id)
+    {
+        if (!method_exists($xpdo, 'getConnection') || !method_exists($xpdo, 'getTableName')) {
+            return null;
+        }
+
+        $connection = $xpdo->getConnection();
+        if (!is_object($connection) || !method_exists($connection, 'prepare')) {
+            return null;
+        }
+
+        $table = (string) $xpdo->getTableName(self::$queueClass);
+        if ($table === '') {
+            return null;
+        }
+
+        $stmt = $connection->prepare('DELETE FROM ' . $table . ' WHERE id = ?');
+        if (!$stmt || !$stmt->execute(array($id))) {
+            return false;
+        }
+
+        if (!method_exists($stmt, 'rowCount')) {
+            return true;
+        }
+
+        return (int) $stmt->rowCount() > 0;
     }
 }

--- a/core/components/sendex/model/sendex/sxsubscribeconfirm.class.php
+++ b/core/components/sendex/model/sendex/sxsubscribeconfirm.class.php
@@ -72,7 +72,6 @@ class sxSubscribeConfirm
      * @param int $userId
      * @param int $linkTTL
      * @param bool $requireConfirm
-     * @param int $rateLimit
      * @return array{status:string,hash?:string,message?:string}
      */
     public static function guestSubscribe(
@@ -80,11 +79,8 @@ class sxSubscribeConfirm
         $email = '',
         $userId = 0,
         $linkTTL = 1800,
-        $requireConfirm = true,
-        $rateLimit = 0
+        $requireConfirm = true
     ) {
-        $xpdo = $subscription->newsletter()->xpdo;
-
         if (!$requireConfirm) {
             $result = $subscription->subscribe($userId, $email, 'guest');
             if ($result === true) {
@@ -98,10 +94,6 @@ class sxSubscribeConfirm
                 'status'  => 'error',
                 'message' => (string) $result,
             );
-        }
-
-        if (sxSubscribeRegistry::isConfirmRateLimited($xpdo, $email, $rateLimit)) {
-            return array('status' => 'rate_limited');
         }
 
         $response = $subscription->checkEmail($email, $userId, $linkTTL);

--- a/core/components/sendex/model/sendex/sxsubscribeconfirm.class.php
+++ b/core/components/sendex/model/sendex/sxsubscribeconfirm.class.php
@@ -24,6 +24,22 @@ class sxSubscribeConfirm
     }
 
     /**
+     * Snippet &confirmRateLimit= overrides system setting sendex_confirm_rate_limit.
+     *
+     * @param object $modx modX
+     * @param array $scriptProperties
+     * @return int
+     */
+    public static function rateLimitSeconds($modx, array $scriptProperties = array())
+    {
+        if (array_key_exists('confirmRateLimit', $scriptProperties)) {
+            return max(0, (int) $scriptProperties['confirmRateLimit']);
+        }
+
+        return max(0, (int) $modx->getOption('sendex_confirm_rate_limit', null, 0));
+    }
+
+    /**
      * @param mixed $value
      * @param bool $default
      * @return bool
@@ -56,6 +72,7 @@ class sxSubscribeConfirm
      * @param int $userId
      * @param int $linkTTL
      * @param bool $requireConfirm
+     * @param int $rateLimit
      * @return array{status:string,hash?:string,message?:string}
      */
     public static function guestSubscribe(
@@ -63,8 +80,11 @@ class sxSubscribeConfirm
         $email = '',
         $userId = 0,
         $linkTTL = 1800,
-        $requireConfirm = true
+        $requireConfirm = true,
+        $rateLimit = 0
     ) {
+        $xpdo = $subscription->newsletter()->xpdo;
+
         if (!$requireConfirm) {
             $result = $subscription->subscribe($userId, $email, 'guest');
             if ($result === true) {
@@ -78,6 +98,10 @@ class sxSubscribeConfirm
                 'status'  => 'error',
                 'message' => (string) $result,
             );
+        }
+
+        if (sxSubscribeRegistry::isConfirmRateLimited($xpdo, $email, $rateLimit)) {
+            return array('status' => 'rate_limited');
         }
 
         $response = $subscription->checkEmail($email, $userId, $linkTTL);

--- a/core/components/sendex/model/sendex/sxsubscribecsrf.class.php
+++ b/core/components/sendex/model/sendex/sxsubscribecsrf.class.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Frontend CSRF helper for subscribe/unsubscribe forms.
+ */
+class sxSubscribeCsrf
+{
+    public const SESSION_KEY = 'sendex_csrf_token';
+
+    /**
+     * @param object $modx
+     * @param array $scriptProperties
+     * @return bool
+     */
+    public static function isRequired($modx, array $scriptProperties = array())
+    {
+        if (array_key_exists('csrfProtect', $scriptProperties)) {
+            return self::parseBool($scriptProperties['csrfProtect']);
+        }
+
+        return self::parseBool($modx->getOption('sendex_csrf_protect', null, false));
+    }
+
+    /**
+     * @return string
+     */
+    public static function token()
+    {
+        if (!isset($_SESSION) || !is_array($_SESSION)) {
+            $_SESSION = array();
+        }
+
+        if (empty($_SESSION[self::SESSION_KEY])) {
+            $_SESSION[self::SESSION_KEY] = bin2hex(random_bytes(16));
+        }
+
+        return (string) $_SESSION[self::SESSION_KEY];
+    }
+
+    /**
+     * @param string $value
+     * @return bool
+     */
+    public static function isValid($value)
+    {
+        $token = isset($_SESSION[self::SESSION_KEY]) ? (string) $_SESSION[self::SESSION_KEY] : '';
+        if ($token === '') {
+            return false;
+        }
+
+        return hash_equals($token, (string) $value);
+    }
+
+    /**
+     * @param mixed $value
+     * @return bool
+     */
+    private static function parseBool($value)
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+        if ($value === null || $value === '') {
+            return false;
+        }
+
+        $normalized = strtolower(trim((string) $value));
+        return in_array($normalized, array('1', 'true', 'yes', 'on'), true);
+    }
+}

--- a/core/components/sendex/model/sendex/sxsubscriberegistry.class.php
+++ b/core/components/sendex/model/sendex/sxsubscriberegistry.class.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once dirname(__FILE__) . '/sxsubscribermatch.class.php';
+
 /**
  * Subscribe confirm hashes in modDbRegister (/sendex/subscribe/).
  */
@@ -8,6 +10,7 @@ class sxSubscribeRegistry
     const PATH_PREFIX = '/sendex/subscribe/';
     const DEFAULT_TTL = 1800;
     const EXPIRES_KEY = '_expires';
+    const RATE_LIMIT_PREFIX = 'rate:';
 
     /**
      * @param object $xpdo
@@ -101,6 +104,102 @@ class sxSubscribeRegistry
 
     /**
      * @param object $xpdo
+     * @param string $email
+     * @param int $window
+     * @return bool
+     */
+    public static function isConfirmRateLimited($xpdo, $email, $window)
+    {
+        $window = (int) $window;
+        if ($window < 1) {
+            return false;
+        }
+
+        $entry = self::consume($xpdo, self::rateLimitKey($email));
+        if ($entry === null) {
+            return false;
+        }
+
+        $ttl = self::remainingTtl($entry);
+        self::restore($xpdo, self::rateLimitKey($email), $entry);
+
+        return $ttl > 0;
+    }
+
+    /**
+     * @param object $xpdo
+     * @param string $email
+     * @param int $window
+     * @return bool
+     */
+    public static function touchConfirmRateLimit($xpdo, $email, $window)
+    {
+        $window = (int) $window;
+        if ($window < 1) {
+            return true;
+        }
+
+        return self::store(
+            $xpdo,
+            self::rateLimitKey($email),
+            array(
+                'email' => sxSubscriberMatch::normalizeEmail($email),
+                'type' => 'confirm_limit',
+            ),
+            $window
+        );
+    }
+
+    /**
+     * Best-effort lock: deny when active window exists, otherwise create it.
+     *
+     * @param object $xpdo
+     * @param string $email
+     * @param int $window
+     * @return bool
+     */
+    public static function claimConfirmRateLimit($xpdo, $email, $window)
+    {
+        $window = (int) $window;
+        if ($window < 1) {
+            return true;
+        }
+
+        $lockHandle = self::openRateLimitLock($email);
+        if ($lockHandle && function_exists('flock')) {
+            if (!flock($lockHandle, LOCK_EX)) {
+                fclose($lockHandle);
+                $lockHandle = null;
+            }
+        }
+
+        $allowed = !self::isConfirmRateLimited($xpdo, $email, $window);
+        if ($allowed) {
+            $allowed = self::touchConfirmRateLimit($xpdo, $email, $window);
+        }
+
+        if ($lockHandle && function_exists('flock')) {
+            flock($lockHandle, LOCK_UN);
+            fclose($lockHandle);
+        }
+
+        return $allowed;
+    }
+
+    /**
+     * Allow immediate retry after transient send failures.
+     *
+     * @param object $xpdo
+     * @param string $email
+     * @return void
+     */
+    public static function releaseConfirmRateLimit($xpdo, $email)
+    {
+        self::consume($xpdo, self::rateLimitKey($email));
+    }
+
+    /**
+     * @param object $xpdo
      * @return object|null
      */
     private static function register($xpdo)
@@ -111,5 +210,31 @@ class sxSubscribeRegistry
         }
 
         return $registry->getRegister('user', 'registry.modDbRegister');
+    }
+
+    /**
+     * @param string $email
+     * @return string
+     */
+    private static function rateLimitKey($email)
+    {
+        return self::RATE_LIMIT_PREFIX . sha1(strtolower(trim((string) $email)));
+    }
+
+    /**
+     * @param string $email
+     * @return resource|false
+     */
+    private static function openRateLimitLock($email)
+    {
+        if (!function_exists('sys_get_temp_dir') || !function_exists('fopen')) {
+            return false;
+        }
+
+        $path = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR)
+            . DIRECTORY_SEPARATOR
+            . 'sendex-confirm-' . sha1(strtolower(trim((string) $email))) . '.lock';
+
+        return @fopen($path, 'c');
     }
 }

--- a/core/components/sendex/model/sendex/sxsubscribermatch.class.php
+++ b/core/components/sendex/model/sendex/sxsubscribermatch.class.php
@@ -117,6 +117,14 @@ class sxSubscriberMatch
                 continue;
             }
 
+            if (substr((string) $key, -3) === ':IN') {
+                $field = substr((string) $key, 0, -3);
+                if (!self::inMatches($field, $subscriber->get($field), $value)) {
+                    return false;
+                }
+                continue;
+            }
+
             if ((string) $subscriber->get($key) !== (string) $value) {
                 return false;
             }
@@ -135,7 +143,24 @@ class sxSubscriberMatch
         foreach ($group as $key => $value) {
             if (strpos($key, 'OR:') === 0) {
                 $field = self::fieldFromOrKey($key);
-                if ($field !== '' && strcasecmp((string) $subscriber->get($field), (string) $value) === 0) {
+                if ($field === '') {
+                    continue;
+                }
+                if (substr($key, -3) === ':IN') {
+                    if (self::inMatches($field, $subscriber->get($field), $value)) {
+                        return true;
+                    }
+                    continue;
+                }
+                if (strcasecmp((string) $subscriber->get($field), (string) $value) === 0) {
+                    return true;
+                }
+                continue;
+            }
+
+            if (substr((string) $key, -3) === ':IN') {
+                $field = substr((string) $key, 0, -3);
+                if (self::inMatches($field, $subscriber->get($field), $value)) {
                     return true;
                 }
                 continue;
@@ -157,6 +182,32 @@ class sxSubscriberMatch
     {
         $parts = explode(':', $key);
         return isset($parts[1]) ? $parts[1] : '';
+    }
+
+    /**
+     * @param string $field
+     * @param mixed $actual
+     * @param mixed $values
+     * @return bool
+     */
+    private static function inMatches($field, $actual, $values)
+    {
+        $actual = (string) $actual;
+        $candidates = is_array($values) ? $values : array($values);
+        foreach ($candidates as $candidate) {
+            $candidate = (string) $candidate;
+            if ($field === 'email') {
+                if (strcasecmp($actual, $candidate) === 0) {
+                    return true;
+                }
+                continue;
+            }
+            if ($actual === $candidate) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/core/components/sendex/model/sendex/sxsubscribermerge.class.php
+++ b/core/components/sendex/model/sendex/sxsubscribermerge.class.php
@@ -112,20 +112,16 @@ class sxSubscriberMerge
         $q = $xpdo->newQuery('sxSubscriber');
         $q->where(array(
             'user_id' => 0,
+            array(
+                'email' => $email,
+                'OR:email:=' => $email,
+            ),
         ));
 
         $rows = $xpdo->getCollection('sxSubscriber', $q);
         if (!is_array($rows)) {
             return array();
         }
-
-        $matched = array();
-        foreach ($rows as $subscriber) {
-            if (strcasecmp((string) $subscriber->get('email'), $email) === 0) {
-                $matched[] = $subscriber;
-            }
-        }
-
-        return $matched;
+        return $rows;
     }
 }

--- a/core/components/sendex/processors/mgr/newsletter/subscriber/getlist.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/subscriber/getlist.class.php
@@ -47,10 +47,10 @@ class sxSubscriberGetListProcessor extends modObjectGetListProcessor
         $array = $object->toArray();
 
         if (empty($array['username'])) {
-            $array['username'] = 'Guest';
+            $array['username'] = $this->modx->lexicon('sendex_subscriber_guest');
         }
         if (empty($array['fullname'])) {
-            $array['fullname'] = 'Anonymous';
+            $array['fullname'] = $this->modx->lexicon('sendex_subscriber_anonymous');
         }
 
         $array['actions'] = array();

--- a/core/components/sendex/sendexmaincontroller.class.php
+++ b/core/components/sendex/sendexmaincontroller.class.php
@@ -60,6 +60,7 @@ abstract class SendexMainController extends modExtraManagerController
      */
     public function checkPermissions()
     {
-        return true;
+        return $this->modx->hasPermission('view_sendex')
+            || $this->modx->hasPermission('view_document');
     }
 }

--- a/tests/Stubs/FakePdoStatement.php
+++ b/tests/Stubs/FakePdoStatement.php
@@ -14,6 +14,9 @@ class FakePdoStatement
     /** @var string */
     private $sql;
 
+    /** @var int */
+    private $affectedRows = 0;
+
     /**
      * @param FakeModX $modx
      * @param FakePdoConnection $connection
@@ -39,10 +42,18 @@ class FakePdoStatement
         );
 
         if (!$this->connection->executeResult) {
+            $this->affectedRows = 0;
             return false;
         }
 
+        if (stripos($this->sql, 'DELETE FROM') === 0) {
+            $this->affectedRows = $this->deleteQueueRow($values);
+
+            return true;
+        }
+
         $rowCount = (int) (count($values) / 4);
+        $this->affectedRows = $rowCount;
         for ($i = 0; $i < $rowCount; $i++) {
             $offset = $i * 4;
             $subscriber = new sxSubscriber($this->modx);
@@ -57,5 +68,38 @@ class FakePdoStatement
         }
 
         return true;
+    }
+
+    /**
+     * @return int
+     */
+    public function rowCount()
+    {
+        return $this->affectedRows;
+    }
+
+    /**
+     * @param array $values
+     * @return int
+     */
+    private function deleteQueueRow(array $values)
+    {
+        $id = isset($values[0]) ? (int) $values[0] : 0;
+        if ($id <= 0) {
+            return 0;
+        }
+
+        foreach ($this->modx->queues as $index => $queue) {
+            if ((int) $queue->get('id') !== $id) {
+                continue;
+            }
+
+            unset($this->modx->queues[$index]);
+            $this->modx->queues = array_values($this->modx->queues);
+
+            return 1;
+        }
+
+        return 0;
     }
 }

--- a/tests/Unit/MgrGridSelectionContractTest.php
+++ b/tests/Unit/MgrGridSelectionContractTest.php
@@ -76,4 +76,19 @@ class MgrGridSelectionContractTest extends TestCase
         $this->assertStringContainsString('sendex_selection_err_ns', $en);
         $this->assertStringContainsString('sendex_selection_err_ns', $ru);
     }
+
+    public function testNewsletterGridRenderersEscapeImageAndCloseSpanTags()
+    {
+        $source = file_get_contents(
+            dirname(__DIR__, 2) . '/assets/components/sendex/js/mgr/widgets/newsletters.grid.js'
+        );
+
+        $this->assertStringContainsString("'</span>'", $source);
+        $this->assertStringContainsString('_escapeHtmlAttr: function(value)', $source);
+        $this->assertStringContainsString(".replace(/\"/g, '&quot;')", $source);
+        $this->assertStringContainsString(
+            "return '<img src=\"' + this._escapeHtmlAttr(val) + '\" alt=\"\" height=\"50\" />';",
+            $source
+        );
+    }
 }

--- a/tests/Unit/NewsletterSubscribeGuestTest.php
+++ b/tests/Unit/NewsletterSubscribeGuestTest.php
@@ -38,15 +38,6 @@ class NewsletterSubscribeGuestTest extends TestCase
         $this->assertCount(0, $this->modx->subscribers);
     }
 
-    public function testConfirmFlowReturnsRateLimitedWhenWindowActive()
-    {
-        sxSubscribeRegistry::touchConfirmRateLimit($this->modx, 'guest@example.com', 120);
-
-        $result = $this->newsletter->subscribeGuest('guest@example.com', 0, 600, true, 120);
-
-        $this->assertSame('rate_limited', $result['status']);
-    }
-
     public function testAlreadySubscribedReturnsAlready()
     {
         $subscriber = new sxSubscriber($this->modx);

--- a/tests/Unit/NewsletterSubscribeGuestTest.php
+++ b/tests/Unit/NewsletterSubscribeGuestTest.php
@@ -38,6 +38,15 @@ class NewsletterSubscribeGuestTest extends TestCase
         $this->assertCount(0, $this->modx->subscribers);
     }
 
+    public function testConfirmFlowReturnsRateLimitedWhenWindowActive()
+    {
+        sxSubscribeRegistry::touchConfirmRateLimit($this->modx, 'guest@example.com', 120);
+
+        $result = $this->newsletter->subscribeGuest('guest@example.com', 0, 600, true, 120);
+
+        $this->assertSame('rate_limited', $result['status']);
+    }
+
     public function testAlreadySubscribedReturnsAlready()
     {
         $subscriber = new sxSubscriber($this->modx);

--- a/tests/Unit/QueueClaimTest.php
+++ b/tests/Unit/QueueClaimTest.php
@@ -25,6 +25,19 @@ class QueueClaimTest extends TestCase
         $this->assertFalse(sxQueueClaim::tryClaim($this->modx, 5));
     }
 
+    public function testTryClaimUsesAtomicDeleteWithoutPreloadingRow()
+    {
+        $this->modx->queues[] = $this->queue(8, 'atomic@example.com');
+
+        $first = sxQueueClaim::tryClaim($this->modx, 8);
+        $second = sxQueueClaim::tryClaim($this->modx, 8);
+
+        $this->assertTrue($first);
+        $this->assertFalse($second);
+        $this->assertSame(0, isset($this->modx->getObjectCalls['sxQueue']) ? $this->modx->getObjectCalls['sxQueue'] : 0);
+        $this->assertSame(2, $this->modx->getConnection()->executeCalls);
+    }
+
     public function testTryClaimRejectsInvalidId()
     {
         $this->assertFalse(sxQueueClaim::tryClaim($this->modx, 0));

--- a/tests/Unit/SendexProcessorAclTest.php
+++ b/tests/Unit/SendexProcessorAclTest.php
@@ -72,4 +72,23 @@ class SendexProcessorAclTest extends TestCase
             $this->assertStringContainsString("'view_document'", $source, $file);
         }
     }
+
+    public function testManagerControllerChecksViewPermission()
+    {
+        $source = file_get_contents(
+            dirname(__DIR__, 2) . '/core/components/sendex/sendexmaincontroller.class.php'
+        );
+
+        $this->assertStringContainsString("hasPermission('view_sendex')", $source);
+        $this->assertStringContainsString("hasPermission('view_document')", $source);
+    }
+
+    public function testTransportMenuDeclaresPermission()
+    {
+        $source = file_get_contents(
+            dirname(__DIR__, 2) . '/_build/data/transport.menu.php'
+        );
+
+        $this->assertStringContainsString("'permissions' => 'view_document'", $source);
+    }
 }

--- a/tests/Unit/SendexSendEmailTest.php
+++ b/tests/Unit/SendexSendEmailTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sendex.class.php';
+
+class SendexSendEmailTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    protected function setUp(): void
+    {
+        $this->modx = new class extends FakeModX {
+            /** @var object */
+            public $lexicon;
+
+            public function __construct()
+            {
+                parent::__construct();
+                $this->lexicon = new class {
+                    public function load($topic)
+                    {
+                    }
+                };
+            }
+
+            public function addPackage($name, $path)
+            {
+            }
+        };
+
+        $this->modx->options['core_path'] = dirname(__DIR__, 2) . '/core/';
+        $this->modx->options['assets_url'] = '/assets/';
+    }
+
+    public function testSendEmailReturnsTrueOnSuccess()
+    {
+        $sendex = new Sendex($this->modx);
+        $result = $sendex->sendEmail('user@example.com', array(
+            'email_subject' => 'Hello',
+            'link' => 'https://example.com/confirm',
+            'email_body' => '<p>Body</p>',
+        ));
+
+        $this->assertTrue($result);
+    }
+
+    public function testSendEmailReturnsMailerErrorOnFailure()
+    {
+        /** @var FakeMail $mail */
+        $mail = $this->modx->getService('mail');
+        $mail->sendResult = false;
+        $mail->mailer->ErrorInfo = 'SMTP down';
+
+        $sendex = new Sendex($this->modx);
+        $result = $sendex->sendEmail('user@example.com', array(
+            'email_subject' => 'Hello',
+            'link' => 'https://example.com/confirm',
+            'email_body' => '<p>Body</p>',
+        ));
+
+        $this->assertSame('SMTP down', $result);
+    }
+}

--- a/tests/Unit/SnippetSubscribeConfirmContractTest.php
+++ b/tests/Unit/SnippetSubscribeConfirmContractTest.php
@@ -11,6 +11,11 @@ class SnippetSubscribeConfirmContractTest extends TestCase
         );
 
         $this->assertStringContainsString('sxSubscribeConfirm::isRequired', $source);
+        $this->assertStringContainsString('sxSubscribeConfirm::rateLimitSeconds', $source);
+        $this->assertStringContainsString('sxSubscribeCsrf::isRequired', $source);
+        $this->assertStringContainsString('sxSubscribeCsrf::isValid', $source);
+        $this->assertStringContainsString("&& \$method === 'POST'", $source);
+        $this->assertStringContainsString("array('subscribe', 'unsubscribe')", $source);
         $this->assertStringContainsString('subscribeGuest(', $source);
         $this->assertStringNotContainsString('->checkEmail(', $source);
     }

--- a/tests/Unit/SubscribeConfirmTest.php
+++ b/tests/Unit/SubscribeConfirmTest.php
@@ -47,4 +47,13 @@ class SubscribeConfirmTest extends TestCase
     {
         $this->assertTrue(sxSubscribeConfirm::isRequired($this->modx, array()));
     }
+
+    public function testRateLimitUsesSnippetOverrideThenSetting()
+    {
+        $this->modx->options['sendex_confirm_rate_limit'] = 30;
+
+        $this->assertSame(15, sxSubscribeConfirm::rateLimitSeconds($this->modx, array('confirmRateLimit' => 15)));
+        $this->assertSame(30, sxSubscribeConfirm::rateLimitSeconds($this->modx, array()));
+        $this->assertSame(0, sxSubscribeConfirm::rateLimitSeconds($this->modx, array('confirmRateLimit' => -5)));
+    }
 }

--- a/tests/Unit/SubscribeCsrfTest.php
+++ b/tests/Unit/SubscribeCsrfTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sxsubscribecsrf.class.php';
+
+class SubscribeCsrfTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+        $_SESSION = array();
+    }
+
+    public function testIsRequiredUsesSnippetOverrideAndSetting()
+    {
+        $this->modx->options['sendex_csrf_protect'] = false;
+
+        $this->assertTrue(sxSubscribeCsrf::isRequired($this->modx, array('csrfProtect' => '1')));
+        $this->assertFalse(sxSubscribeCsrf::isRequired($this->modx, array('csrfProtect' => '0')));
+        $this->assertFalse(sxSubscribeCsrf::isRequired($this->modx, array()));
+    }
+
+    public function testTokenAndValidation()
+    {
+        $token = sxSubscribeCsrf::token();
+
+        $this->assertNotSame('', $token);
+        $this->assertTrue(sxSubscribeCsrf::isValid($token));
+        $this->assertFalse(sxSubscribeCsrf::isValid('wrong'));
+    }
+}

--- a/tests/Unit/SubscribeRegistryTest.php
+++ b/tests/Unit/SubscribeRegistryTest.php
@@ -6,6 +6,14 @@ require_once dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sxsubsc
 
 class SubscribeRegistryTest extends TestCase
 {
+    /** @var FakeModX */
+    private $modx;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+    }
+
     public function testRemainingTtlUsesExpiresMeta(): void
     {
         $ttl = sxSubscribeRegistry::remainingTtl(array(
@@ -29,5 +37,38 @@ class SubscribeRegistryTest extends TestCase
             1,
             sxSubscribeRegistry::remainingTtl(array('_expires' => time() - 10))
         );
+    }
+
+    public function testStoreAndConsumeRoundtrip(): void
+    {
+        $stored = sxSubscribeRegistry::store(
+            $this->modx,
+            'hash1',
+            array('email' => 'a@example.com'),
+            120
+        );
+        $entry = sxSubscribeRegistry::consume($this->modx, 'hash1');
+
+        $this->assertTrue($stored);
+        $this->assertIsArray($entry);
+        $this->assertSame('a@example.com', $entry['email']);
+        $this->assertArrayHasKey('_expires', $entry);
+    }
+
+    public function testConfirmRateLimitTouchAndCheck(): void
+    {
+        $this->assertFalse(sxSubscribeRegistry::isConfirmRateLimited($this->modx, 'a@example.com', 60));
+        sxSubscribeRegistry::touchConfirmRateLimit($this->modx, 'a@example.com', 60);
+        $this->assertTrue(sxSubscribeRegistry::isConfirmRateLimited($this->modx, 'a@example.com', 60));
+    }
+
+    public function testConfirmRateLimitClaimAndRelease(): void
+    {
+        $this->assertTrue(sxSubscribeRegistry::claimConfirmRateLimit($this->modx, 'a@example.com', 60));
+        $this->assertFalse(sxSubscribeRegistry::claimConfirmRateLimit($this->modx, 'a@example.com', 60));
+
+        sxSubscribeRegistry::releaseConfirmRateLimit($this->modx, 'a@example.com');
+
+        $this->assertTrue(sxSubscribeRegistry::claimConfirmRateLimit($this->modx, 'a@example.com', 60));
     }
 }

--- a/tests/Unit/SubscriberMergeTest.php
+++ b/tests/Unit/SubscriberMergeTest.php
@@ -59,6 +59,21 @@ class SubscriberMergeTest extends TestCase
         $this->assertSame(8, (int) $this->modx->subscribers[0]->get('user_id'));
     }
 
+    public function testAttachGuestsByEmailWithLargeGuestPoolUpdatesOnlyMatchingRows()
+    {
+        for ($i = 1; $i <= 1000; $i++) {
+            $this->modx->subscribers[] = $this->guest($i, 10, 'bulk' . $i . '@example.com');
+        }
+        $target = $this->guest(1001, 10, 'Target@Example.com');
+        $this->modx->subscribers[] = $target;
+
+        $updated = sxSubscriberMerge::attachGuestsByEmail($this->modx, 77, 'target@example.com');
+
+        $this->assertSame(1, $updated);
+        $this->assertSame(77, (int) $target->get('user_id'));
+        $this->assertSame(0, (int) $this->modx->subscribers[0]->get('user_id'));
+    }
+
     public function testEmailFromUserReturnsEmptyWithoutProfile()
     {
         $user = new modUser($this->modx);


### PR DESCRIPTION
Закрывает оставшиеся задачи #103 в одном PR: security/perf/ACL/CI/docs после roadmap #75.

Сделано:
- P1: `sxQueueClaim` переведен на atomic `DELETE ... WHERE id = ?` c проверкой `rowCount()`; добавлены тесты на single-owner claim.
- P2: добавлены опциональные frontend-защиты: CSRF (`sendex_csrf_protect`) и confirm rate limit (`sendex_confirm_rate_limit`, 0=off) с безопасным claim/release around send.
- P3/P4: сохранены и расширены ранее внесенные security-фиксы (mail header sanitization, mgr-grid XSS/HTML).
- P5: устранены full-scan паттерны в merge/group subscribe, добавлен индекс `user_id` через Phinx миграцию `20260725170000_subscriber_user_id_index.php`, schema/map синхронизированы.
- P6: `SendexMainController::checkPermissions()` теперь проверяет `view_sendex || view_document`; menu transport получил явный `permissions`.
- P7: CI расширен coverage-артефактом (Clover), интеграционным smoke job (MODX 2.8/3.x, allow-failure), добавлен tag-based release workflow.
- P8: добавлены unit/contract тесты на новые security/rate-limit/claim/sendEmail сценарии.
- P9/P10: убраны hardcoded UI-строки в пользу lexicon, обновлен README раздел про тесты/покрытие.

Review:
- Pass 1: были findings (CSRF regression, premature rate-limit, auth subscribe success regression, inconsistent IN matching) — все исправлены.
- Pass 2 (re-run): Findings: none (/code-review + code-reviewer + thermo-nuclear).

Проверка:
- `composer test` — exit 0 (258 tests, 805 assertions)
- `composer phpcs` — exit 0
- Миграция: `core/components/sendex/migrations/20260725170000_subscriber_user_id_index.php`

Fixes #103