### PR TITLE
feat(migrations): harden queue claim and utf8mb4 upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ Build/package notes:
 - `core/components/sendex/bootstrap.php` — shared init for connector, mgr, and cron (autoload + processor base aliases).
 - `sxModxCompat` / `sxUserProfile` — MODX 2/3 boundary for mail, parser, registry, and user/profile placeholders.
 
-Not covered yet (see [#74](https://github.com/modx-pro/Sendex/issues/74)): new non-ExtJS admin UI, CI matrix MODX 2.8 + 3.x.
-
 ## Features
 
 - Newsletters and subscribers in the manager
@@ -38,6 +36,17 @@ Schema changes ship as Phinx migrations (same pattern as MiniShop3):
 - Config: `core/components/sendex/phinx.php`
 - Migrations: `core/components/sendex/migrations/`
 - Metadata table: `{table_prefix}sendex_migrations`
+
+Current upgrade chain:
+
+1. `20260724120000_initial_schema.php`
+2. `20260724120100_subscriber_unique_email.php`
+3. `20260724130000_innodb_queue_subscriber_link.php`
+4. `20260725123000_purge_orphan_queue_rows.php`
+5. `20260725170000_subscriber_user_id_index.php`
+6. `20260725190000_add_queue_claim_fields.php`
+7. `20260725191000_convert_sendex_tables_to_utf8mb4.php`
+8. `20260725192000_normalize_subscriber_email_collation.php`
 
 Before building the transport package, install runtime deps into the component:
 

--- a/assets/components/sendex/css/mgr/main.css
+++ b/assets/components/sendex/css/mgr/main.css
@@ -2,17 +2,17 @@
     background: transparent !important;
 }
 
-.x-grid3-col-image {padding: 2px 0 2px 5px;}
-.x-grid3-col-actions {padding: 3px 0 3px 5px;}
+.x-grid3-col-image {padding: 0.125rem 0 0.125rem 0.3125rem;}
+.x-grid3-col-actions {padding: 0.1875rem 0 0.1875rem 0.3125rem;}
 
 ul.sendex-row-actions {margin:0; padding: 0; list-style: none;}
 ul.sendex-row-actions li {float:left;}
-ul.sendex-row-actions .btn {padding: 5px; margin-right:2px; min-width:26px; font-size: inherit;}
+ul.sendex-row-actions .btn {padding: 0.3125rem; margin-right:0.125rem; min-width:1.625rem; font-size: inherit;}
 ul.sendex-row-actions .btn > .icon,
 ul.sendex-row-actions .btn > .fa {
     font-family: "Font Awesome 5 Free";
     font-weight: 900;
-    line-height: 16px;
+    line-height: 1rem;
 }
 ul.sendex-row-actions .btn > .icon.icon-check-circle-o,
 ul.sendex-row-actions .btn > .icon.icon-trash-o,
@@ -30,7 +30,7 @@ a.x-menu-item .x-menu-item-text, a.x-menu-item .x-menu-item-text .fa,
 a.x-menu-item .x-menu-item-text .icon {cursor: pointer;}
 a.x-menu-item .x-menu-item-text .fa,
 a.x-menu-item .x-menu-item-text .icon {
-    line-height:16px;
+    line-height:1rem;
     top:auto;
     font-family: "Font Awesome 5 Free";
     font-weight: 900;
@@ -43,9 +43,17 @@ a.x-menu-item .x-menu-item-text .icon.icon-paper-plane-o {
 }
 .x-menu-list .fa,
 .x-menu-list .icon {min-width: 1em; text-align:center;}
-.fa.actions-menu {width: 40px;}
+.fa.actions-menu {width: 2.5rem;}
 .fa.actions-menu:after {content: " \f107";}
 
 .sendex-row-disabled {font-style: italic; opacity: .6; color: #555;}
 
-#sendex-grid-newsletter-subscribers .x-toolbar-right-row .x-form-field-wrap{margin-right: 1px;}
+#sendex-grid-newsletter-subscribers .x-toolbar-right-row .x-form-field-wrap{margin-right: 0.0625rem;}
+
+#sendex-panel-home-div .x-tab-panel {
+    margin: 0 1rem 1rem 0;
+}
+
+#sendex-panel-home-div .x-grid3 {
+    margin-bottom: 0.75rem;
+}

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - [#42] Frontend AJAX subscribe/unsubscribe: JSON `{success, message, html}` from snippet, default chunks + `assets/components/sendex/js/web/sendex.js`. Multi-widget pages scope POST via `newsletter_id` and optional `widgetKey`.
-- [#38] Guest subscribe can skip email confirmation: snippet `&confirmEmail=`0`` or system setting `sendex_confirm_email`; domain helper `subscribeGuest()` keeps one subscribe path.
+- [#38] Guest subscribe can skip email confirmation: snippet `&confirmEmail=0` or system setting `sendex_confirm_email`; domain helper `subscribeGuest()` keeps one subscribe path.
 - [#29] Mgr newsletter «Send to subscribers»: one action runs `addQueues` + `sxQueueSender::flush` for the newsletter (`mgr/newsletter/send`); button in grid row actions and update window.
 - [#46] Search subscribers and queue by email or username.
 - [#44] Plugin events for subscribe/unsubscribe (`sxOnBeforeSubscribe`, `sxOnSubscribe`, `sxOnBeforeUnsubscribe`, `sxOnUnsubscribe`).
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#57] `addQueues` returns an error when 0 queue rows were created (all subscribers skipped); mgr `queue/add` reports the created count on success.
 - [#55] Queue send claims the row (remove-before-send) so parallel cron/mgr workers do not double-deliver; mail failure requeues and logs; cron logs non-true `send()` results.
 - [#103] Queue claim uses atomic `DELETE ... WHERE id = ?` with `rowCount()` fallback-safe behavior for single-owner delivery.
+- [#105] Queue claim switches to `UPDATE ... SET claimed_at, attempts = attempts + 1 ... WHERE claimed_at IS NULL` with legacy delete fallback.
 - [#56] Unsubscribe from email: snippet resolves newsletter by subscriber `code` when snippet `&id` differs; default letter link includes `newsletter_id` (not MODX resource `id`).
 - [#67] / [#52] Schema and upgrade: Sendex tables use InnoDB; queue index renamed `user_id` → `subscriber_id`; `addQueues` stores `sxSubscriber.id` (not `user_id`); Phinx backfill remaps legacy queue rows (by user_id, guests by email).
 - [#54] `isSubscribed` matches by `user_id` OR `email` within a newsletter; unique key is `(newsletter_id, email)`; guest rows attach `user_id` when the same email confirms as a user.
@@ -58,6 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#73] Newsletter mgr `getlist`: COUNT runs on filters only; JOIN/COUNT(`Subscribers`)/GROUP BY moved to `prepareQueryAfterCount` via `sxNewsletterListQuery`.
 - [#103] Group subscribe loads only relevant existing rows (`user_id/email` subset) instead of all newsletter subscribers.
 - [#103] Subscriber schema adds `user_id` index via Phinx migration `20260725170000_subscriber_user_id_index.php`.
+- [#105] Queue schema adds claim/retry fields (`claimed_at`, `attempts`, `expires_at`) and normalizes `subscriber_id` to `NOT NULL DEFAULT 0`.
+- [#105] Sendex tables are converted to `utf8mb4_unicode_ci`; subscriber email is backfilled to lowercase and uses case-insensitive `utf8mb4` collation.
 - [#103] Mgr controller ACL now checks `view_sendex` or `view_document`; transport menu declares explicit `view_document` permission.
 - [#103] Frontend i18n cleanup: lexicon-based request failure text, guest/anonymous labels, and email placeholder.
 - [#103] CI adds integration smoke matrix (MODX 2.8/3.x, allow-failure), Clover coverage artifact, and tag-driven release workflow.

--- a/core/components/sendex/migrations/20260725190000_add_queue_claim_fields.php
+++ b/core/components/sendex/migrations/20260725190000_add_queue_claim_fields.php
@@ -1,0 +1,82 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Queue fields for atomic claim/retry flow (#105 M2, M11).
+ */
+class AddQueueClaimFields extends AbstractMigration
+{
+    public function up()
+    {
+        if (!$this->hasTable('sendex_queue')) {
+            return;
+        }
+
+        $table = $this->table('sendex_queue');
+
+        if (!$table->hasColumn('claimed_at')) {
+            $table->addColumn('claimed_at', 'timestamp', array(
+                'null' => true,
+                'default' => null,
+                'after' => 'timestamp',
+            ));
+        }
+        if (!$table->hasColumn('attempts')) {
+            $table->addColumn('attempts', 'integer', array(
+                'limit' => 10,
+                'null' => false,
+                'default' => 0,
+                'signed' => false,
+                'after' => 'claimed_at',
+            ));
+        }
+        if (!$table->hasColumn('expires_at')) {
+            $table->addColumn('expires_at', 'timestamp', array(
+                'null' => true,
+                'default' => null,
+                'after' => 'attempts',
+            ));
+        }
+
+        // Keep queue link policy explicit: guest rows use 0, not NULL.
+        if ($table->hasColumn('subscriber_id')) {
+            $table->changeColumn('subscriber_id', 'integer', array(
+                'limit' => 10,
+                'null' => false,
+                'default' => 0,
+                'signed' => false,
+            ));
+        }
+
+        $table->update();
+    }
+
+    public function down()
+    {
+        if (!$this->hasTable('sendex_queue')) {
+            return;
+        }
+
+        $table = $this->table('sendex_queue');
+        if ($table->hasColumn('expires_at')) {
+            $table->removeColumn('expires_at');
+        }
+        if ($table->hasColumn('attempts')) {
+            $table->removeColumn('attempts');
+        }
+        if ($table->hasColumn('claimed_at')) {
+            $table->removeColumn('claimed_at');
+        }
+        if ($table->hasColumn('subscriber_id')) {
+            $table->changeColumn('subscriber_id', 'integer', array(
+                'limit' => 10,
+                'null' => true,
+                'default' => 0,
+                'signed' => false,
+            ));
+        }
+
+        $table->update();
+    }
+}

--- a/core/components/sendex/migrations/20260725191000_convert_sendex_tables_to_utf8mb4.php
+++ b/core/components/sendex/migrations/20260725191000_convert_sendex_tables_to_utf8mb4.php
@@ -1,0 +1,58 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Normalize Sendex tables to utf8mb4 (#105 M7).
+ */
+class ConvertSendexTablesToUtf8mb4 extends AbstractMigration
+{
+    /** @var string[] */
+    private $sendexTableNames = array(
+        'sendex_newsletters',
+        'sendex_subscribers',
+        'sendex_queue',
+    );
+
+    public function up()
+    {
+        foreach ($this->sendexTableNames as $tableName) {
+            if (!$this->hasTable($tableName)) {
+                continue;
+            }
+            $this->execute(
+                'ALTER TABLE ' . $this->quotedTableName($tableName)
+                . ' CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci'
+            );
+        }
+    }
+
+    public function down()
+    {
+        foreach ($this->sendexTableNames as $tableName) {
+            if (!$this->hasTable($tableName)) {
+                continue;
+            }
+            $this->execute(
+                'ALTER TABLE ' . $this->quotedTableName($tableName)
+                . ' CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci'
+            );
+        }
+    }
+
+    /**
+     * @param string $tableName
+     * @return string
+     */
+    private function quotedTableName($tableName)
+    {
+        $adapter = $this->getAdapter();
+        if (method_exists($adapter, 'getAdapterTableName')) {
+            $tableName = $adapter->getAdapterTableName($tableName);
+        } elseif ($adapter->hasOption('table_prefix')) {
+            $tableName = (string) $adapter->getOption('table_prefix') . $tableName;
+        }
+
+        return $adapter->quoteTableName($tableName);
+    }
+}

--- a/core/components/sendex/migrations/20260725192000_normalize_subscriber_email_collation.php
+++ b/core/components/sendex/migrations/20260725192000_normalize_subscriber_email_collation.php
@@ -1,0 +1,54 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Lowercase subscriber emails and enforce case-insensitive collation (#105 M8).
+ */
+class NormalizeSubscriberEmailCollation extends AbstractMigration
+{
+    public function up()
+    {
+        if (!$this->hasTable('sendex_subscribers')) {
+            return;
+        }
+
+        $table = $this->quotedTableName('sendex_subscribers');
+        $this->execute(
+            'UPDATE ' . $table . ' SET email = LOWER(email) WHERE email IS NOT NULL'
+        );
+        $this->execute(
+            'ALTER TABLE ' . $table
+            . ' MODIFY email VARCHAR(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL DEFAULT \'\''
+        );
+    }
+
+    public function down()
+    {
+        if (!$this->hasTable('sendex_subscribers')) {
+            return;
+        }
+
+        $table = $this->quotedTableName('sendex_subscribers');
+        $this->execute(
+            'ALTER TABLE ' . $table
+            . ' MODIFY email VARCHAR(191) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT \'\''
+        );
+    }
+
+    /**
+     * @param string $tableName
+     * @return string
+     */
+    private function quotedTableName($tableName)
+    {
+        $adapter = $this->getAdapter();
+        if (method_exists($adapter, 'getAdapterTableName')) {
+            $tableName = $adapter->getAdapterTableName($tableName);
+        } elseif ($adapter->hasOption('table_prefix')) {
+            $tableName = (string) $adapter->getOption('table_prefix') . $tableName;
+        }
+
+        return $adapter->quoteTableName($tableName);
+    }
+}

--- a/core/components/sendex/model/schema/sendex.mysql.schema.xml
+++ b/core/components/sendex/model/schema/sendex.mysql.schema.xml
@@ -52,8 +52,11 @@
 
     <object class="sxQueue" table="sendex_queue" extends="xPDOSimpleObject">
         <field key="newsletter_id" dbtype="int" precision="10" phptype="integer" attributes="unsigned" null="false" default="0" />
-        <field key="subscriber_id" dbtype="int" precision="10" phptype="integer" attributes="unsigned" null="true" default="0" />
+        <field key="subscriber_id" dbtype="int" precision="10" phptype="integer" attributes="unsigned" null="false" default="0" />
         <field key="timestamp" dbtype="timestamp" phptype="timestamp" null="false" default="CURRENT_TIMESTAMP" />
+        <field key="claimed_at" dbtype="timestamp" phptype="timestamp" null="true" default="NULL" />
+        <field key="attempts" dbtype="int" precision="10" phptype="integer" attributes="unsigned" null="false" default="0" />
+        <field key="expires_at" dbtype="timestamp" phptype="timestamp" null="true" default="NULL" />
 
         <field key="email_to" dbtype="varchar" precision="191" phptype="string" null="true" default="" />
         <field key="email_subject" dbtype="varchar" precision="191" phptype="string" null="true" default="" />

--- a/core/components/sendex/model/sendex/mysql/sxqueue.map.inc.php
+++ b/core/components/sendex/model/sendex/mysql/sxqueue.map.inc.php
@@ -10,6 +10,9 @@ $xpdo_meta_map['sxQueue'] = array(
     'newsletter_id'   => 0,
     'subscriber_id'   => 0,
     'timestamp'       => 'CURRENT_TIMESTAMP',
+    'claimed_at'      => null,
+    'attempts'        => 0,
+    'expires_at'      => null,
     'email_to'        => '',
     'email_subject'   => '',
     'email_body'      => '',
@@ -35,7 +38,7 @@ $xpdo_meta_map['sxQueue'] = array(
       'precision'  => '10',
       'phptype'    => 'integer',
       'attributes' => 'unsigned',
-      'null'       => true,
+      'null'       => false,
       'default'    => 0,
     ),
     'timestamp'       =>
@@ -44,6 +47,29 @@ $xpdo_meta_map['sxQueue'] = array(
       'phptype' => 'timestamp',
       'null'    => false,
       'default' => 'CURRENT_TIMESTAMP',
+    ),
+    'claimed_at'      =>
+    array(
+      'dbtype'  => 'timestamp',
+      'phptype' => 'timestamp',
+      'null'    => true,
+      'default' => null,
+    ),
+    'attempts'        =>
+    array(
+      'dbtype'     => 'int',
+      'precision'  => '10',
+      'phptype'    => 'integer',
+      'attributes' => 'unsigned',
+      'null'       => false,
+      'default'    => 0,
+    ),
+    'expires_at'      =>
+    array(
+      'dbtype'  => 'timestamp',
+      'phptype' => 'timestamp',
+      'null'    => true,
+      'default' => null,
     ),
     'email_to'        =>
     array(

--- a/core/components/sendex/model/sendex/sxqueueclaim.class.php
+++ b/core/components/sendex/model/sendex/sxqueueclaim.class.php
@@ -1,17 +1,26 @@
 <?php
 
 /**
- * Atomic-ish claim of a queue row before send (#55).
+ * Atomic claim of a queue row before send (#55, #105).
  *
- * Strategy: remove-before-send. First worker deletes the row; peers see a miss.
- * On mail failure the caller must requeue from in-memory fields.
+ * Strategy: UPDATE claimed_at/attempts first, DELETE fallback for legacy schema.
  */
 class sxQueueClaim
 {
     /**
+     * @var int
+     */
+    private const CLAIM_TTL_SECONDS = 900;
+
+    /**
      * @var string
      */
     private static $queueClass = 'sxQueue';
+
+    /**
+     * @var string
+     */
+    private static $lastStrategy = 'none';
 
     /**
      * @param object $xpdo
@@ -22,21 +31,111 @@ class sxQueueClaim
     {
         $id = (int) $id;
         if ($id <= 0) {
+            self::$lastStrategy = 'none';
             return false;
+        }
+
+        $claimed = self::tryAtomicUpdateClaim($xpdo, $id);
+        if ($claimed !== null) {
+            self::$lastStrategy = 'lease';
+            return $claimed;
         }
 
         $claimed = self::tryAtomicDelete($xpdo, $id);
         if ($claimed !== null) {
+            self::$lastStrategy = 'delete';
             return $claimed;
         }
 
         /** @var object|null $row */
         $row = $xpdo->getObject(self::$queueClass, $id);
         if (!$row) {
+            self::$lastStrategy = 'none';
             return false;
         }
 
+        self::$lastStrategy = 'delete';
         return (bool) $row->remove();
+    }
+
+    /**
+     * @return string
+     */
+    public static function lastStrategy()
+    {
+        return self::$lastStrategy;
+    }
+
+    /**
+     * @param object $xpdo
+     * @param int $id
+     * @return bool|null true/false when SQL path is available, null when fallback needed
+     */
+    private static function tryAtomicUpdateClaim($xpdo, $id)
+    {
+        if (!method_exists($xpdo, 'getConnection') || !method_exists($xpdo, 'getTableName')) {
+            return null;
+        }
+
+        $connection = $xpdo->getConnection();
+        if (!is_object($connection) || !method_exists($connection, 'prepare')) {
+            return null;
+        }
+
+        $table = (string) $xpdo->getTableName(self::$queueClass);
+        if ($table === '') {
+            return null;
+        }
+
+        $sql = 'UPDATE ' . $table
+            . ' SET claimed_at = CURRENT_TIMESTAMP,'
+            . ' attempts = attempts + 1,'
+            . ' expires_at = DATE_ADD(CURRENT_TIMESTAMP, INTERVAL ' . self::CLAIM_TTL_SECONDS . ' SECOND)'
+            . ' WHERE id = ?'
+            . ' AND (claimed_at IS NULL OR (expires_at IS NOT NULL AND expires_at < CURRENT_TIMESTAMP))';
+        $stmt = $connection->prepare($sql);
+        if (!$stmt) {
+            return null;
+        }
+        if (!$stmt->execute(array($id))) {
+            if (self::hasLegacySchemaError($stmt, $connection)) {
+                return null;
+            }
+            return false;
+        }
+
+        if (!method_exists($stmt, 'rowCount')) {
+            return true;
+        }
+
+        return (int) $stmt->rowCount() > 0;
+    }
+
+    /**
+     * @param object $statement
+     * @param object $connection
+     * @return bool
+     */
+    private static function hasLegacySchemaError($statement, $connection)
+    {
+        $sources = array($statement, $connection);
+        foreach ($sources as $source) {
+            if (!is_object($source) || !method_exists($source, 'errorInfo')) {
+                continue;
+            }
+
+            $info = $source->errorInfo();
+            $code = isset($info[0]) ? (string) $info[0] : '';
+            $message = isset($info[2]) ? strtolower((string) $info[2]) : '';
+            if ($code === '42S22' || $code === '42S02') {
+                return true;
+            }
+            if (strpos($message, 'unknown column') !== false || strpos($message, 'no such column') !== false) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/core/components/sendex/model/sendex/sxqueuedeliver.class.php
+++ b/core/components/sendex/model/sendex/sxqueuedeliver.class.php
@@ -4,12 +4,12 @@ require_once dirname(__FILE__) . '/sxqueueclaim.class.php';
 require_once dirname(__FILE__) . '/sxsendexevent.class.php';
 
 /**
- * Deliver one queue email with claim / requeue (#55) and send events (#104 A1).
+ * Deliver one queue email with claim/retry (#55, #105) and send events (#104 A1).
  *
  * sendMail return values:
  * - true: sent
- * - false: skip (row already claimed; do not requeue)
- * - string: mail error (requeue + sxOnQueueSendFailed)
+ * - false: skip (row already claimed or plugin skip)
+ * - string: mail error (release claim + sxOnQueueSendFailed)
  */
 class sxQueueDeliver
 {
@@ -24,23 +24,30 @@ class sxQueueDeliver
         if (!sxQueueClaim::tryClaim($xpdo, (int) $queue->get('id'))) {
             return false;
         }
+        $claimStrategy = sxQueueClaim::lastStrategy();
+        $snapshot = self::queueSnapshot($queue);
 
         $result = call_user_func($sendMail, $queue);
         if ($result === true) {
+            if ($claimStrategy === 'lease') {
+                self::dropQueueRow($queue);
+            }
             return true;
         }
 
-        // Plugin skip or soft abort: row already removed; do not put it back.
+        // Plugin skip or soft abort: consume queue row, no retry.
         if ($result === false) {
+            if ($claimStrategy === 'lease') {
+                self::dropQueueRow($queue);
+            }
             return false;
         }
 
-        // Claim already removed the row; put it back for retry.
-        $payload = $queue->toArray();
-        unset($payload['id']);
-        $again = $xpdo->newObject('sxQueue');
-        $again->fromArray($payload, '', true, true);
-        $again->save();
+        if ($claimStrategy === 'lease') {
+            self::releaseClaimForRetry($queue);
+        } else {
+            self::requeueFromSnapshot($xpdo, $snapshot);
+        }
 
         $error = is_string($result) ? $result : 'unknown error';
         $failedParams = array(
@@ -57,5 +64,168 @@ class sxQueueDeliver
         }
 
         return $result;
+    }
+
+    /**
+     * @param object $queue
+     * @return void
+     */
+    private static function dropQueueRow($queue)
+    {
+        if (!method_exists($queue, 'remove')) {
+            return;
+        }
+
+        if ($queue->remove() !== false) {
+            return;
+        }
+
+        if (self::forceDeleteRowViaSql($queue)) {
+            return;
+        }
+
+        self::pinClaimAsConsumed($queue);
+    }
+
+    /**
+     * @param object $queue
+     * @return void
+     */
+    private static function releaseClaimForRetry($queue)
+    {
+        if (!method_exists($queue, 'toArray') || !method_exists($queue, 'set') || !method_exists($queue, 'save')) {
+            return;
+        }
+
+        $data = $queue->toArray();
+        if (array_key_exists('claimed_at', $data)) {
+            $queue->set('claimed_at', null);
+        }
+        if (array_key_exists('expires_at', $data)) {
+            $queue->set('expires_at', null);
+        }
+        if ($queue->save() !== false) {
+            return;
+        }
+
+        self::forceReleaseClaimViaSql($queue);
+    }
+
+    /**
+     * @param object $queue
+     * @return void
+     */
+    private static function forceReleaseClaimViaSql($queue)
+    {
+        $xpdo = isset($queue->xpdo) ? $queue->xpdo : null;
+        if (
+            !is_object($xpdo)
+            || !method_exists($xpdo, 'getConnection')
+            || !method_exists($xpdo, 'getTableName')
+        ) {
+            return;
+        }
+
+        $connection = $xpdo->getConnection();
+        if (!is_object($connection) || !method_exists($connection, 'prepare')) {
+            return;
+        }
+
+        $table = (string) $xpdo->getTableName('sxQueue');
+        if ($table === '') {
+            return;
+        }
+
+        $stmt = $connection->prepare(
+            'UPDATE ' . $table . ' SET claimed_at = NULL, expires_at = NULL WHERE id = ?'
+        );
+        if ($stmt) {
+            $stmt->execute(array((int) $queue->get('id')));
+        }
+    }
+
+    /**
+     * @param object $queue
+     * @return void
+     */
+    private static function forceDeleteRowViaSql($queue)
+    {
+        $xpdo = isset($queue->xpdo) ? $queue->xpdo : null;
+        if (
+            !is_object($xpdo)
+            || !method_exists($xpdo, 'getConnection')
+            || !method_exists($xpdo, 'getTableName')
+        ) {
+            return;
+        }
+
+        $connection = $xpdo->getConnection();
+        if (!is_object($connection) || !method_exists($connection, 'prepare')) {
+            return;
+        }
+
+        $table = (string) $xpdo->getTableName('sxQueue');
+        if ($table === '') {
+            return;
+        }
+
+        $stmt = $connection->prepare('DELETE FROM ' . $table . ' WHERE id = ?');
+        if (!$stmt || !$stmt->execute(array((int) $queue->get('id')))) {
+            return false;
+        }
+
+        return !method_exists($stmt, 'rowCount') || (int) $stmt->rowCount() > 0;
+    }
+
+    /**
+     * @param object $queue
+     * @return void
+     */
+    private static function pinClaimAsConsumed($queue)
+    {
+        if (method_exists($queue, 'toArray') && method_exists($queue, 'set') && method_exists($queue, 'save')) {
+            $data = $queue->toArray();
+            if (array_key_exists('expires_at', $data)) {
+                $queue->set('expires_at', null);
+            }
+            $queue->save();
+        }
+    }
+
+    /**
+     * @param object $queue
+     * @return array
+     */
+    private static function queueSnapshot($queue)
+    {
+        if (!method_exists($queue, 'toArray')) {
+            return array();
+        }
+
+        return $queue->toArray();
+    }
+
+    /**
+     * @param object $xpdo
+     * @param array $snapshot
+     * @return void
+     */
+    private static function requeueFromSnapshot($xpdo, array $snapshot)
+    {
+        if (empty($snapshot) || !method_exists($xpdo, 'newObject')) {
+            return;
+        }
+
+        unset($snapshot['id']);
+        if (array_key_exists('claimed_at', $snapshot)) {
+            $snapshot['claimed_at'] = null;
+        }
+        if (array_key_exists('expires_at', $snapshot)) {
+            $snapshot['expires_at'] = null;
+        }
+
+        $again = $xpdo->newObject('sxQueue');
+        $again->fromArray($snapshot, '', true, true);
+        $again->save();
     }
 }

--- a/tests/Stubs/FakePdoConnection.php
+++ b/tests/Stubs/FakePdoConnection.php
@@ -17,6 +17,18 @@ class FakePdoConnection
     /** @var bool */
     public $executeResult = true;
 
+    /** @var bool */
+    public $failClaimUpdate = false;
+
+    /** @var string */
+    public $claimUpdateErrorCode = 'HY000';
+
+    /** @var string */
+    public $claimUpdateErrorMessage = 'Simulated claim update failure';
+
+    /** @var bool */
+    public $failDelete = false;
+
     /** @var array<int,array{sql:string,values:array}> */
     public $executions = array();
 

--- a/tests/Stubs/FakePdoStatement.php
+++ b/tests/Stubs/FakePdoStatement.php
@@ -17,6 +17,9 @@ class FakePdoStatement
     /** @var int */
     private $affectedRows = 0;
 
+    /** @var array */
+    private $lastErrorInfo = array('00000', null, null);
+
     /**
      * @param FakeModX $modx
      * @param FakePdoConnection $connection
@@ -47,7 +50,40 @@ class FakePdoStatement
         }
 
         if (stripos($this->sql, 'DELETE FROM') === 0) {
+            if (!empty($this->connection->failDelete)) {
+                $this->affectedRows = 0;
+                $this->lastErrorInfo = array('HY000', null, 'Simulated delete failure');
+                return false;
+            }
             $this->affectedRows = $this->deleteQueueRow($values);
+
+            return true;
+        }
+
+        if (
+            stripos($this->sql, 'UPDATE ') === 0
+            && strpos($this->sql, 'claimed_at') !== false
+            && strpos($this->sql, 'attempts = attempts + 1') !== false
+        ) {
+            if (!empty($this->connection->failClaimUpdate)) {
+                $this->affectedRows = 0;
+                $this->lastErrorInfo = array(
+                    $this->connection->claimUpdateErrorCode,
+                    null,
+                    $this->connection->claimUpdateErrorMessage,
+                );
+                return false;
+            }
+            $this->affectedRows = $this->claimQueueRow($values);
+
+            return true;
+        }
+
+        if (
+            stripos($this->sql, 'UPDATE ') === 0
+            && strpos($this->sql, 'SET claimed_at = NULL, expires_at = NULL') !== false
+        ) {
+            $this->affectedRows = $this->releaseClaimRow($values);
 
             return true;
         }
@@ -79,6 +115,14 @@ class FakePdoStatement
     }
 
     /**
+     * @return array
+     */
+    public function errorInfo()
+    {
+        return $this->lastErrorInfo;
+    }
+
+    /**
      * @param array $values
      * @return int
      */
@@ -96,6 +140,66 @@ class FakePdoStatement
 
             unset($this->modx->queues[$index]);
             $this->modx->queues = array_values($this->modx->queues);
+
+            return 1;
+        }
+
+        return 0;
+    }
+
+    /**
+     * @param array $values
+     * @return int
+     */
+    private function claimQueueRow(array $values)
+    {
+        $id = isset($values[0]) ? (int) $values[0] : 0;
+        if ($id <= 0) {
+            return 0;
+        }
+
+        foreach ($this->modx->queues as $queue) {
+            if ((int) $queue->get('id') !== $id) {
+                continue;
+            }
+            $claimedAt = $queue->get('claimed_at');
+            $expiresAt = $queue->get('expires_at');
+            $hasClaim = $claimedAt !== null && $claimedAt !== '';
+            $isExpired = $expiresAt !== null
+                && $expiresAt !== ''
+                && strtotime((string) $expiresAt) < time();
+            if ($hasClaim && !$isExpired) {
+                return 0;
+            }
+
+            $queue->set('claimed_at', date('Y-m-d H:i:s'));
+            $queue->set('attempts', ((int) $queue->get('attempts')) + 1);
+            $queue->set('expires_at', date('Y-m-d H:i:s', time() + 900));
+
+            return 1;
+        }
+
+        return 0;
+    }
+
+    /**
+     * @param array $values
+     * @return int
+     */
+    private function releaseClaimRow(array $values)
+    {
+        $id = isset($values[0]) ? (int) $values[0] : 0;
+        if ($id <= 0) {
+            return 0;
+        }
+
+        foreach ($this->modx->queues as $queue) {
+            if ((int) $queue->get('id') !== $id) {
+                continue;
+            }
+
+            $queue->set('claimed_at', null);
+            $queue->set('expires_at', null);
 
             return 1;
         }

--- a/tests/Unit/MigrationHardening105Test.php
+++ b/tests/Unit/MigrationHardening105Test.php
@@ -1,0 +1,85 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class MigrationHardening105Test extends TestCase
+{
+    /** @var string */
+    private $root;
+
+    protected function setUp(): void
+    {
+        $this->root = dirname(__DIR__, 2);
+    }
+
+    public function testQueueClaimAndUtf8MigrationsExist()
+    {
+        $this->assertFileExists(
+            $this->root . '/core/components/sendex/migrations/20260725190000_add_queue_claim_fields.php'
+        );
+        $this->assertFileExists(
+            $this->root . '/core/components/sendex/migrations/20260725191000_convert_sendex_tables_to_utf8mb4.php'
+        );
+        $this->assertFileExists(
+            $this->root . '/core/components/sendex/migrations/20260725192000_normalize_subscriber_email_collation.php'
+        );
+    }
+
+    public function testQueueMapContainsClaimRetryFields()
+    {
+        $queueMap = file_get_contents(
+            $this->root . '/core/components/sendex/model/sendex/mysql/sxqueue.map.inc.php'
+        );
+
+        $this->assertStringContainsString("'claimed_at'", $queueMap);
+        $this->assertStringContainsString("'attempts'", $queueMap);
+        $this->assertStringContainsString("'expires_at'", $queueMap);
+        $this->assertStringContainsString("'subscriber_id'   =>", $queueMap);
+        $this->assertStringContainsString("'default'    => 0", $queueMap);
+    }
+
+    public function testSubscriberMapKeepsNullableEmail()
+    {
+        $subscriberMap = file_get_contents(
+            $this->root . '/core/components/sendex/model/sendex/mysql/sxsubscriber.map.inc.php'
+        );
+
+        $this->assertStringContainsString("'email'         =>", $subscriberMap);
+        $this->assertStringContainsString("'null'      => true", $subscriberMap);
+    }
+
+    public function testQueueClaimUsesAtomicUpdate()
+    {
+        $source = file_get_contents(
+            $this->root . '/core/components/sendex/model/sendex/sxqueueclaim.class.php'
+        );
+
+        $this->assertStringContainsString('SET claimed_at = CURRENT_TIMESTAMP,', $source);
+        $this->assertStringContainsString('attempts = attempts + 1,', $source);
+        $this->assertStringContainsString('expires_at = DATE_ADD', $source);
+        $this->assertStringContainsString('claimed_at IS NULL OR (expires_at IS NOT NULL AND expires_at < CURRENT_TIMESTAMP)', $source);
+    }
+
+    public function testMigrationsDeclareExpectedSchemaOperations()
+    {
+        $queueMigration = file_get_contents(
+            $this->root . '/core/components/sendex/migrations/20260725190000_add_queue_claim_fields.php'
+        );
+        $this->assertStringContainsString("addColumn('claimed_at'", $queueMigration);
+        $this->assertStringContainsString("addColumn('attempts'", $queueMigration);
+        $this->assertStringContainsString("addColumn('expires_at'", $queueMigration);
+        $this->assertStringContainsString("changeColumn('subscriber_id'", $queueMigration);
+
+        $utfMigration = file_get_contents(
+            $this->root . '/core/components/sendex/migrations/20260725191000_convert_sendex_tables_to_utf8mb4.php'
+        );
+        $this->assertStringContainsString('CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci', $utfMigration);
+
+        $emailMigration = file_get_contents(
+            $this->root . '/core/components/sendex/migrations/20260725192000_normalize_subscriber_email_collation.php'
+        );
+        $this->assertStringContainsString('SET email = LOWER(email) WHERE email IS NOT NULL', $emailMigration);
+        $this->assertStringContainsString('COLLATE utf8mb4_unicode_ci', $emailMigration);
+        $this->assertStringContainsString('utf8_general_ci NULL DEFAULT', $emailMigration);
+    }
+}

--- a/tests/Unit/QueueClaimTest.php
+++ b/tests/Unit/QueueClaimTest.php
@@ -15,14 +15,29 @@ class QueueClaimTest extends TestCase
         $this->modx = new FakeModX();
     }
 
-    public function testTryClaimRemovesRowOnce()
+    public function testTryClaimMarksRowOnce()
     {
         $queue = $this->queue(5, 'a@example.com');
         $this->modx->queues[] = $queue;
 
         $this->assertTrue(sxQueueClaim::tryClaim($this->modx, 5));
-        $this->assertCount(0, $this->modx->queues);
+        $this->assertCount(1, $this->modx->queues);
+        $this->assertNotEmpty($this->modx->queues[0]->get('claimed_at'));
+        $this->assertSame(1, (int) $this->modx->queues[0]->get('attempts'));
+        $this->assertNotEmpty($this->modx->queues[0]->get('expires_at'));
         $this->assertFalse(sxQueueClaim::tryClaim($this->modx, 5));
+    }
+
+    public function testTryClaimReclaimsExpiredLease()
+    {
+        $queue = $this->queue(6, 'stale@example.com');
+        $queue->set('claimed_at', date('Y-m-d H:i:s', time() - 3600));
+        $queue->set('expires_at', date('Y-m-d H:i:s', time() - 60));
+        $this->modx->queues[] = $queue;
+
+        $this->assertTrue(sxQueueClaim::tryClaim($this->modx, 6));
+        $this->assertSame(1, (int) $this->modx->queues[0]->get('attempts'));
+        $this->assertNotEmpty($this->modx->queues[0]->get('expires_at'));
     }
 
     public function testTryClaimUsesAtomicDeleteWithoutPreloadingRow()
@@ -35,6 +50,28 @@ class QueueClaimTest extends TestCase
         $this->assertTrue($first);
         $this->assertFalse($second);
         $this->assertSame(0, isset($this->modx->getObjectCalls['sxQueue']) ? $this->modx->getObjectCalls['sxQueue'] : 0);
+        $this->assertSame(2, $this->modx->getConnection()->executeCalls);
+    }
+
+    public function testTryClaimDoesNotDeleteRowWhenUpdateClaimFails()
+    {
+        $this->modx->queues[] = $this->queue(10, 'legacy@example.com');
+        $this->modx->getConnection()->failClaimUpdate = true;
+
+        $this->assertFalse(sxQueueClaim::tryClaim($this->modx, 10));
+        $this->assertCount(1, $this->modx->queues);
+        $this->assertSame(1, $this->modx->getConnection()->executeCalls);
+    }
+
+    public function testTryClaimFallsBackToDeleteOnLegacyUnknownColumnError()
+    {
+        $this->modx->queues[] = $this->queue(12, 'legacy-delete@example.com');
+        $this->modx->getConnection()->failClaimUpdate = true;
+        $this->modx->getConnection()->claimUpdateErrorCode = '42S22';
+        $this->modx->getConnection()->claimUpdateErrorMessage = 'Unknown column claimed_at';
+
+        $this->assertTrue(sxQueueClaim::tryClaim($this->modx, 12));
+        $this->assertCount(0, $this->modx->queues);
         $this->assertSame(2, $this->modx->getConnection()->executeCalls);
     }
 
@@ -64,6 +101,21 @@ class QueueClaimTest extends TestCase
         $this->assertCount(0, $this->modx->queues);
     }
 
+    public function testDeliverDeleteFallbackRunsWhenRemoveFails()
+    {
+        $queue = $this->queue(11, 'force-delete@example.com');
+        $queue->removeResult = false;
+        $this->modx->queues[] = $queue;
+
+        $result = sxQueueDeliver::send($queue, function () {
+            return true;
+        });
+
+        $this->assertTrue($result);
+        $this->assertCount(0, $this->modx->queues);
+        $this->assertSame(2, $this->modx->getConnection()->executeCalls);
+    }
+
     public function testDeliverRequeuesOnMailFailure()
     {
         $queue = $this->queue(3, 'fail@example.com');
@@ -77,7 +129,59 @@ class QueueClaimTest extends TestCase
         $this->assertSame('SMTP down', $result);
         $this->assertCount(1, $this->modx->queues);
         $this->assertSame('fail@example.com', $this->modx->queues[0]->get('email_to'));
-        $this->assertNotSame(3, (int) $this->modx->queues[0]->get('id'));
+        $this->assertSame(3, (int) $this->modx->queues[0]->get('id'));
+        $this->assertSame(1, (int) $this->modx->queues[0]->get('attempts'));
+        $this->assertNull($this->modx->queues[0]->get('claimed_at'));
+    }
+
+    public function testDeliverRequeuesOnMailFailureForLegacyDeleteClaim()
+    {
+        $queue = $this->queue(14, 'legacy-fail@example.com');
+        $this->modx->queues[] = $queue;
+        $this->modx->getConnection()->failClaimUpdate = true;
+        $this->modx->getConnection()->claimUpdateErrorCode = '42S22';
+        $this->modx->getConnection()->claimUpdateErrorMessage = 'Unknown column claimed_at';
+
+        $result = sxQueueDeliver::send($queue, function () {
+            return 'legacy smtp error';
+        });
+
+        $this->assertSame('legacy smtp error', $result);
+        $this->assertCount(1, $this->modx->queues);
+        $this->assertSame('legacy-fail@example.com', $this->modx->queues[0]->get('email_to'));
+    }
+
+    public function testDeliverReleaseClaimFallsBackToSqlWhenSaveFails()
+    {
+        $queue = $this->queue(13, 'fallback@example.com');
+        $queue->saveResult = false;
+        $this->modx->queues[] = $queue;
+
+        $result = sxQueueDeliver::send($queue, function () {
+            return 'smtp failed';
+        });
+
+        $this->assertSame('smtp failed', $result);
+        $this->assertNull($this->modx->queues[0]->get('claimed_at'));
+        $this->assertNull($this->modx->queues[0]->get('expires_at'));
+        $this->assertSame(2, $this->modx->getConnection()->executeCalls);
+    }
+
+    public function testDeliverPinsLeaseWhenDeleteFallbackFailsAfterSend()
+    {
+        $queue = $this->queue(15, 'pin@example.com');
+        $queue->removeResult = false;
+        $this->modx->getConnection()->failDelete = true;
+        $this->modx->queues[] = $queue;
+
+        $result = sxQueueDeliver::send($queue, function () {
+            return true;
+        });
+
+        $this->assertTrue($result);
+        $this->assertCount(1, $this->modx->queues);
+        $this->assertNotNull($this->modx->queues[0]->get('claimed_at'));
+        $this->assertNull($this->modx->queues[0]->get('expires_at'));
     }
 
     /**
@@ -92,6 +196,9 @@ class QueueClaimTest extends TestCase
             'id'            => $id,
             'newsletter_id' => 1,
             'subscriber_id' => 2,
+            'claimed_at'    => null,
+            'attempts'      => 0,
+            'expires_at'    => null,
             'email_to'      => $email,
             'email_subject' => 'S',
             'email_body'    => 'B',


### PR DESCRIPTION
Кратко: закрыт обязательный миграционный минимум issue #105 по очереди и кодировкам (`M2`, `M7`, `M8`) с безопасными fallback-сценариями для legacy-установок.

## Что сделано
- добавлены миграции `20260725190000_add_queue_claim_fields.php`, `20260725191000_convert_sendex_tables_to_utf8mb4.php`, `20260725192000_normalize_subscriber_email_collation.php`;
- обновлены runtime-потоки `sxQueueClaim`/`sxQueueDeliver`: lease-based claim (`claimed_at`, `attempts`, `expires_at`), reclaim expired lease, legacy delete fallback, requeue для legacy error-path, защитные fallback-и от двойного сбоя очистки;
- синхронизированы schema/map для queue claim fields и policy `subscriber_id`; добавлен контрактный `MigrationHardening105Test`, расширены `QueueClaimTest` и stubs;
- обновлены `README.md` (цепочка миграций) и `changelog.txt`.

## Review
- Findings: нет (финальный pass 2 после повторного прогона `/code-review` + code-reviewer + thermo-nuclear).

## Проверка
- `composer test` — exit 0
- `composer phpcs` — exit 0
- waive: live Phinx migrate на реальной MODX DB не прогонялся локально в CI-контуре.

Fixes #105