### PR TITLE
fix(release): match changelog headings with optional -pl suffix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,11 +124,16 @@ jobs:
       - name: Prepare release notes
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
+          # Changelog headings are like [2.0.1-pl]; tag may be v2.0.1 or v2.0.1-pl
           awk -v ver="$VERSION" '
-            $0 ~ "^## \\[" ver "\\]" {print; show=1; next}
+            $0 ~ "^## \[" ver "(-pl)?\]" {print; show=1; next}
             show && /^## \[/ {exit}
             show {print}
           ' core/components/sendex/docs/changelog.txt > release-notes.md
+          if ! grep -q . release-notes.md; then
+            echo "WARN: no changelog section for ${VERSION}; using compare link fallback" >&2
+            echo "**Full Changelog**: https://github.com/${GITHUB_REPOSITORY}/compare/v${VERSION}" > release-notes.md
+          fi
 
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Fix empty GitHub release notes when the tag is `v2.0.1` but changelog uses `## [2.0.1-pl]`.

The release workflow stripped `v` from the tag and looked for an exact `## [2.0.1]` heading, so softprops fell back to a bare compare link. Notes now match an optional `-pl` suffix.

Also related: mgr icons fix for #111 already shipped in 2.0.1-pl on master (`ae0024e`); this PR only hardens the release notes path for the next tag.