### PR TITLE
chore: require all changes through pull requests

### DIFF
--- a/.cursor/rules/pr-only-workflow.mdc
+++ b/.cursor/rules/pr-only-workflow.mdc
@@ -1,0 +1,20 @@
+---
+description: All code changes ship through pull requests, never direct to master
+alwaysApply: true
+---
+
+# PR-only workflow
+
+Все правки в этом репозитории идут **только через Pull Request**.
+
+## Обязательно
+
+1. Не коммитить и не пушить напрямую в `master` / `main`.
+2. Создать ветку от актуального `master` (`fix/…`, `feat/…`, `chore/…`).
+3. Коммиты в ветку → `gh pr create` → дождаться CI → merge PR.
+4. Релизы/теги — после merge в `master` (или отдельным PR на bump версии + тег по согласованию).
+5. Hotfix на прод-пакет: ветка → PR → merge → тег/release workflow; не править zip в обход git.
+
+## Исключения
+
+Только если пользователь **явно** сказал коммитить/пушить в `master` в этом сообщении.

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .idea
 .DS_Store
-.cursor/
+.cursor/*
+!.cursor/rules/
+!.cursor/rules/**
 
 # VSCode
 .vscode

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Sendex — agent / contributor notes
+
+## Workflow
+
+All changes go through a **Pull Request**. Do not commit or push directly to `master`.
+
+1. Branch from up-to-date `master` (`fix/…`, `feat/…`, `chore/…`).
+2. Commit on the branch, open a PR, wait for CI, merge.
+3. Releases/tags after merge (or a version-bump PR, then tag).
+4. Do not ship transport zips outside git + the release workflow.
+
+Exception: only if the user explicitly asks to commit/push to `master` in that message.


### PR DESCRIPTION
Зафиксировать процесс: дальше все правки только через PR, без прямых коммитов в `master`.

Добавлены `AGENTS.md`, правило Cursor `.cursor/rules/pr-only-workflow.mdc`, и в `.gitignore` разрешён трекинг `.cursor/rules/`.