### PR TITLE
fix(mgr): restore newsletter grid after create (#114)

### DIFF
--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.0.1-pl] - 2026-07-29
 
 ### Fixed
+- [#114] Mgr newsletter create appeared to hang on «Загружается…» and the grid stayed empty after reload (row was saved; duplicate-name error on retry). Newsletter `getlist` no longer uses JOIN/COUNT/GROUP BY (MySQL `ONLY_FULL_GROUP_BY`); subscriber totals come from a correlated subquery. Create processor returns a plain array so ExtJS always gets parseable JSON.
 - [#111] Mgr row-action and menu icons no longer force `font-family: "Font Awesome 5 Free"` (Sendex does not load FA5); icons inherit the mgr icon font on MODX 2.3+/3.x or bundled FA4 on older MODX.
 - [#25666] Transport package built on MODX 3.x stored vehicle class as `xPDO\Transport\xPDOObjectVehicle`, which MODX 2.8.8/2.8.9 cannot load (install fails with ~30 "Could not load class" errors). Release build now runs on MODX 2.x so the manifest uses the legacy vehicle format that installs on both MODX 2.8+ and 3.x.
 

--- a/core/components/sendex/model/sendex/sxnewsletterlistquery.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletterlistquery.class.php
@@ -30,7 +30,9 @@ class sxNewsletterListQuery
     }
 
     /**
-     * List SELECT/JOIN/GROUP BY — run from prepareQueryAfterCount only.
+     * List SELECT/JOIN — run from prepareQueryAfterCount only.
+     * Subscriber totals use a correlated subquery (no GROUP BY) so MySQL
+     * ONLY_FULL_GROUP_BY does not break the grid after the first create (#114).
      *
      * @param object $modx
      * @param object $query
@@ -40,11 +42,15 @@ class sxNewsletterListQuery
     public static function applyListSelects($modx, $query, $classKey = 'sxNewsletter')
     {
         $query->leftJoin('modTemplate', 'Template');
-        $query->leftJoin('sxSubscriber', 'Subscribers');
         $query->select($modx->getSelectColumns($classKey, $classKey));
         $query->select($modx->getSelectColumns('modTemplate', 'Template', '', array('templatename')));
-        $query->select('COUNT(`Subscribers`.`id`) as `subscribers`');
-        $query->groupby($classKey . '.id');
+
+        $subscriberTable = $modx->getTableName('sxSubscriber');
+        $query->select(sprintf(
+            '(SELECT COUNT(*) FROM %s AS `sxSubCnt` WHERE `sxSubCnt`.`newsletter_id` = %s.id) AS `subscribers`',
+            $subscriberTable,
+            $classKey
+        ));
 
         return $query;
     }

--- a/core/components/sendex/processors/mgr/newsletter/create.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/create.class.php
@@ -44,6 +44,16 @@ class sxNewsletterCreateProcessor extends modObjectCreateProcessor
 
         return !$this->hasErrors();
     }
+
+    /**
+     * Return a plain array so ExtJS always gets JSON it can parse (MODX 3).
+     *
+     * @return array
+     */
+    public function cleanup()
+    {
+        return $this->success('', $this->object->toArray());
+    }
 }
 
 return 'sxNewsletterCreateProcessor';

--- a/tests/Unit/NewsletterGetListQueryTest.php
+++ b/tests/Unit/NewsletterGetListQueryTest.php
@@ -29,17 +29,20 @@ class NewsletterGetListQueryTest extends TestCase
         $this->assertSame(1, $query->where['active']);
     }
 
-    public function testApplyListSelectsAddsJoinsAndGroupBy()
+    public function testApplyListSelectsAddsTemplateJoinAndSubscriberSubquery()
     {
         $query = new FakeQuery('sxNewsletter');
 
         sxNewsletterListQuery::applyListSelects($this->modx, $query, 'sxNewsletter');
 
-        $this->assertCount(2, $query->joins);
+        $this->assertCount(1, $query->joins);
         $this->assertSame('modTemplate', $query->joins[0][0]);
-        $this->assertSame('sxSubscriber', $query->joins[1][0]);
-        $this->assertSame('sxNewsletter.id', $query->groupby);
+        $this->assertNull($query->groupby);
         $this->assertGreaterThanOrEqual(3, count($query->selects));
+        $subscriberSelect = end($query->selects);
+        $this->assertStringContainsString('SELECT COUNT(*)', $subscriberSelect);
+        $this->assertStringContainsString('newsletter_id', $subscriberSelect);
+        $this->assertStringNotContainsString('GROUP BY', strtoupper(implode(' ', $query->selects)));
     }
 
     public function testGetListProcessorUsesAfterCountForAggregates()


### PR DESCRIPTION
После «Сохранить» подписка писалась в БД, но mgr зависал на «Загружается…», а после перезагрузки грид оставался пустым (повтор с тем же именем давал «уже существует»).

`getlist` строил JOIN + `COUNT` + `GROUP BY`, что падает на MySQL с `ONLY_FULL_GROUP_BY`, как только появляется хотя бы одна строка. Пустой список работал, поэтому баг проявлялся только после первого успешного create.

Исправление: correlated subquery для числа подписчиков без `GROUP BY`; create возвращает `toArray()` для стабильного JSON в ExtJS.

Fixes #114