### PR TITLE
fix(mgr): newsletter grid loading after create (#114)

### DIFF
--- a/_build/build.config.php
+++ b/_build/build.config.php
@@ -4,7 +4,7 @@
 define('PKG_NAME', 'Sendex');
 define('PKG_NAME_LOWER', strtolower(PKG_NAME));
 
-define('PKG_VERSION', '2.0.1');
+define('PKG_VERSION', '2.0.2');
 define('PKG_RELEASE', 'pl');
 define('PKG_AUTO_INSTALL', true);
 define('PKG_NAMESPACE_PATH', '{core_path}components/' . PKG_NAME_LOWER . '/');

--- a/assets/components/sendex/js/mgr/widgets/newsletters.grid.js
+++ b/assets/components/sendex/js/mgr/widgets/newsletters.grid.js
@@ -118,7 +118,10 @@ Ext.extend(Sendex.grid.Newsletters,MODx.grid.Grid,Ext.apply({
             this.windows.createNewsletter = MODx.load({
                 xtype: 'sendex-window-newsletter-create'
                 ,listeners: {
-                    'success': {fn:function() { this.refresh(); },scope:this}
+                    'success': {fn:function() {
+                        var grid = this;
+                        window.setTimeout(function() { grid.refresh(); }, 50);
+                    },scope:this}
                 }
             });
         }

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2-pl] - 2026-07-29
+
+### Fixed
+- [#114] Mgr newsletter create still showed endless «Загружается…» after 2.0.1: `getlist` no longer uses JOIN/subquery SQL (subscriber count and template name are added in `prepareRow`); grid refresh after save is deferred so the create window can close first; `getlist`/`get` accept `view_sendex` as well as `view_document`; create `beforeSet()` returns strict `true` for MODX 3.
+
 ## [2.0.1-pl] - 2026-07-29
 
 ### Fixed

--- a/core/components/sendex/model/sendex/sxnewsletterlistquery.class.php
+++ b/core/components/sendex/model/sendex/sxnewsletterlistquery.class.php
@@ -1,7 +1,8 @@
 <?php
 
 /**
- * Newsletter mgr grid query: cheap COUNT in prepareQueryBeforeCount, aggregates after (#73).
+ * Newsletter mgr grid query: cheap COUNT in prepareQueryBeforeCount (#73).
+ * Row extras (subscriber total, template name) are added in prepareRow — no JOIN/GROUP BY/subquery (#114).
  */
 class sxNewsletterListQuery
 {
@@ -30,28 +31,28 @@ class sxNewsletterListQuery
     }
 
     /**
-     * List SELECT/JOIN — run from prepareQueryAfterCount only.
-     * Subscriber totals use a correlated subquery (no GROUP BY) so MySQL
-     * ONLY_FULL_GROUP_BY does not break the grid after the first create (#114).
+     * Enrich a newsletter row for the mgr grid (subscriber count + template label).
      *
-     * @param object $modx
-     * @param object $query
-     * @param string $classKey
-     * @return object
+     * @param modX $modx
+     * @param array $array newsletter row from sxNewsletter::toArray()
+     * @return array
      */
-    public static function applyListSelects($modx, $query, $classKey = 'sxNewsletter')
+    public static function enrichRow($modx, array $array)
     {
-        $query->leftJoin('modTemplate', 'Template');
-        $query->select($modx->getSelectColumns($classKey, $classKey));
-        $query->select($modx->getSelectColumns('modTemplate', 'Template', '', array('templatename')));
+        $newsletterId = isset($array['id']) ? (int) $array['id'] : 0;
+        $array['subscribers'] = $newsletterId > 0
+            ? (int) $modx->getCount('sxSubscriber', array('newsletter_id' => $newsletterId))
+            : 0;
 
-        $subscriberTable = $modx->getTableName('sxSubscriber');
-        $query->select(sprintf(
-            '(SELECT COUNT(*) FROM %s AS `sxSubCnt` WHERE `sxSubCnt`.`newsletter_id` = %s.id) AS `subscribers`',
-            $subscriberTable,
-            $classKey
-        ));
+        $array['templatename'] = '';
+        $templateId = isset($array['template']) ? (int) $array['template'] : 0;
+        if ($templateId > 0) {
+            $template = $modx->getObject('modTemplate', $templateId);
+            if ($template) {
+                $array['templatename'] = (string) $template->get('templatename');
+            }
+        }
 
-        return $query;
+        return $array;
     }
 }

--- a/core/components/sendex/processors/mgr/newsletter/create.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/create.class.php
@@ -39,20 +39,14 @@ class sxNewsletterCreateProcessor extends modObjectCreateProcessor
             }
         }
 
+        if ($this->hasErrors()) {
+            return false;
+        }
+
         $active = $this->getProperty('active');
         $this->setProperty('active', !empty($active) && $active != 'false');
 
-        return !$this->hasErrors();
-    }
-
-    /**
-     * Return a plain array so ExtJS always gets JSON it can parse (MODX 3).
-     *
-     * @return array
-     */
-    public function cleanup()
-    {
-        return $this->success('', $this->object->toArray());
+        return true;
     }
 }
 

--- a/core/components/sendex/processors/mgr/newsletter/get.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/get.class.php
@@ -10,6 +10,15 @@ class sxNewsletterGetProcessor extends modObjectGetProcessor
     public $classKey = 'sxNewsletter';
     public $languageTopics = array('sendex:default');
     public $permission = 'view_document';
+
+    /**
+     * @return bool
+     */
+    public function checkPermissions()
+    {
+        return $this->modx->hasPermission('view_sendex')
+            || $this->modx->hasPermission('view_document');
+    }
 }
 
 return 'sxNewsletterGetProcessor';

--- a/core/components/sendex/processors/mgr/newsletter/getlist.class.php
+++ b/core/components/sendex/processors/mgr/newsletter/getlist.class.php
@@ -14,6 +14,17 @@ class sxNewsletterGetListProcessor extends modObjectGetListProcessor
     public $permission = 'view_document';
 
     /**
+     * Match mgr controller ACL: Sendex menu may grant view_sendex without view_document.
+     *
+     * @return bool
+     */
+    public function checkPermissions()
+    {
+        return $this->modx->hasPermission('view_sendex')
+            || $this->modx->hasPermission('view_document');
+    }
+
+    /**
      * @param xPDOQuery $c
      *
      * @return xPDOQuery
@@ -27,23 +38,13 @@ class sxNewsletterGetListProcessor extends modObjectGetListProcessor
     }
 
     /**
-     * @param xPDOQuery $c
-     *
-     * @return xPDOQuery
-     */
-    public function prepareQueryAfterCount(xPDOQuery $c)
-    {
-        return sxNewsletterListQuery::applyListSelects($this->modx, $c, $this->classKey);
-    }
-
-    /**
      * @param xPDOObject $object
      *
      * @return array
      */
     public function prepareRow(xPDOObject $object)
     {
-        $array = $object->toArray();
+        $array = sxNewsletterListQuery::enrichRow($this->modx, $object->toArray());
         $array['actions'] = array();
 
         // Update

--- a/tests/Unit/NewsletterGetListQueryTest.php
+++ b/tests/Unit/NewsletterGetListQueryTest.php
@@ -29,32 +29,67 @@ class NewsletterGetListQueryTest extends TestCase
         $this->assertSame(1, $query->where['active']);
     }
 
-    public function testApplyListSelectsAddsTemplateJoinAndSubscriberSubquery()
+    public function testEnrichRowAddsSubscriberCountAndTemplateName()
     {
-        $query = new FakeQuery('sxNewsletter');
+        $this->modx->newsletters[] = new sxNewsletter($this->modx);
+        $this->modx->newsletters[0]->fromArray(array(
+            'id'       => 5,
+            'name'     => 'Weekly',
+            'template' => 2,
+        ));
 
-        sxNewsletterListQuery::applyListSelects($this->modx, $query, 'sxNewsletter');
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array('id' => 1, 'newsletter_id' => 5));
+        $this->modx->subscribers[] = $subscriber;
 
-        $this->assertCount(1, $query->joins);
-        $this->assertSame('modTemplate', $query->joins[0][0]);
-        $this->assertNull($query->groupby);
-        $this->assertGreaterThanOrEqual(3, count($query->selects));
-        $subscriberSelect = end($query->selects);
-        $this->assertStringContainsString('SELECT COUNT(*)', $subscriberSelect);
-        $this->assertStringContainsString('newsletter_id', $subscriberSelect);
-        $this->assertStringNotContainsString('GROUP BY', strtoupper(implode(' ', $query->selects)));
+        $subscriber = new sxSubscriber($this->modx);
+        $subscriber->fromArray(array('id' => 2, 'newsletter_id' => 5));
+        $this->modx->subscribers[] = $subscriber;
+
+        $template = new class {
+            /** @var array<string,string> */
+            private $data = array('templatename' => 'Mail layout');
+
+            /**
+             * @param string $key
+             * @return string|null
+             */
+            public function get($key)
+            {
+                return isset($this->data[$key]) ? $this->data[$key] : null;
+            }
+        };
+        $this->modx->templates[2] = $template;
+
+        $row = sxNewsletterListQuery::enrichRow($this->modx, array(
+            'id'       => 5,
+            'template' => 2,
+        ));
+
+        $this->assertSame(2, $row['subscribers']);
+        $this->assertSame('Mail layout', $row['templatename']);
     }
 
-    public function testGetListProcessorUsesAfterCountForAggregates()
+    public function testGetListProcessorUsesFiltersOnlyBeforeCount()
     {
         $source = file_get_contents(
             dirname(__DIR__, 2) . '/core/components/sendex/processors/mgr/newsletter/getlist.class.php'
         );
 
-        $this->assertStringContainsString('prepareQueryAfterCount', $source);
-        $this->assertStringContainsString('sxNewsletterListQuery::applyListSelects', $source);
         $this->assertStringContainsString('sxNewsletterListQuery::applyFilters', $source);
+        $this->assertStringContainsString('sxNewsletterListQuery::enrichRow', $source);
+        $this->assertStringNotContainsString('prepareQueryAfterCount', $source);
         $this->assertStringNotContainsString('groupby', $this->beforeCountBody($source));
+    }
+
+    public function testGetListProcessorAllowsViewSendexPermission()
+    {
+        $source = file_get_contents(
+            dirname(__DIR__, 2) . '/core/components/sendex/processors/mgr/newsletter/getlist.class.php'
+        );
+
+        $this->assertStringContainsString("hasPermission('view_sendex')", $source);
+        $this->assertStringContainsString("hasPermission('view_document')", $source);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Убираем JOIN/subquery из `mgr/newsletter/getlist`: счётчик подписчиков и имя шаблона считаются в `prepareRow`, без SQL, который ломал грид на MySQL.
- `getlist` и `get` принимают `view_sendex` (как и mgr-контроллер), не только `view_document`.
- После создания подписки `refresh()` грида откладывается на 50 ms, чтобы окно успело закрыться до маски «Загружается…».
- `beforeSet()` в create возвращает строго `true` для MODX 3.

## Test plan
- [ ] Установить/обновить до 2.0.2-pl, очистить кеш MODX
- [ ] Открыть Sendex → Рассылки: грид загружается с существующими записями
- [ ] Создать рассылку (имя + шаблон) → «Сохранить» → окно закрывается, строка появляется в гриде
- [ ] F5 → список не пустой
- [ ] Повтор с тем же именем → ошибка «уже существует», без зависания