### PR TITLE
fix(mgr): image renderer scope for escapeHtmlAttr (#114)

### DIFF
--- a/assets/components/sendex/js/mgr/misc/utils.js
+++ b/assets/components/sendex/js/mgr/misc/utils.js
@@ -1,3 +1,11 @@
+Sendex.utils.escapeHtmlAttr = function(value) {
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+};
+
 Sendex.utils.renderActions = function(value, props, row) {
     var res = [];
     for (var i in row.data.actions) {

--- a/assets/components/sendex/js/mgr/widgets/newsletters.grid.js
+++ b/assets/components/sendex/js/mgr/widgets/newsletters.grid.js
@@ -88,21 +88,13 @@ Ext.extend(Sendex.grid.Newsletters,MODx.grid.Grid,Ext.apply({
             : '<span style="color:green">' + _('yes') + '</span>';
     }
 
-    ,_escapeHtmlAttr: function(value) {
-        return String(value)
-            .replace(/&/g, '&amp;')
-            .replace(/"/g, '&quot;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;');
-    }
-
     ,_renderImage: function(val,cell,row) {
         if (!val) {return '';}
         else if (val.substr(0,1) != '/') {
             val = '/' + val;
         }
 
-        return '<img src="' + this._escapeHtmlAttr(val) + '" alt="" height="50" />';
+        return '<img src="' + Sendex.utils.escapeHtmlAttr(val) + '" alt="" height="50" />';
     }
 
     ,_renderTemplate: function(val,cell,row) {

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.0.1-pl] - 2026-07-29
 
 ### Fixed
-- [#114] Mgr newsletter create appeared to hang on «Загружается…» and the grid stayed empty after reload (row was saved; duplicate-name error on retry). Newsletter `getlist` no longer uses JOIN/subquery SQL (subscriber count and template name are added in `prepareRow`); grid refresh after save is deferred so the create window can close first; `getlist`/`get` accept `view_sendex` as well as `view_document`; create `beforeSet()` returns strict `true` for MODX 3.
+- [#114] Mgr newsletter create appeared to hang on «Загружается…» and the grid stayed empty after reload (row was saved; duplicate-name error on retry). Newsletter `getlist` no longer uses JOIN/subquery SQL (subscriber count and template name are added in `prepareRow`); grid refresh after save is deferred so the create window can close first; `getlist`/`get` accept `view_sendex` as well as `view_document`; create `beforeSet()` returns strict `true` for MODX 3. Image column renderer uses `Sendex.utils.escapeHtmlAttr` (ExtJS does not keep grid scope for column renderers).
 - [#111] Mgr row-action and menu icons no longer force `font-family: "Font Awesome 5 Free"` (Sendex does not load FA5); icons inherit the mgr icon font on MODX 2.3+/3.x or bundled FA4 on older MODX.
 - [#25666] Transport package built on MODX 3.x stored vehicle class as `xPDO\Transport\xPDOObjectVehicle`, which MODX 2.8.8/2.8.9 cannot load (install fails with ~30 "Could not load class" errors). Release build now runs on MODX 2.x so the manifest uses the legacy vehicle format that installs on both MODX 2.8+ and 3.x.
 

--- a/tests/Unit/MgrGridSelectionContractTest.php
+++ b/tests/Unit/MgrGridSelectionContractTest.php
@@ -84,11 +84,15 @@ class MgrGridSelectionContractTest extends TestCase
         );
 
         $this->assertStringContainsString("'</span>'", $source);
-        $this->assertStringContainsString('_escapeHtmlAttr: function(value)', $source);
-        $this->assertStringContainsString(".replace(/\"/g, '&quot;')", $source);
         $this->assertStringContainsString(
-            "return '<img src=\"' + this._escapeHtmlAttr(val) + '\" alt=\"\" height=\"50\" />';",
+            "return '<img src=\"' + Sendex.utils.escapeHtmlAttr(val) + '\" alt=\"\" height=\"50\" />';",
             $source
         );
+
+        $utils = file_get_contents(
+            dirname(__DIR__, 2) . '/assets/components/sendex/js/mgr/misc/utils.js'
+        );
+        $this->assertStringContainsString('Sendex.utils.escapeHtmlAttr = function(value)', $utils);
+        $this->assertStringContainsString(".replace(/\"/g, '&quot;')", $utils);
     }
 }


### PR DESCRIPTION
## Summary
- Column renderer `_renderImage` called `this._escapeHtmlAttr`, but ExtJS does not bind grid scope → `TypeError` and broken newsletters grid.
- Move escape helper to `Sendex.utils.escapeHtmlAttr` and call it from the renderer (same pattern as `renderActions`).

## Test plan
- [ ] Open Sendex → Newsletters with at least one row that has an image
- [ ] Grid renders without console error
- [ ] Image `src` still escapes `&` `"` `<` `>`