### PR TITLE
fix(mgr): row-action icon buttons (#119)

### DIFF
--- a/assets/components/sendex/js/mgr/misc/utils.js
+++ b/assets/components/sendex/js/mgr/misc/utils.js
@@ -16,9 +16,10 @@ Sendex.utils.renderActions = function(value, props, row) {
                 ? a['class']['button']
                 : '';
             var iconCls = (MODx.modx23 ? 'icon icon-' : 'fa fa-') + a['icon'];
+            var action = Sendex.utils.escapeHtmlAttr(a['type'] || '');
             res.push(
                 '<li>\
-                    <button class="btn btn-default '+ btnCls +'" type="'+a['type']+'" title="'+_('sendex_action_'+a['type'])+'"><i class="'+iconCls+'"></i></button>\
+                    <button class="btn btn-default '+ btnCls +'" type="button" data-action="'+action+'" title="'+_('sendex_action_'+a['type'])+'"><i class="'+iconCls+'"></i></button>\
                 </li>'
             );
         }
@@ -156,6 +157,50 @@ Sendex.grid.SelectionMixin = {
 
     requireSelectedIds: function(emptyLex) {
         return Sendex.utils.requireSelectedIds(this, emptyLex);
+    },
+
+    /**
+     * Row-action buttons wrap an <i> icon; clicks often hit the icon, not BUTTON (#119).
+     * Resolve the button via getTarget and the row via GridView.findRowIndex.
+     * Action name lives in data-action (HTML button type is only submit/button/reset).
+     */
+    onClick: function(e) {
+        var btn = e.getTarget('button');
+        if (!btn) {
+            return this.processEvent('click', e);
+        }
+
+        var type = btn.getAttribute('data-action') || btn.getAttribute('type');
+        if (!type || type === 'button' || type === 'submit' || type === 'reset') {
+            return this.processEvent('click', e);
+        }
+
+        var record = null;
+        var view = this.getView();
+        var rowIndex = view && view.findRowIndex ? view.findRowIndex(btn) : false;
+        if (rowIndex !== false && rowIndex !== null && rowIndex >= 0) {
+            record = this.getStore().getAt(rowIndex);
+        }
+        if (!record) {
+            record = this.getSelectionModel().getSelected();
+        }
+        if (!record) {
+            return this.processEvent('click', e);
+        }
+
+        if (!this.menu) {
+            this.menu = {};
+        }
+        this.menu.record = record.data;
+
+        if (type === 'menu') {
+            var storeIndex = this.getStore().find('id', record.id);
+            return this._showMenu(this, storeIndex, e);
+        }
+        if (typeof this[type] === 'function') {
+            return this[type](this, e);
+        }
+        return this.processEvent('click', e);
     },
 
     confirmWithSelection: function(config) {

--- a/assets/components/sendex/js/mgr/widgets/newsletters.grid.js
+++ b/assets/components/sendex/js/mgr/widgets/newsletters.grid.js
@@ -63,25 +63,6 @@ Ext.extend(Sendex.grid.Newsletters,MODx.grid.Grid,Ext.apply({
         this.addContextMenuItem(menu);
     }
 
-    ,onClick: function(e) {
-        var elem = e.getTarget();
-        if (elem.nodeName == 'BUTTON') {
-            var row = this.getSelectionModel().getSelected();
-            if (typeof(row) != 'undefined') {
-                var type = elem.getAttribute('type');
-                if (type == 'menu') {
-                    var ri = this.getStore().find('id', row.id);
-                    return this._showMenu(this, ri, e);
-                }
-                else {
-                    this.menu.record = row.data;
-                    return this[type](this, e);
-                }
-            }
-        }
-        return this.processEvent('click', e);
-    }
-
     ,_renderBoolean: function(val,cell,row) {
         return val == '' || val == 0
             ? '<span style="color:red">' + _('no') + '</span>'
@@ -438,25 +419,6 @@ Ext.extend(Sendex.grid.NewsletterSubscribers,MODx.grid.Grid, Ext.apply({
         var row = grid.getStore().getAt(rowIndex);
         var menu = Sendex.utils.getMenu(row.data.actions, this);
         this.addContextMenuItem(menu);
-    }
-
-    ,onClick: function(e) {
-        var elem = e.getTarget();
-        if (elem.nodeName == 'BUTTON') {
-            var row = this.getSelectionModel().getSelected();
-            if (typeof(row) != 'undefined') {
-                var type = elem.getAttribute('type');
-                if (type == 'menu') {
-                    var ri = this.getStore().find('id', row.id);
-                    return this._showMenu(this, ri, e);
-                }
-                else {
-                    this.menu.record = row.data;
-                    return this[type](this, e);
-                }
-            }
-        }
-        return this.processEvent('click', e);
     }
 
     ,addSubscriber: function(combo, user, e) {

--- a/assets/components/sendex/js/mgr/widgets/queues.grid.js
+++ b/assets/components/sendex/js/mgr/widgets/queues.grid.js
@@ -69,25 +69,6 @@ Ext.extend(Sendex.grid.Queues,MODx.grid.Grid, Ext.apply({
         this.addContextMenuItem(menu);
     }
 
-    ,onClick: function(e) {
-        var elem = e.getTarget();
-        if (elem.nodeName == 'BUTTON') {
-            var row = this.getSelectionModel().getSelected();
-            if (typeof(row) != 'undefined') {
-                var type = elem.getAttribute('type');
-                if (type == 'menu') {
-                    var ri = this.getStore().find('id', row.id);
-                    return this._showMenu(this, ri, e);
-                }
-                else {
-                    this.menu.record = row.data;
-                    return this[type](this, e);
-                }
-            }
-        }
-        return this.processEvent('click', e);
-    }
-
     ,createQueues: function(combo, newsletter, e) {
         MODx.Ajax.request({
             url: Sendex.config.connector_url

--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.0.1-pl] - 2026-07-29
 
 ### Fixed
+- [#119] Mgr row-action icon buttons (edit/disable/send/remove) did nothing when the click hit the inner `<i>`: shared `SelectionMixin.onClick` now finds the button via `getTarget('button')`, resolves the row via `findRowIndex`, and reads the action from `data-action`.
 - [#114] Mgr newsletter create appeared to hang on «Загружается…» and the grid stayed empty after reload (row was saved; duplicate-name error on retry). Newsletter `getlist` no longer uses JOIN/subquery SQL (subscriber count and template name are added in `prepareRow`); grid refresh after save is deferred so the create window can close first; `getlist`/`get` accept `view_sendex` as well as `view_document`; create `beforeSet()` returns strict `true` for MODX 3. Image column renderer uses `Sendex.utils.escapeHtmlAttr` (ExtJS does not keep grid scope for column renderers).
 - [#111] Mgr row-action and menu icons no longer force `font-family: "Font Awesome 5 Free"` (Sendex does not load FA5); icons inherit the mgr icon font on MODX 2.3+/3.x or bundled FA4 on older MODX.
 - [#25666] Transport package built on MODX 3.x stored vehicle class as `xPDO\Transport\xPDOObjectVehicle`, which MODX 2.8.8/2.8.9 cannot load (install fails with ~30 "Could not load class" errors). Release build now runs on MODX 2.x so the manifest uses the legacy vehicle format that installs on both MODX 2.8+ and 3.x.

--- a/tests/Unit/MgrGridSelectionContractTest.php
+++ b/tests/Unit/MgrGridSelectionContractTest.php
@@ -18,6 +18,10 @@ class MgrGridSelectionContractTest extends TestCase
         $this->assertStringContainsString('Sendex.grid.SelectionMixin', $source);
         $this->assertStringContainsString('return ids.length > 0 ? ids : null', $source);
         $this->assertStringContainsString('grid.menu.record', $source);
+        $this->assertStringContainsString("e.getTarget('button')", $source);
+        $this->assertStringContainsString("getAttribute('data-action')", $source);
+        $this->assertStringContainsString('findRowIndex', $source);
+        $this->assertStringContainsString('data-action="', $source);
     }
 
     public function testGridsUseSelectionMixinAndDropLocalCopyPaste()
@@ -33,6 +37,7 @@ class MgrGridSelectionContractTest extends TestCase
             $this->assertStringContainsString('Sendex.grid.SelectionMixin', $source, $file);
             $this->assertStringNotContainsString('_getSelectedIds', $source, $file);
             $this->assertStringContainsString('confirmWithSelection', $source, $file);
+            $this->assertStringNotContainsString('elem.nodeName == \'BUTTON\'', $source, $file);
             $this->assertStringNotContainsString(
                 '}, Sendex.grid.SelectionMixin);',
                 $source,


### PR DESCRIPTION
## Summary
- [#119](https://github.com/modx-pro/Sendex/issues/119): row-action buttons did nothing when the click landed on the `<i>` icon; context menu still worked.
- Shared `SelectionMixin.onClick` finds the button with `getTarget('button')`, resolves the row via `findRowIndex`, and reads `data-action` (valid HTML `type=\"button\"`).
- Removes duplicate `onClick` from newsletters / subscribers / queues grids.

## Test plan
- [ ] Newsletters grid: click edit / disable / send / remove icons (on the glyph, not only button padding)
- [ ] Same for queue grid and subscribers tab inside update window
- [ ] Context menu (right-click) still works