### PR TITLE
fix(queue): ensure claim columns when Phinx did not run

### DIFF
--- a/core/components/sendex/docs/changelog.txt
+++ b/core/components/sendex/docs/changelog.txt
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#114] Mgr newsletter create appeared to hang on «Загружается…» and the grid stayed empty after reload (row was saved; duplicate-name error on retry). Newsletter `getlist` no longer uses JOIN/subquery SQL (subscriber count and template name are added in `prepareRow`); grid refresh after save is deferred so the create window can close first; `getlist`/`get` accept `view_sendex` as well as `view_document`; create `beforeSet()` returns strict `true` for MODX 3. Image column renderer uses `Sendex.utils.escapeHtmlAttr` (ExtJS does not keep grid scope for column renderers).
 - [#111] Mgr row-action and menu icons no longer force `font-family: "Font Awesome 5 Free"` (Sendex does not load FA5); icons inherit the mgr icon font on MODX 2.3+/3.x or bundled FA4 on older MODX.
 - [#25666] Transport package built on MODX 3.x stored vehicle class as `xPDO\Transport\xPDOObjectVehicle`, which MODX 2.8.8/2.8.9 cannot load (install fails with ~30 "Could not load class" errors). Release build now runs on MODX 2.x so the manifest uses the legacy vehicle format that installs on both MODX 2.8+ and 3.x.
+- Queue claim columns (`claimed_at`, `attempts`, `expires_at`) are ensured on Sendex bootstrap when Phinx did not apply `#105` migration, avoiding `Unknown column sxQueue.claimed_at` on live upgrades.
 
 ## [2.0.0-pl] - 2026-07-25
 

--- a/core/components/sendex/model/sendex/sendex.class.php
+++ b/core/components/sendex/model/sendex/sendex.class.php
@@ -65,6 +65,12 @@ class Sendex
 
         $this->modx->addPackage('sendex', $this->config['modelPath']);
         $this->modx->lexicon->load('sendex:default');
+
+        // Backfill claim columns when package files landed without a successful Phinx run.
+        if (!class_exists('sxQueueSchema', false)) {
+            require_once dirname(__FILE__) . '/sxqueueschema.class.php';
+        }
+        sxQueueSchema::ensureClaimFields($this->modx);
     }
 
 

--- a/core/components/sendex/model/sendex/sxqueueschema.class.php
+++ b/core/components/sendex/model/sendex/sxqueueschema.class.php
@@ -1,0 +1,162 @@
+<?php
+
+/**
+ * Ensures queue claim/retry columns exist when Phinx did not run (#105).
+ *
+ * Protects mgr/cron from xPDO SELECT failures on claimed_at/attempts/expires_at.
+ */
+class sxQueueSchema
+{
+    /**
+     * @var bool
+     */
+    private static $ensured = false;
+
+    /**
+     * @var string
+     */
+    private static $queueClass = 'sxQueue';
+
+    /**
+     * Reset once-per-process guard (unit tests only).
+     *
+     * @return void
+     */
+    public static function resetEnsured()
+    {
+        self::$ensured = false;
+    }
+
+    /**
+     * @param object $xpdo
+     * @return bool true when schema is ready (or already ensured)
+     */
+    public static function ensureClaimFields($xpdo)
+    {
+        if (self::$ensured) {
+            return true;
+        }
+
+        if (!is_object($xpdo) || !method_exists($xpdo, 'getTableName')) {
+            return false;
+        }
+
+        $table = (string) $xpdo->getTableName(self::$queueClass);
+        if ($table === '') {
+            return false;
+        }
+
+        $columns = self::listColumns($xpdo, $table);
+        if ($columns === null) {
+            return false;
+        }
+
+        $alters = array();
+        if (!isset($columns['claimed_at'])) {
+            $alters[] = 'ADD COLUMN `claimed_at` TIMESTAMP NULL DEFAULT NULL';
+        }
+        if (!isset($columns['attempts'])) {
+            $alters[] = 'ADD COLUMN `attempts` INT(10) UNSIGNED NOT NULL DEFAULT 0';
+        }
+        if (!isset($columns['expires_at'])) {
+            $alters[] = 'ADD COLUMN `expires_at` TIMESTAMP NULL DEFAULT NULL';
+        }
+
+        if ($alters === array()) {
+            self::$ensured = true;
+
+            return true;
+        }
+
+        $sql = 'ALTER TABLE ' . $table . ' ' . implode(', ', $alters);
+        $stmt = self::prepare($xpdo, $sql);
+        if (!$stmt || !$stmt->execute()) {
+            // Concurrent bootstrap may add the same columns first.
+            $retry = self::listColumns($xpdo, $table);
+            if (
+                is_array($retry)
+                && isset($retry['claimed_at'], $retry['attempts'], $retry['expires_at'])
+            ) {
+                self::$ensured = true;
+
+                return true;
+            }
+
+            if (method_exists($xpdo, 'log')) {
+                $xpdo->log(
+                    defined('xPDO::LOG_LEVEL_ERROR') ? constant('xPDO::LOG_LEVEL_ERROR') : 0,
+                    '[Sendex] Failed to ensure queue claim columns: ' . $sql
+                );
+            }
+
+            return false;
+        }
+
+        self::$ensured = true;
+
+        return true;
+    }
+
+    /**
+     * @param object $xpdo
+     * @param string $sql
+     * @return object|false|null
+     */
+    private static function prepare($xpdo, $sql)
+    {
+        if (method_exists($xpdo, 'prepare')) {
+            return $xpdo->prepare($sql);
+        }
+
+        if (!method_exists($xpdo, 'getConnection')) {
+            return null;
+        }
+
+        $connection = $xpdo->getConnection();
+        if (!is_object($connection) || !method_exists($connection, 'prepare')) {
+            return null;
+        }
+
+        return $connection->prepare($sql);
+    }
+
+    /**
+     * @param object $xpdo
+     * @param string $table
+     * @return array<string,true>|null
+     */
+    private static function listColumns($xpdo, $table)
+    {
+        $stmt = self::prepare($xpdo, 'SHOW COLUMNS FROM ' . $table);
+        if (!$stmt || !$stmt->execute()) {
+            return null;
+        }
+
+        if (!method_exists($stmt, 'fetchAll')) {
+            return null;
+        }
+
+        $rows = $stmt->fetchAll();
+        if (!is_array($rows)) {
+            return null;
+        }
+
+        $columns = array();
+        foreach ($rows as $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+            $name = '';
+            if (isset($row['Field'])) {
+                $name = (string) $row['Field'];
+            } elseif (isset($row[0])) {
+                $name = (string) $row[0];
+            }
+            if ($name !== '') {
+                $columns[strtolower($name)] = true;
+            }
+        }
+
+        return $columns;
+    }
+}

--- a/tests/Stubs/FakeModX.php
+++ b/tests/Stubs/FakeModX.php
@@ -561,6 +561,9 @@ class FakeModX extends modX
         if ($class === 'sxSubscriber') {
             return 'sendex_subscribers';
         }
+        if ($class === 'sxQueue') {
+            return 'sendex_queue';
+        }
 
         return $class;
     }

--- a/tests/Stubs/FakePdoConnection.php
+++ b/tests/Stubs/FakePdoConnection.php
@@ -33,6 +33,24 @@ class FakePdoConnection
     public $executions = array();
 
     /**
+     * Column names returned by SHOW COLUMNS for sendex_queue (schema ensure tests).
+     *
+     * @var array<int,string>
+     */
+    public $queueSchemaColumns = array(
+        'id',
+        'newsletter_id',
+        'subscriber_id',
+        'timestamp',
+        'email_to',
+        'email_subject',
+        'email_body',
+        'email_from',
+        'email_from_name',
+        'email_reply',
+    );
+
+    /**
      * @param FakeModX $modx
      */
     public function __construct(FakeModX $modx)

--- a/tests/Stubs/FakePdoStatement.php
+++ b/tests/Stubs/FakePdoStatement.php
@@ -88,6 +88,19 @@ class FakePdoStatement
             return true;
         }
 
+        if (stripos($this->sql, 'SHOW COLUMNS FROM ') === 0) {
+            $this->affectedRows = count($this->connection->queueSchemaColumns);
+
+            return true;
+        }
+
+        if (stripos($this->sql, 'ALTER TABLE ') === 0) {
+            $this->applyQueueSchemaAlter();
+            $this->affectedRows = 1;
+
+            return true;
+        }
+
         $rowCount = (int) (count($values) / 4);
         $this->affectedRows = $rowCount;
         for ($i = 0; $i < $rowCount; $i++) {
@@ -120,6 +133,39 @@ class FakePdoStatement
     public function errorInfo()
     {
         return $this->lastErrorInfo;
+    }
+
+    /**
+     * @return array
+     */
+    public function fetchAll()
+    {
+        if (stripos($this->sql, 'SHOW COLUMNS FROM ') !== 0) {
+            return array();
+        }
+
+        $rows = array();
+        foreach ($this->connection->queueSchemaColumns as $field) {
+            $rows[] = array('Field' => $field);
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return void
+     */
+    private function applyQueueSchemaAlter()
+    {
+        if (strpos($this->sql, '`claimed_at`') !== false && !in_array('claimed_at', $this->connection->queueSchemaColumns, true)) {
+            $this->connection->queueSchemaColumns[] = 'claimed_at';
+        }
+        if (strpos($this->sql, '`attempts`') !== false && !in_array('attempts', $this->connection->queueSchemaColumns, true)) {
+            $this->connection->queueSchemaColumns[] = 'attempts';
+        }
+        if (strpos($this->sql, '`expires_at`') !== false && !in_array('expires_at', $this->connection->queueSchemaColumns, true)) {
+            $this->connection->queueSchemaColumns[] = 'expires_at';
+        }
     }
 
     /**

--- a/tests/Unit/QueueSchemaEnsureTest.php
+++ b/tests/Unit/QueueSchemaEnsureTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sxqueueschema.class.php';
+
+class QueueSchemaEnsureTest extends TestCase
+{
+    /** @var FakeModX */
+    private $modx;
+
+    protected function setUp(): void
+    {
+        $this->modx = new FakeModX();
+        sxQueueSchema::resetEnsured();
+    }
+
+    public function testEnsureAddsMissingClaimColumns()
+    {
+        $connection = $this->modx->getConnection();
+        $this->assertNotContains('claimed_at', $connection->queueSchemaColumns);
+
+        $this->assertTrue(sxQueueSchema::ensureClaimFields($this->modx));
+        $this->assertContains('claimed_at', $connection->queueSchemaColumns);
+        $this->assertContains('attempts', $connection->queueSchemaColumns);
+        $this->assertContains('expires_at', $connection->queueSchemaColumns);
+
+        $alters = array_filter($connection->executions, static function ($item) {
+            return stripos($item['sql'], 'ALTER TABLE ') === 0;
+        });
+        $this->assertCount(1, $alters);
+    }
+
+    public function testEnsureIsIdempotentWhenColumnsExist()
+    {
+        $connection = $this->modx->getConnection();
+        $connection->queueSchemaColumns = array_merge($connection->queueSchemaColumns, array(
+            'claimed_at',
+            'attempts',
+            'expires_at',
+        ));
+
+        $this->assertTrue(sxQueueSchema::ensureClaimFields($this->modx));
+        $this->assertSame(array(), array_filter($connection->executions, static function ($item) {
+            return stripos($item['sql'], 'ALTER TABLE ') === 0;
+        }));
+
+        $before = count($connection->executions);
+        $this->assertTrue(sxQueueSchema::ensureClaimFields($this->modx));
+        $this->assertSame($before, count($connection->executions));
+    }
+
+    public function testSendexConstructorWiresSchemaEnsure()
+    {
+        $source = file_get_contents(
+            dirname(__DIR__, 2) . '/core/components/sendex/model/sendex/sendex.class.php'
+        );
+
+        $this->assertStringContainsString('sxQueueSchema::ensureClaimFields', $source);
+        $this->assertStringContainsString('sxqueueschema.class.php', $source);
+    }
+}


### PR DESCRIPTION
Production upgrades that deliver Sendex 2.0 maps without a successful Phinx run (`20260725190000_add_queue_claim_fields`) fail with `Unknown column 'sxQueue.claimed_at' in 'field list'`.

`Sendex` now ensures `claimed_at`, `attempts`, and `expires_at` once per process after `addPackage`, using `$xpdo->prepare` (MODX 2/3). Concurrent ALTERs that hit duplicate-column are treated as success when the columns are already present.

Verified locally: drop columns → ensure restores them → `getCount('sxQueue')` works. PHPUnit 277 green, PHPCS green.